### PR TITLE
Update com.microsoft.office.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -6,19 +6,12 @@
 	<string>https://www.office.com</string>
 	<key>pfm_description</key>
 	<string>Microsoft Office settings</string>
-	<key>pfm_documentation_url</key>
-	<array>
-		<string>https://docs.google.com/spreadsheets/d/1ESX5td0y0OP3jdzZ-C2SItm-TUi-iA_bcHCBvaoCumw/htmlview#</string>
-		<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
-		<string>https://docs.microsoft.com/en-us/deployoffice/privacy/mac-privacy-preferences</string>
-		<string>https://docs.microsoft.com/en-us/DeployOffice/mac/preferences-outlook</string>
-	</array>
 	<key>pfm_domain</key>
 	<string>com.microsoft.office</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-08-18T16:55:00Z</date>
+	<date>2019-08-19T01:45:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -168,6 +161,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>If you don't want your users to see the Office 2019 Use Terms dialog, and instead accept the terms on their behalf, set this value to TRUE.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1536524701000100</string>
 			<key>pfm_name</key>
 			<string>TermsAccepted1809</string>
 			<key>pfm_title</key>
@@ -180,6 +175,8 @@
 			<string>16.13</string>
 			<key>pfm_description</key>
 			<string>This value pre-fills the account authentication field for O365 users and sets the 'Belongs to' field in the About Box for both O365 and VL users.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1526327108000247</string>
 			<key>pfm_name</key>
 			<string>OfficeActivationEmailAddress</string>
 			<key>pfm_note</key>
@@ -198,6 +195,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Automatically configure Office 365 mailbox on first launch for Outlook. Will suppress first run dialogs for Word, Excel, PowerPoint and OneNote. For new installations from the Mac App Store, will bypass the first run dialogs that ask users if they wish to purchase a new Office 365 subscription.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/search/?search=OfficeAutoSignIn</string>
 			<key>pfm_name</key>
 			<string>OfficeAutoSignIn</string>
 			<key>pfm_title</key>
@@ -212,6 +211,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>You can use this preference to control whether most connected experiences are available to your users.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployoffice/privacy/mac-privacy-preferences#preference-setting-for-most-connected-experiences</string>
 			<key>pfm_name</key>
 			<string>ConnectedOfficeExperiencesPreference</string>
 			<key>pfm_note</key>
@@ -228,6 +229,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>Connected experiences that analyze your content are experiences that use your Office content to provide you with design recommendations, editing suggestions, data insights, and similar features. For example, PowerPoint Designer or Researcher in Word.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployoffice/privacy/mac-privacy-preferences#preference-setting-for-connected-experiences-that-analyze-your-content</string>
 			<key>pfm_name</key>
 			<string>OfficeExperiencesAnalyzingContentPreference</string>
 			<key>pfm_title</key>
@@ -242,6 +245,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>Connected experiences that download online content are experiences that allow you to search and download online content including templates, images, 3D models, videos, and reference materials to enhance your documents. For example, Office templates or PowerPoint QuickStarter.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployoffice/privacy/mac-privacy-preferences#preference-setting-for-connected-experiences-that-download-online-content</string>
 			<key>pfm_name</key>
 			<string>OfficeExperiencesDownloadingContentPreference</string>
 			<key>pfm_title</key>
@@ -256,6 +261,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>In addition to the connected experiences above, there are some optional connected experiences that you may choose to allow your users to access. For example, the LinkedIn features of the Resume Assistant in Word or the Weather Bar in Outlook, which uses MSN Weather.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployoffice/privacy/mac-privacy-preferences#preference-setting-for-optional-connected-experiences</string>
 			<key>pfm_name</key>
 			<string>OptionalConnectedExperiencesPreference</string>
 			<key>pfm_title</key>
@@ -270,6 +277,8 @@
 			<string>FullDiagnosticData</string>
 			<key>pfm_description</key>
 			<string>Diagnostic data is used to keep Office secure and up-to-date, detect, diagnose and remediate problems, and also make product improvements.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployoffice/privacy/mac-privacy-preferences#preference-setting-for-diagnostic-data</string>
 			<key>pfm_name</key>
 			<string>DiagnosticDataTypePreference</string>
 			<key>pfm_note</key>
@@ -298,6 +307,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>Controls wether diagnostic data transmission is on or off.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/docs/16.28-Privacy-Consent.key</string>
 			<key>pfm_name</key>
 			<string>SendAllTelemetryEnabled</string>
 			<key>pfm_note</key>
