### PR TITLE
New payload to disable iCloud Save defaults

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -2,16 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>pfm_description_reference</key>
-	<string>The Global Preferences payload is designated by specifying .GlobalPreferences as the PayloadType value.</string>
 	<key>pfm_description</key>
 	<string>Global Preferences settings</string>
+	<key>pfm_description_reference</key>
+	<string>The Global Preferences payload is designated by specifying .GlobalPreferences as the PayloadType value.</string>
 	<key>pfm_domain</key>
 	<string>.GlobalPreferences</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:48Z</date>
+	<date>2019-08-21T15:15:48Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -129,22 +129,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string></string>
 			<key>pfm_description</key>
 			<string>Hides the one-time alert shown when opening a 32-bit application.</string>
+			<key>pfm_description_reference</key>
+			<string></string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.apple.com/en-us/HT208436</string>
-			<key>pfm_macos_min</key>
-			<string>10.13.4</string>
 			<key>pfm_macos_max</key>
 			<string>10.13.6</string>
+			<key>pfm_macos_min</key>
+			<string>10.13.4</string>
 			<key>pfm_name</key>
 			<string>CSUIDisable32BitWarning</string>
-			<key>pfm_title</key>
-			<string>Hide 32-bit app compatibility alert</string>
 			<key>pfm_note</key>
 			<string>To hide the 32-bit app compatibility alert on macOS 10.14+ use the CoreServices UIAgent payload.</string>
+			<key>pfm_title</key>
+			<string>Hide 32-bit app compatibility alert</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -167,18 +167,18 @@ The payload organization for a payload need not match the payload organization i
 			<string>A value of zero, means auto-logout is off. In some cases, this value may be restricted to values between 5 minutes and 24 hours.</string>
 			<key>pfm_description_reference</key>
 			<string>Optional. The auto log out delay (in seconds). A value of zero, means auto-logout is off. In some cases, this value may be restricted to values between 5 minutes and 24 hours.</string>
-			<key>pfm_range_min</key>
-			<integer>0</integer>
-			<key>pfm_range_max</key>
-			<integer>86400</integer>
-			<key>pfm_value_unit</key>
-			<string>Seconds</string>
 			<key>pfm_name</key>
 			<string>com.apple.autologout.AutoLogOutDelay</string>
+			<key>pfm_range_max</key>
+			<integer>86400</integer>
+			<key>pfm_range_min</key>
+			<integer>0</integer>
 			<key>pfm_title</key>
 			<string>Auto LogOut Delay</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>Seconds</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -187,6 +187,8 @@ The payload organization for a payload need not match the payload organization i
 			<string></string>
 			<key>pfm_description_reference</key>
 			<string></string>
+			<key>pfm_name</key>
+			<string>AppleShowScrollBars</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>Automatic</string>
@@ -199,13 +201,23 @@ The payload organization for a payload need not match the payload organization i
 				<string>When scrolling</string>
 				<string>Always</string>
 			</array>
-			<key>pfm_name</key>
-			<string>AppleShowScrollBars</string>
 			<key>pfm_title</key>
 			<string>Show scroll bars</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
