### PR TITLE
Add RecentWhatsNewPanelVersion preference to GarageBand & Logic

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.apple.garageband10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.garageband10.plist
@@ -15,7 +15,7 @@
 		<string>macOS</string>
 	</array>
 	<key>pfm_last_modified</key>
-	<date>2019-02-04T12:00:00Z</date>
+	<date>2019-08-05T17:00:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -143,6 +143,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>So long as the integer value of this preference is set equal or higher to the value produced in the user-level plist after launching the app and acknowledging the "What's New" prompt, this will prevent the "What's New" prompt from appearing.</string>
+			<key>pfm_name</key>
+			<string>RecentWhatsNewPanelVersion</string>
+			<key>pfm_note</key>
+			<string>As of GarageBand 10.3.2, this integer value was 3. So, a value of 3 or above would suppress the prompt.</string>
+			<key>pfm_title</key>
+			<string>What's New Prompt</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
 	</array>
 	<key>pfm_title</key>
 	<string>GarageBand</string>
@@ -154,6 +166,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.apple.garageband10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.garageband10.plist
@@ -144,6 +144,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<integer>99</integer>
 			<key>pfm_description</key>
 			<string>So long as the integer value of this preference is set equal or higher to the value produced in the user-level plist after launching the app and acknowledging the "What's New" prompt, this will prevent the "What's New" prompt from appearing.</string>
 			<key>pfm_name</key>
@@ -151,7 +153,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_note</key>
 			<string>As of GarageBand 10.3.2, this integer value was 3. So, a value of 3 or above would suppress the prompt.</string>
 			<key>pfm_title</key>
-			<string>What's New Prompt</string>
+			<string>Suppress What's New Prompt</string>
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
@@ -253,6 +253,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<integer>99</integer>
 			<key>pfm_description</key>
 			<string>So long as the integer value of this preference is set equal or higher to the value produced in the user-level plist after launching the app and acknowledging the "What's New" prompt, this will prevent the "What's New" prompt from appearing.</string>
 			<key>pfm_name</key>
@@ -260,7 +262,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_note</key>
 			<string>As of Logic Pro X 10.4.1, this integer value was 6. So, a value of 6 or above would suppress the prompt.</string>
 			<key>pfm_title</key>
-			<string>What's New Prompt</string>
+			<string>Suppress What's New Prompt</string>
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-02-24T12:00:00Z</date>
+	<date>2019-08-05T17:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -252,6 +252,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>So long as the integer value of this preference is set equal or higher to the value produced in the user-level plist after launching the app and acknowledging the "What's New" prompt, this will prevent the "What's New" prompt from appearing.</string>
+			<key>pfm_name</key>
+			<string>RecentWhatsNewPanelVersion</string>
+			<key>pfm_note</key>
+			<string>As of Logic Pro X 10.4.1, this integer value was 6. So, a value of 6 or above would suppress the prompt.</string>
+			<key>pfm_title</key>
+			<string>What's New Prompt</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -263,6 +275,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/index
+++ b/Manifests/index
@@ -285,13 +285,13 @@
 		<key>com.apple.garageband10</key>
 		<dict>
 			<key>hash</key>
-			<string>b520420196f74bdc8351860c6824ab41</string>
+			<string>fec682099fd48d3c78595d367c392943</string>
 			<key>modified</key>
-			<date>2019-02-04T12:00:00Z</date>
+			<date>2019-08-05T17:00:00Z</date>
 			<key>path</key>
 			<string>Manifests/ManagedPreferencesApplications/com.apple.garageband10.plist</string>
 			<key>version</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<key>com.apple.iMovieApp</key>
 		<dict>
@@ -307,13 +307,13 @@
 		<key>com.apple.logic10</key>
 		<dict>
 			<key>hash</key>
-			<string>54627745eed3561d4e7f7a750cbf577d</string>
+			<string>280790c1eaf10822a413ac202288e903</string>
 			<key>modified</key>
-			<date>2019-02-24T12:00:00Z</date>
+			<date>2019-08-05T17:00:00Z</date>
 			<key>path</key>
 			<string>Manifests/ManagedPreferencesApplications/com.apple.logic10.plist</string>
 			<key>version</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 		<key>com.barebones.bbedit</key>
 		<dict>
@@ -1786,6 +1786,6 @@
 		</dict>
 	</dict>
 	<key>date</key>
-	<date>2019-08-05T20:29:46Z</date>
+	<date>2019-08-05T21:16:29Z</date>
 </dict>
 </plist>


### PR DESCRIPTION
Allows for suppression of the "What's New" prompt in both these apps.