@@ -314,6 +325,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Setting this option to TRUE will suppress the 'Your privacy options' dialog for Volume License users only.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/?redir=%2Farchives%2FC07UZ1X7B%2Fp1565725927223700</string>
 			<key>pfm_name</key>
 			<string>HasUserSeenEnterpriseFREDialog</string>
 			<key>pfm_note</key>
@@ -330,6 +343,8 @@
 			<integer>0</integer>
 			<key>pfm_description</key>
 			<string>Increase logging levels for authentication requests. Enable Minimum Severity (msoridDefaultMinimumSeverity) option if this key is enabled.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1510921449000105</string>
 			<key>pfm_name</key>
 			<string>msoridEnableLogging</string>
 			<key>pfm_title</key>
@@ -346,6 +361,8 @@
 			<integer>200</integer>
 			<key>pfm_description</key>
 			<string>Set value to 200 if 'logging for authentication requests' (msoridEnableLogging) is enabled.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.google.com/spreadsheets/d/1ESX5td0y0OP3jdzZ-C2SItm-TUi-iA_bcHCBvaoCumw/</string>
 			<key>pfm_name</key>
 			<string>msoridDefaultMinimumSeverity</string>
 			<key>pfm_title</key>
@@ -360,6 +377,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>When set to true will force the open/save panel to ‘On My Mac’ instead of 'Online Locations'.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://derflounder.wordpress.com/2017/04/17/office-2016-defaultstolocalopensave-setting-change-as-of-office-2016-15-33-x/</string>
 			<key>pfm_name</key>
 			<string>DefaultsToLocalOpenSave</string>
 			<key>pfm_title</key>
@@ -374,6 +393,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>Show or Hide the Document gallery selector when office applications are launched.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1506713968000569</string>
 			<key>pfm_name</key>
 			<string>ShowDocStageOnLaunch</string>
 			<key>pfm_title</key>
@@ -388,6 +409,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>A setting of FALSE supresses all "What's new" messages for all suite apps: Word, PowerPoint, Excel, Outlook and OneNote.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1492636076913449</string>
 			<key>pfm_name</key>
 			<string>ShowWhatsNewOnLaunch</string>
 			<key>pfm_title</key>
@@ -402,6 +425,8 @@
 			<integer>0</integer>
 			<key>pfm_description</key>
 			<string>Set the theme used by Microsoft Office.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1528897732000348</string>
 			<key>pfm_name</key>
 			<string>kCUIThemePreferencesThemeKeyPath</string>
 			<key>pfm_range_list</key>
@@ -430,6 +455,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing AutoUpdate. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing AutoUpdate. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallAutoUpdate</string>
 			<key>pfm_title</key>
@@ -446,6 +473,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Excel. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing Excel. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallExcel</string>
 			<key>pfm_title</key>
@@ -462,6 +491,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing OneDrive. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing OneDrive. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallOneDrive</string>
 			<key>pfm_title</key>
@@ -478,6 +509,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing OneNote. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing OneNote. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallOneNote</string>
 			<key>pfm_title</key>
@@ -494,6 +527,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Outlook. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing Outlook. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallOutlook</string>
 			<key>pfm_title</key>
@@ -510,6 +545,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing PowerPoint. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing PowerPoint. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallPowerPoint</string>
 			<key>pfm_title</key>
@@ -526,6 +563,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Teams. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing Teams. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallTeams</string>
 			<key>pfm_title</key>
@@ -542,6 +581,8 @@
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Word. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing Word. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C07UZ1X7B/p1554308409392900</string>
 			<key>pfm_name</key>
 			<string>InstallWord</string>
 			<key>pfm_title</key>
@@ -558,6 +599,8 @@
 			<string>The VisualBasicMacroExecutionState1 setting controls whether macros are ever allowed to execute, and what the user experience is when opening
 a file that contains a macro. By default, macros will only run after the user is presented with an alert when opening a file that contains a macro. The
 user must make a choice whether to allow or deny macros for each individual file, each time that file is opened.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
 			<key>pfm_name</key>
 			<string>VisualBasicMacroExecutionState</string>
 			<key>pfm_range_list</key>