+        <dict>
+            <key>pfm_description</key>
+            <string>If set to false, applications won't default to save to iCloud.</string>
+            <key>pfm_description_reference</key>
+            <string>Optional. If set to false, applications won't default to save to iCloud. Defaults to true.</string>
+            <key>pfm_name</key>
+            <string>NSDocumentSaveNewDocumentsToCloud</string>
+            <key>pfm_title</key>
+            <string>Enable iCloud as default document save location</string>
+            <key>pfm_type</key>
+            <string>boolean</string>
+        </dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -217,6 +229,6 @@ The payload organization for a payload need not match the payload organization i
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -1,234 +1,229 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>pfm_description</key>
-	<string>Global Preferences settings</string>
-	<key>pfm_description_reference</key>
-	<string>The Global Preferences payload is designated by specifying .GlobalPreferences as the PayloadType value.</string>
-	<key>pfm_domain</key>
-	<string>.GlobalPreferences</string>
-	<key>pfm_format_version</key>
-	<integer>1</integer>
-	<key>pfm_last_modified</key>
-	<date>2019-08-21T15:15:48Z</date>
-	<key>pfm_platforms</key>
-	<array>
-		<string>macOS</string>
-	</array>
-	<key>pfm_subkeys</key>
-	<array>
-		<dict>
-			<key>pfm_default</key>
-			<string>Configures Global Preferences settings</string>
-			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
-			<key>pfm_name</key>
-			<string>PayloadDescription</string>
-			<key>pfm_title</key>
-			<string>Payload Description</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string>Global Preferences</string>
-			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
-			<key>pfm_name</key>
-			<string>PayloadDisplayName</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Display Name</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string>.GlobalPreferences</string>
-			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
-			<key>pfm_name</key>
-			<string>PayloadIdentifier</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Identifier</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string>.GlobalPreferences</string>
-			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
-			<key>pfm_name</key>
-			<string>PayloadType</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Type</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string></string>
-			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
-			<key>pfm_format</key>
-			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
-			<key>pfm_name</key>
-			<string>PayloadUUID</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload UUID</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<integer>1</integer>
-			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
+	<dict>
+		<key>pfm_description</key>
+		<string>Global Preferences settings</string>
+		<key>pfm_description_reference</key>
+		<string>The Global Preferences payload is designated by specifying .GlobalPreferences as the PayloadType value.</string>
+		<key>pfm_domain</key>
+		<string>.GlobalPreferences</string>
+		<key>pfm_format_version</key>
+		<integer>1</integer>
+		<key>pfm_last_modified</key>
+		<date>2019-08-26T00:00:00Z</date>
+		<key>pfm_platforms</key>
+		<array>
+			<string>macOS</string>
+		</array>
+		<key>pfm_subkeys</key>
+		<array>
+			<dict>
+				<key>pfm_default</key>
+				<string>Configures Global Preferences settings</string>
+				<key>pfm_description</key>
+				<string>Description of the payload.</string>
+				<key>pfm_description_reference</key>
+				<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+				<key>pfm_name</key>
+				<string>PayloadDescription</string>
+				<key>pfm_title</key>
+				<string>Payload Description</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>Global Preferences</string>
+				<key>pfm_description</key>
+				<string>Name of the payload.</string>
+				<key>pfm_description_reference</key>
+				<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+				<key>pfm_name</key>
+				<string>PayloadDisplayName</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Display Name</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>.GlobalPreferences</string>
+				<key>pfm_description</key>
+				<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+				<key>pfm_description_reference</key>
+				<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+				<key>pfm_name</key>
+				<string>PayloadIdentifier</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Identifier</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>.GlobalPreferences</string>
+				<key>pfm_description</key>
+				<string>The type of the payload, a reverse dns string.</string>
+				<key>pfm_description_reference</key>
+				<string>The payload type.</string>
+				<key>pfm_name</key>
+				<string>PayloadType</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Type</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string/>
+				<key>pfm_description</key>
+				<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+				<key>pfm_description_reference</key>
+				<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+				<key>pfm_format</key>
+				<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+				<key>pfm_name</key>
+				<string>PayloadUUID</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload UUID</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<integer>1</integer>
+				<key>pfm_description</key>
+				<string>The version of the whole configuration profile.</string>
+				<key>pfm_description_reference</key>
+				<string>The version number of the individual payload.
 A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
-			<key>pfm_name</key>
-			<string>PayloadVersion</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Version</string>
-			<key>pfm_type</key>
-			<string>integer</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
-			<key>pfm_name</key>
-			<string>PayloadOrganization</string>
-			<key>pfm_title</key>
-			<string>Payload Organization</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>Hides the one-time alert shown when opening a 32-bit application.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
-			<key>pfm_documentation_url</key>
-			<string>https://support.apple.com/en-us/HT208436</string>
-			<key>pfm_macos_max</key>
-			<string>10.13.6</string>
-			<key>pfm_macos_min</key>
-			<string>10.13.4</string>
-			<key>pfm_name</key>
-			<string>CSUIDisable32BitWarning</string>
-			<key>pfm_note</key>
-			<string>To hide the 32-bit app compatibility alert on macOS 10.14+ use the CoreServices UIAgent payload.</string>
-			<key>pfm_title</key>
-			<string>Hide 32-bit app compatibility alert</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>If set to false, fast user switching is disabled.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, fast user switching is disabled. Defaults to true.</string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>MultipleSessionEnabled</string>
-			<key>pfm_title</key>
-			<string>Enable Fast User Switching</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>A value of zero, means auto-logout is off. In some cases, this value may be restricted to values between 5 minutes and 24 hours.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The auto log out delay (in seconds). A value of zero, means auto-logout is off. In some cases, this value may be restricted to values between 5 minutes and 24 hours.</string>
-			<key>pfm_name</key>
-			<string>com.apple.autologout.AutoLogOutDelay</string>
-			<key>pfm_range_max</key>
-			<integer>86400</integer>
-			<key>pfm_range_min</key>
-			<integer>0</integer>
-			<key>pfm_title</key>
-			<string>Auto LogOut Delay</string>
-			<key>pfm_type</key>
-			<string>integer</string>
-			<key>pfm_value_unit</key>
-			<string>Seconds</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string>Automatic</string>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string></string>
-			<key>pfm_name</key>
-			<string>AppleShowScrollBars</string>
-			<key>pfm_range_list</key>
-			<array>
+				<key>pfm_name</key>
+				<string>PayloadVersion</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Version</string>
+				<key>pfm_type</key>
+				<string>integer</string>
+			</dict>
+			<dict>
+				<key>pfm_description</key>
+				<string>The autologout delay, in seconds. A value of 0 means autologout is off. In some cases, this delay may be restricted to values between 5 minutes and 24 hours.</string>
+				<key>pfm_description_reference</key>
+				<string>The autologout delay, in seconds. A value of 0 means autologout is off. In some cases, this delay may be restricted to values between 5 minutes and 24 hours.</string>
+				<key>pfm_documentation_url</key>
+				<string>https://developer.apple.com/documentation/devicemanagement/globalpreferences</string>
+				<key>pfm_name</key>
+				<string>com.apple.autologout.AutoLogOutDelay</string>
+				<key>pfm_range_max</key>
+				<integer>86400</integer>
+				<key>pfm_range_min</key>
+				<integer>0</integer>
+				<key>pfm_title</key>
+				<string>Auto LogOut Delay</string>
+				<key>pfm_type</key>
+				<string>integer</string>
+				<key>pfm_value_unit</key>
+				<string>Seconds</string>
+			</dict>
+			<dict>
+				<key>pfm_description</key>
+				<string>If set to false, fast user switching is disabled.</string>
+				<key>pfm_description_reference</key>
+				<string>Optional. If set to false, fast user switching is disabled. Defaults to true.</string>
+				<key>pfm_documentation_url</key>
+				<string>https://developer.apple.com/documentation/devicemanagement/globalpreferences</string>
+				<key>pfm_macos_min</key>
+				<string>10.12</string>
+				<key>pfm_name</key>
+				<string>MultipleSessionEnabled</string>
+				<key>pfm_title</key>
+				<string>Enable Fast User Switching</string>
+				<key>pfm_type</key>
+				<string>boolean</string>
+			</dict>
+			<dict>
+				<key>pfm_description</key>
+				<string>Hides the one-time alert shown when opening a 32-bit application.</string>
+				<key>pfm_documentation_url</key>
+				<string>https://support.apple.com/en-us/HT208436</string>
+				<key>pfm_macos_deprecated</key>
+				<string>10.13.6</string>
+				<key>pfm_macos_max</key>
+				<string>10.13.6</string>
+				<key>pfm_macos_min</key>
+				<string>10.13.4</string>
+				<key>pfm_name</key>
+				<string>CSUIDisable32BitWarning</string>
+				<key>pfm_note</key>
+				<string>To hide the 32-bit app compatibility alert on macOS 10.14+ use the CoreServices UIAgent payload.</string>
+				<key>pfm_title</key>
+				<string>Hide 32-bit App Compatibility Alert</string>
+				<key>pfm_type</key>
+				<string>boolean</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<true/>
+				<key>pfm_description</key>
+				<string>If set to false, applications won't default to save to iCloud.</string>
+				<key>pfm_description_reference</key>
+				<string>Optional. If set to false, applications won't default to save to iCloud. Defaults to true.</string>
+				<key>pfm_documentation_url</key>
+				<string>https://eclecticlight.co/2017/11/09/customising-it-all-global-defaults-in-macos-sierra-and-high-sierra/</string>
+				<key>pfm_name</key>
+				<string>NSDocumentSaveNewDocumentsToCloud</string>
+				<key>pfm_title</key>
+				<string>Save New Documents to iCloud</string>
+				<key>pfm_type</key>
+				<string>boolean</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
 				<string>Automatic</string>