@@ -586,6 +629,8 @@ user must make a choice whether to allow or deny macros for each individual file
 			<string>Controls the ability for 3rd party vendors to use a DECLARE statement to bind a Visual Basic symbol name to an external procedure in the local OS.</string>
 			<key>pfm_description_reference</key>
 			<string>The DisableVisualBasicExternalDylibs setting determines if macros are allowed to use a DECLARE statement to bind a Visual Basic symbol name to an external procedure in the local OS. The default value for this setting is to allow binding to external dylibs because many legitimate 3rd party addin vendors use this feature of Visual Basic to add and extend features in Office for Mac. When this setting is set to NO, macros that attempt to use a DECLARE statement will fail with an error at the point where the external procedure is invoked.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
 			<key>pfm_name</key>
 			<string>DisableVisualBasicExternalDylibs</string>
 			<key>pfm_note</key>
@@ -604,6 +649,8 @@ user must make a choice whether to allow or deny macros for each individual file
 			<string>Determines if macros are allowed to use a DECLARE to bind to the system() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line.</string>
 			<key>pfm_description_reference</key>
 			<string>The AllowVisualBasicToBindToSystem setting determines if macros are allowed to use a DECLARE to bind to the system() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line. The default value for this setting disallows the binding, as the system() API should not be used. When this setting is set to NO, macros that attempt to use system() will fail with an error at the point where system() is invoked.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
 			<key>pfm_name</key>
 			<string>AllowVisualBasicToBindToSystem</string>
 			<key>pfm_note</key>
@@ -622,6 +669,8 @@ user must make a choice whether to allow or deny macros for each individual file
 			<string>Determines if macros are allowed to use a DECLARE to bind to the popen() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line.</string>
 			<key>pfm_description_reference</key>
 			<string>The DisableVisualBasicToBindToPopen setting determines if macros are allowed to use a DECLARE to bind to the popen() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line. The default value for this setting allows the binding, as at least one 3rd party vendor uses popen to communicate with their own code. When this setting is set to NO, macros that attempt to use popen() will fail with an error at the point where popen() is invoked.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
 			<key>pfm_name</key>
 			<string>DisableVisualBasicToBindToPopen</string>
 			<key>pfm_note</key>
@@ -641,6 +690,8 @@ user must make a choice whether to allow or deny macros for each individual file
 			<key>pfm_description_reference</key>
 			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including “do shell script ...” in the AppleScript code. 
 The default value for this setting allows using MacScript, as there are a number of legitimate uses of AppleScript that do not rely on external processes. When this setting is set to NO, macros that attempt to use MacScript will fail with an error at the point where MacScript is invoked.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
 			<key>pfm_name</key>
 			<string>DisableVisualBasicMacScript</string>
 			<key>pfm_note</key>
@@ -659,6 +710,8 @@ The default value for this setting allows using MacScript, as there are a number
 			<string>Controls the ability for Office to write to the VB project through the VBA object model.</string>
 			<key>pfm_description_reference</key>
 			<string>For Office 2019 only: The VBAObjectModelIsTrusted setting determines if macros are allowed to modify the VB project itself through the VBA object model.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
 			<key>pfm_name</key>
 			<string>VBAObjectModelIsTrusted</string>
 			<key>pfm_note</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -18,21 +18,9 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-08-18T16:37:00Z</date>
+	<date>2019-08-18T16:55:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
-		<dict>
-			<key>pfm_default</key>
-			<string>Configures Microsoft Office settings</string>
-			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_name</key>
-			<string>PayloadDescription</string>
-			<key>pfm_title</key>
-			<string>Payload Description</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
 		<dict>
 			<key>pfm_default</key>
 			<string>Microsoft Office</string>
@@ -104,6 +92,18 @@
 			<string>Payload Version</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures Microsoft Office settings</string>
+			<key>pfm_description</key>
+			<string>Description of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
 		</dict>
 		<dict>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -7,13 +7,18 @@
 	<key>pfm_description</key>
 	<string>Microsoft Office settings</string>
 	<key>pfm_documentation_url</key>
-	<string>https://docs.google.com/spreadsheets/d/1ESX5td0y0OP3jdzZ-C2SItm-TUi-iA_bcHCBvaoCumw/htmlview#</string>
+	<array>
+		<string>https://docs.google.com/spreadsheets/d/1ESX5td0y0OP3jdzZ-C2SItm-TUi-iA_bcHCBvaoCumw/htmlview#</string>
+		<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>
+		<string>https://docs.microsoft.com/en-us/deployoffice/privacy/mac-privacy-preferences</string>
+		<string>https://docs.microsoft.com/en-us/DeployOffice/mac/preferences-outlook</string>
+	</array>
 	<key>pfm_domain</key>
 	<string>com.microsoft.office</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-08-05T21:16:00Z</date>
+	<date>2019-08-18T16:37:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -101,18 +106,298 @@
 			<string>integer</string>
 		</dict>
 		<dict>
-			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
 			<key>pfm_name</key>
-			<string>PayloadOrganization</string>
-			<key>pfm_title</key>
-			<string>Payload Organization</string>
+			<string>PFC_SegmentedControl_0</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>General</string>
+				<string>Installation</string>
+				<string>Visual Basic</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>General</key>
+				<array>
+					<string>TermsAccepted1809</string>
+					<string>OfficeActivationEmailAddress</string>
+					<string>OfficeAutoSignIn</string>
+					<string>ConnectedOfficeExperiencesPreference</string>
+					<string>OfficeExperiencesAnalyzingContentPreference</string>
+					<string>OfficeExperiencesDownloadingContentPreference</string>
+					<string>OptionalConnectedExperiencesPreference</string>
+					<string>DiagnosticDataTypePreference</string>
+					<string>SendAllTelemetryEnabled</string>
+					<string>HasUserSeenEnterpriseFREDialog</string>
+					<string>msoridEnableLogging</string>
+					<string>msoridDefaultMinimumSeverity</string>
+					<string>DefaultsToLocalOpenSave</string>
+					<string>ShowDocStageOnLaunch</string>
+					<string>ShowWhatsNewOnLaunch</string>
+					<string>kCUIThemePreferencesThemeKeyPath</string>
+				</array>
+				<key>Installation</key>
+				<array>
+					<string>InstallAutoUpdate</string>
+					<string>InstallExcel</string>
+					<string>InstallOneDrive</string>
+					<string>InstallOneNote</string>
+					<string>InstallOutlook</string>
+					<string>InstallPowerPoint</string>
+					<string>InstallTeams</string>
+					<string>InstallWord</string>
+				</array>
+				<key>Visual Basic</key>
+				<array>
+					<string>VisualBasicMacroExecutionState</string>
+					<string>DisableVisualBasicExternalDylibs</string>
+					<string>AllowVisualBasicToBindToSystem</string>
+					<string>DisableVisualBasicToBindToPopen</string>
+					<string>DisableVisualBasicMacScript</string>
+					<string>VBAObjectModelIsTrusted</string>
+				</array>
+			</dict>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15.33.0</string>
+			<string>16.17</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>If you don't want your users to see the Office 2019 Use Terms dialog, and instead accept the terms on their behalf, set this value to TRUE.</string>
+			<key>pfm_name</key>
+			<string>TermsAccepted1809</string>
+			<key>pfm_title</key>
+			<string>Accept Office 2019 Use Terms</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.13</string>
+			<key>pfm_description</key>
+			<string>This value pre-fills the account authentication field for O365 users and sets the 'Belongs to' field in the About Box for both O365 and VL users.</string>
+			<key>pfm_name</key>
+			<string>OfficeActivationEmailAddress</string>
+			<key>pfm_note</key>
+			<string>The "Belongs to" line will not appear in the About Box for Volume License users running versions 16.13 through 16.28 but will return in 16.29.</string>
+			<key>pfm_title</key>
+			<string>Activation Account</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>jane.doe@microsoft.com</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.17</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Automatically configure Office 365 mailbox on first launch for Outlook. Will suppress first run dialogs for Word, Excel, PowerPoint and OneNote. For new installations from the Mac App Store, will bypass the first run dialogs that ask users if they wish to purchase a new Office 365 subscription.</string>
+			<key>pfm_name</key>
+			<string>OfficeAutoSignIn</string>
+			<key>pfm_title</key>
+			<string>Auto Sign In</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.28</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>You can use this preference to control whether most connected experiences are available to your users.</string>
+			<key>pfm_name</key>
+			<string>ConnectedOfficeExperiencesPreference</string>
+			<key>pfm_note</key>
+			<string>If you don't set this preference, all connected experiences are available to your users, unless you have set one of the other preferences for connected experiences.</string>
+			<key>pfm_title</key>
+			<string>Connected Experiences, Most</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.28</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Connected experiences that analyze your content are experiences that use your Office content to provide you with design recommendations, editing suggestions, data insights, and similar features. For example, PowerPoint Designer or Researcher in Word.</string>
+			<key>pfm_name</key>
+			<string>OfficeExperiencesAnalyzingContentPreference</string>
+			<key>pfm_title</key>
+			<string>Connected Experiences: Analyzing Content</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.28</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Connected experiences that download online content are experiences that allow you to search and download online content including templates, images, 3D models, videos, and reference materials to enhance your documents. For example, Office templates or PowerPoint QuickStarter.</string>
+			<key>pfm_name</key>
+			<string>OfficeExperiencesDownloadingContentPreference</string>
+			<key>pfm_title</key>
+			<string>Connected Experiences: Downloading Content</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.28</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>In addition to the connected experiences above, there are some optional connected experiences that you may choose to allow your users to access. For example, the LinkedIn features of the Resume Assistant in Word or the Weather Bar in Outlook, which uses MSN Weather.</string>
+			<key>pfm_name</key>
+			<string>OptionalConnectedExperiencesPreference</string>
+			<key>pfm_title</key>
+			<string>Connected Experiences, Optional</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.28</string>
+			<key>pfm_default</key>
+			<string>FullDiagnosticData</string>
+			<key>pfm_description</key>
+			<string>Diagnostic data is used to keep Office secure and up-to-date, detect, diagnose and remediate problems, and also make product improvements.</string>
+			<key>pfm_name</key>
+			<string>DiagnosticDataTypePreference</string>
+			<key>pfm_note</key>
+			<string>Required Service Data is still sent even with a setting of 'Zero.' Use the 'Send Telemetry Data' setting to completely stop all data.</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>BasicDiagnosticData</string>
+				<string>FullDiagnosticData</string>
+				<string>ZeroDiagnosticData</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Required Data Only</string>
+				<string>Required and Optional Data</string>
+				<string>Zero Diagnostic Data</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Diagnostic Data</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.28</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Controls wether diagnostic data transmission is on or off.</string>
+			<key>pfm_name</key>
+			<string>SendAllTelemetryEnabled</string>
+			<key>pfm_note</key>
+			<string>If false then the 'Diagnostic Data' setting has no effect.</string>
+			<key>pfm_title</key>
+			<string>Send Telemetry Data</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.28</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Setting this option to TRUE will suppress the 'Your privacy options' dialog for Volume License users only.</string>
+			<key>pfm_name</key>
+			<string>HasUserSeenEnterpriseFREDialog</string>
+			<key>pfm_note</key>
+			<string>This dialog can only be suppressed for Office 365 users by disabling 'Optional Connected Experiences' completely.</string>
+			<key>pfm_title</key>
+			<string>Has User Seen First Run Experience</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>15.33</string>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Increase logging levels for authentication requests. Enable Minimum Severity (msoridDefaultMinimumSeverity) option if this key is enabled.</string>
+			<key>pfm_name</key>
+			<string>msoridEnableLogging</string>
+			<key>pfm_title</key>
+			<string>Enable logging for authentication requests</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+			<key>pfm_type_input</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>15.33</string>
+			<key>pfm_default</key>
+			<integer>200</integer>
+			<key>pfm_description</key>
+			<string>Set value to 200 if 'logging for authentication requests' (msoridEnableLogging) is enabled.</string>
+			<key>pfm_name</key>
+			<string>msoridDefaultMinimumSeverity</string>
+			<key>pfm_title</key>
+			<string>Minimum severity for authentication requests logging</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>15.33</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>When set to true will force the open/save panel to ‘On My Mac’ instead of 'Online Locations'.</string>
+			<key>pfm_name</key>
+			<string>DefaultsToLocalOpenSave</string>
+			<key>pfm_title</key>
+			<string>'On My Mac' as default open and save location</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>15.36</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Show or Hide the Document gallery selector when office applications are launched.</string>
+			<key>pfm_name</key>
+			<string>ShowDocStageOnLaunch</string>
+			<key>pfm_title</key>
+			<string>Show Document Selector</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>15.34</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>A setting of FALSE supresses all "What's new" messages for all suite apps: Word, PowerPoint, Excel, Outlook and OneNote.</string>
+			<key>pfm_name</key>
+			<string>ShowWhatsNewOnLaunch</string>
+			<key>pfm_title</key>
+			<string>Show 'What's New' dialogs</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>15.33</string>
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
@@ -138,79 +423,141 @@
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15.33.0</string>
-			<key>pfm_description</key>
-			<string>Sets value of 'Belongs to' field in the About Box. This happens automatically on 15.33+ installs. As of version 16.13+ this value also pre-fills the account authentication field.</string>
-			<key>pfm_name</key>
-			<string>OfficeActivationEmailAddress</string>
-			<key>pfm_title</key>
-			<string>Activation Account</string>
-			<key>pfm_type</key>
-			<string>string</string>
-			<key>pfm_value_placeholder</key>
-			<string>jane.doe@microsoft.com</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.13.0</string>
+			<string>16.24</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Only prompt user for needed information like a O365 authentication.</string>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing AutoUpdate. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing AutoUpdate. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
 			<key>pfm_name</key>