-				<string>WhenScrolling</string>
-				<string>Always</string>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Automatically based on mouse or trackpad</string>
-				<string>When scrolling</string>
-				<string>Always</string>
-			</array>
-			<key>pfm_title</key>
-			<string>Show scroll bars</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-        <dict>
-            <key>pfm_description</key>
-            <string>If set to false, applications won't default to save to iCloud.</string>
-            <key>pfm_description_reference</key>
-            <string>Optional. If set to false, applications won't default to save to iCloud. Defaults to true.</string>
-            <key>pfm_name</key>
-            <string>NSDocumentSaveNewDocumentsToCloud</string>
-            <key>pfm_title</key>
-            <string>Enable iCloud as default document save location</string>
-            <key>pfm_type</key>
-            <string>boolean</string>
-        </dict>
-	</array>
-	<key>pfm_targets</key>
-	<array>
-		<string>system</string>
-		<string>user</string>
-	</array>
-	<key>pfm_title</key>
-	<string>Global Preferences</string>
-	<key>pfm_unique</key>
-	<true/>
-	<key>pfm_version</key>
-	<integer>6</integer>
-</dict>
+				<key>pfm_description</key>
+				<string>When should the scroll bars be shown?</string>
+				<key>pfm_documentation_url</key>
+				<string>https://eclecticlight.co/2017/11/09/customising-it-all-global-defaults-in-macos-sierra-and-high-sierra/</string>
+				<key>pfm_name</key>
+				<string>AppleShowScrollBars</string>
+				<key>pfm_range_list</key>
+				<array>
+					<string>Automatic</string>
+					<string>WhenScrolling</string>
+					<string>Always</string>
+				</array>
+				<key>pfm_range_list_titles</key>
+				<array>
+					<string>Automatically based on mouse or trackpad</string>
+					<string>When scrolling</string>
+					<string>Always</string>
+				</array>
+				<key>pfm_title</key>
+				<string>Show Scroll Bars</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+		</array>
+		<key>pfm_targets</key>
+		<array>
+			<string>system</string>
+			<string>user</string>
+		</array>
+		<key>pfm_title</key>
+		<string>Global Preferences</string>
+		<key>pfm_unique</key>
+		<true/>
+		<key>pfm_version</key>
+		<integer>6</integer>
+	</dict>
 </plist>


### PR DESCRIPTION
Updated:

- Enable iCloud as default document save location