-			<string>OfficeAutoSignIn</string>
+			<string>InstallAutoUpdate</string>
 			<key>pfm_title</key>
-			<string>Hide welcome window of first launch</string>
+			<string>Install AutoUpdate (MAU)</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15.36.0</string>
+			<string>16.24</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Disables the gallery view on application launch.</string>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Excel. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing Excel. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
 			<key>pfm_name</key>
-			<string>ShowDocStageOnLaunch</string>
+			<string>InstallExcel</string>
 			<key>pfm_title</key>
-			<string>Hide gallery view on launch</string>
+			<string>Install Excel</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15.34.0</string>
+			<string>16.24</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Additional key to 'OUIWhatsNewShownItemIds' that services as a single place to remove all future "What's new" messages for all suite apps: Word, PowerPoint, Excel, Outlook, and OneNote.</string>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing OneDrive. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing OneDrive. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
 			<key>pfm_name</key>
-			<string>ShowWhatsNewOnLaunch</string>
+			<string>InstallOneDrive</string>
 			<key>pfm_title</key>
-			<string>Show What's New message after updates</string>
+			<string>Install OneDrive</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15.33.0</string>
+			<string>16.24</string>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
-			<string>Sets the Open and Save options to default to 'On My Mac' instead of 'Online Locations'.</string>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing OneNote. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing OneNote. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
 			<key>pfm_name</key>
-			<string>DefaultsToLocalOpenSave</string>
+			<string>InstallOneNote</string>
 			<key>pfm_title</key>
-			<string>Use 'On My Mac' as default open and save location</string>
+			<string>Install OneNote</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15.33.0</string>
+			<string>16.24</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Outlook. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing Outlook. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_name</key>
+			<string>InstallOutlook</string>
+			<key>pfm_title</key>
+			<string>Install Outlook</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.24</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing PowerPoint. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing PowerPoint. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_name</key>
+			<string>InstallPowerPoint</string>
+			<key>pfm_title</key>
+			<string>Install PowerPoint</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.24</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Teams. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing Teams. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_name</key>
+			<string>InstallTeams</string>
+			<key>pfm_title</key>
+			<string>Install Teams</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.24</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Word. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing Word. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_name</key>
+			<string>InstallWord</string>
+			<key>pfm_title</key>
+			<string>Install Word</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>15.32</string>
 			<key>pfm_default</key>
 			<string>DisabledWithWarnings</string>
 			<key>pfm_description</key>
-			<string>Sets the VisualBasic Macro security level.</string>
+			<string>The VisualBasicMacroExecutionState1 setting controls whether macros are ever allowed to execute, and what the user experience is when opening
+a file that contains a macro. By default, macros will only run after the user is presented with an alert when opening a file that contains a macro. The
+user must make a choice whether to allow or deny macros for each individual file, each time that file is opened.</string>
 			<key>pfm_name</key>
 			<string>VisualBasicMacroExecutionState</string>
 			<key>pfm_range_list</key>
@@ -232,95 +579,9 @@
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15.33.0</string>
-			<key>pfm_default</key>
-			<integer>0</integer>
-			<key>pfm_description</key>
-			<string>Increase logging levels for authentication requests.</string>
-			<key>pfm_name</key>
-			<string>msoridEnableLogging</string>
-			<key>pfm_title</key>
-			<string>Enable logging for authentication requests</string>
-			<key>pfm_type</key>
-			<string>integer</string>
-			<key>pfm_type_input</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>15.33.0</string>
-			<key>pfm_default</key>
-			<integer>200</integer>
-			<key>pfm_description</key>
-			<string>Set value to 200 if msoridEnableLogging is enabled.</string>
-			<key>pfm_name</key>
-			<string>msoridDefaultMinimumSeverity</string>
-			<key>pfm_title</key>
-			<string>Minimum severity for authentication requests logging</string>
-			<key>pfm_type</key>
-			<string>integer</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>15.33.0</string>
-			<key>pfm_description</key>
-			<string>Triggers for pre 15.32 preferences to be migrated to the new domain going forward. In most cases you should NOT manage or touch this.</string>
-			<key>pfm_name</key>
-			<string>HaveMergedOldPrefs</string>
-			<key>pfm_title</key>
-			<string>Migrate old preferences to new domain</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.16</string>
-			<key>pfm_description</key>
-			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including “do shell script ...” in the AppleScript code. 
-The default value for this setting allows using MacScript, as there are a number of legitimate uses of AppleScript that do not rely on external processes. When this setting is set to NO, macros that attempt to use MacScript will fail with an error at the point where MacScript is invoked.</string>
-			<key>pfm_description_reference</key>
-			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including “do shell script ...” in the AppleScript code. 
-The default value for this setting allows using MacScript, as there are a number of legitimate uses of AppleScript that do not rely on external processes. When this setting is set to NO, macros that attempt to use MacScript will fail with an error at the point where MacScript is invoked.</string>
-			<key>pfm_name</key>
-			<string>DisableVisualBasicMacScript</string>
-			<key>pfm_title</key>
-			<string>Disable macros from invoking the MacScript() Visual Basic API.</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.17</string>
-			<key>pfm_description</key>
-			<string>If you don't want your users to see the new MS Use Terms (Sept 2018) dialog, and instead auto-accept the terms on their behalf, set this value to True.</string>
-			<key>pfm_description_reference</key>
-			<string>If you don't want your users to see the new MS Use Terms (Sept 2018) dialog, and instead auto-accept the terms on their behalf, set this value to True.</string>
-			<key>pfm_name</key>
-			<string>TermsAccepted1809</string>
-			<key>pfm_title</key>
-			<string>Auto accept the MS Use Terms (Sept 2018).</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.21</string>
-			<key>pfm_description</key>
-			<string>Controls the ability for Office to write to the VB project through the VBA object model.</string>
-			<key>pfm_description_reference</key>
-			<string>For Office 2019 only: The VBAObjectModelIsTrusted setting determines if macros are allowed to modify the VB project itself through the VBA object model. The default value for this setting distrusts the VB object model and prevents macros from modifying the VB project. When this setting is set to NO, macros that attempt to invoke any method in the VB object model will fail with an error at that point in the code.</string>
-			<key>pfm_name</key>
-			<string>VBAObjectModelIsTrusted</string>
-			<key>pfm_title</key>
-			<string>VBAObjectModelIsTrusted</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
 			<string>15.31</string>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Controls the ability for 3rd party vendors to use a DECLARE statement to bind a Visual Basic symbol name to an external procedure in the local OS.</string>
 			<key>pfm_description_reference</key>
@@ -330,7 +591,7 @@ The default value for this setting allows using MacScript, as there are a number
 			<key>pfm_note</key>
 			<string>Many legitimate 3rd party addin vendors use this feature of Visual Basic to add and extend features in Office for Mac.</string>
 			<key>pfm_title</key>
-			<string>DisableVisualBasicExternalDylibs</string>
+			<string>Disable Visual Basic External Dylibs</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -340,13 +601,15 @@ The default value for this setting allows using MacScript, as there are a number
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Determines if macros are allowed to use a DECLARE to bind to the system() OS API.</string>
+			<string>Determines if macros are allowed to use a DECLARE to bind to the system() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line.</string>
 			<key>pfm_description_reference</key>
 			<string>The AllowVisualBasicToBindToSystem setting determines if macros are allowed to use a DECLARE to bind to the system() OS API. This API allows macros to execute arbitrary external processes and pass them arbitrary data on the command line. The default value for this setting disallows the binding, as the system() API should not be used. When this setting is set to NO, macros that attempt to use system() will fail with an error at the point where system() is invoked.</string>
 			<key>pfm_name</key>
 			<string>AllowVisualBasicToBindToSystem</string>
+			<key>pfm_note</key>
+			<string>The default value for this setting disallows the binding, as the system() API should not be used. When this setting is set to NO, macros that attempt to use system() will fail with an error at the point where system() is invoked.</string>
 			<key>pfm_title</key>
-			<string>AllowVisualBasicToBindToSystem</string>
+			<string>Allow Visual Basic to Bind to System</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -364,119 +627,44 @@ The default value for this setting allows using MacScript, as there are a number
 			<key>pfm_note</key>
 			<string>At least one 3rd party vendor uses popen to communicate with their own code.</string>
 			<key>pfm_title</key>
-			<string>DisableVisualBasicToBindToPopen</string>
+			<string>Disable Visual Basic to Bind to Popen</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>16.24</string>
+			<string>16.16</string>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
-			<string>Disable the Office Suite installer from installing Word. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
+			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including “do shell script ...” in the AppleScript code.</string>
 			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing Word. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including “do shell script ...” in the AppleScript code. 
+The default value for this setting allows using MacScript, as there are a number of legitimate uses of AppleScript that do not rely on external processes. When this setting is set to NO, macros that attempt to use MacScript will fail with an error at the point where MacScript is invoked.</string>
 			<key>pfm_name</key>
-			<string>InstallWord</string>
+			<string>DisableVisualBasicMacScript</string>
+			<key>pfm_note</key>
+			<string>The default value for this setting allows using MacScript, as there are a number of legitimate uses of AppleScript that do not rely on external processes. When this setting is set to NO, macros that attempt to use MacScript will fail with an error at the point where MacScript is invoked.</string>
 			<key>pfm_title</key>
-			<string>Install Word</string>
+			<string>Disable macros from invoking the MacScript() Visual Basic API.</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>16.24</string>
+			<string>16.21</string>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
-			<string>Disable the Office Suite installer from installing Excel. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
+			<string>Controls the ability for Office to write to the VB project through the VBA object model.</string>
 			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing Excel. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
+			<string>For Office 2019 only: The VBAObjectModelIsTrusted setting determines if macros are allowed to modify the VB project itself through the VBA object model.</string>
 			<key>pfm_name</key>
-			<string>InstallExcel</string>
+			<string>VBAObjectModelIsTrusted</string>
+			<key>pfm_note</key>
+			<string>The default value for this setting distrusts the VB object model and prevents macros from modifying the VB project. When this setting is set to NO, macros that attempt to invoke any method in the VB object model will fail with an error at that point in the code.</string>
 			<key>pfm_title</key>
-			<string>Install Excel</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.24</string>
-			<key>pfm_default</key>
-			<true/>
-			<key>pfm_description</key>
-			<string>Disable the Office Suite installer from installing PowerPoint. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
-			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing PowerPoint. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
-			<key>pfm_name</key>
-			<string>InstallPowerPoint</string>
-			<key>pfm_title</key>
-			<string>Install PowerPoint</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.24</string>
-			<key>pfm_default</key>
-			<true/>
-			<key>pfm_description</key>
-			<string>Disable the Office Suite installer from installing Outlook. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
-			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing Outlook. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
-			<key>pfm_name</key>
-			<string>InstallOutlook</string>
-			<key>pfm_title</key>
-			<string>Install Outlook</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.24</string>
-			<key>pfm_default</key>
-			<true/>
-			<key>pfm_description</key>
-			<string>Disable the Office Suite installer from installing OneNote. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
-			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing OneNote. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
-			<key>pfm_name</key>
-			<string>InstallOneNote</string>
-			<key>pfm_title</key>
-			<string>Install OneNote</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.24</string>
-			<key>pfm_default</key>
-			<true/>
-			<key>pfm_description</key>
-			<string>Disable the Office Suite installer from installing OneDrive. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
-			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing OneDrive. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
-			<key>pfm_name</key>
-			<string>InstallOneDrive</string>
-			<key>pfm_title</key>
-			<string>Install OneDrive</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.24</string>
-			<key>pfm_default</key>
-			<true/>
-			<key>pfm_description</key>
-			<string>Disable the Office Suite installer from installing AutoUpdate (MAU). Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist.</string>
-			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing AutoUpdate. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
-			<key>pfm_name</key>
-			<string>InstallAutoUpdate</string>
-			<key>pfm_title</key>
-			<string>Install AutoUpdate (MAU)</string>
+			<string>VBA Object Model is Trusted</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -486,6 +674,6 @@ The default value for this setting allows using MacScript, as there are a number
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>7</integer>
+	<integer>8</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Major reworking to bring manifest up-to-date:
• Segmentation for easier navigation
• Added all new 16.28 keys
• Added other missing keys
• Clarified language and descriptions
• Grouped related keys and alphabetized
• Removed `HaveMergedOldPrefs` since it should not be managed

Covers the primary request for #116 (additional PRs coming) and takes care of #104 completely.