### PR TITLE
Update Notifications manifests for iOS & macOS

### DIFF
--- a/Manifests/ManifestsApple/com.apple.notificationsettings-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.notificationsettings-iOS.plist
@@ -5,23 +5,23 @@
 	<key>pfm_description</key>
 	<string>Configures Notification settings for iOS apps</string>
 	<key>pfm_documentation_url</key>
-	<string>https://help.apple.com/deployment/mdm/#/mdm46b6547ba</string>
+	<string>https://developer.apple.com/documentation/devicemanagement/notifications/notificationsettingsitem?changes=latest_minor</string>
 	<key>pfm_domain</key>
 	<string>com.apple.notificationsettings</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
-	<key>pfm_ios_min</key>
-	<string>9.3</string>
 	<key>pfm_last_modified</key>
-	<date>2019-02-17T20:27:52Z</date>
+	<date>2019-09-24T19:27:52Z</date>
 	<key>pfm_supervised</key>
 	<true/>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
 	</array>
+	<key>pfm_subdomain</key>
+	<string>iOS</string>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -139,6 +139,8 @@
 							<string>Whether notifications are allowed for this app.</string>
 							<key>pfm_description_reference</key>
 							<string>Optional. Whether notifications are allowed for this app. Default is true.</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
 							<key>pfm_name</key>
 							<string>NotificationsEnabled</string>
 							<key>pfm_title</key>
@@ -151,6 +153,8 @@
 							<string>Bundle identifier of the target app</string>
 							<key>pfm_description_reference</key>
 							<string>Required. Bundle identifier of app to which to apply these notification settings</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
 							<key>pfm_name</key>
 							<string>BundleIdentifier</string>
 							<key>pfm_require</key>
@@ -169,6 +173,8 @@
 							<string>Whether notifications can be shown in notification center.</string>
 							<key>pfm_description_reference</key>
 							<string>Optional. Whether notifications can be shown in notification center. Default is true.</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
 							<key>pfm_name</key>
 							<string>ShowInNotificationCenter</string>
 							<key>pfm_title</key>
@@ -180,72 +186,17 @@
 							<key>pfm_default</key>
 							<true/>
 							<key>pfm_description</key>
-							<string>Whether sounds are allowed for this app.</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. Whether sounds are allowed for this app. Default is true.</string>
-							<key>pfm_name</key>
-							<string>SoundsEnabled</string>
-							<key>pfm_title</key>
-							<string>Sounds Enabled</string>
-							<key>pfm_type</key>
-							<string>boolean</string>
-						</dict>
-						<dict>
-							<key>pfm_default</key>
-							<true/>
-							<key>pfm_description</key>
-							<string>Whether badges are allowed for this app.</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. Whether badges are allowed for this app. Default is true.</string>
-							<key>pfm_name</key>
-							<string>BadgesEnabled</string>
-							<key>pfm_title</key>
-							<string>Badges Enabled</string>
-							<key>pfm_type</key>
-							<string>boolean</string>
-						</dict>
-						<dict>
-							<key>pfm_default</key>
-							<true/>
-							<key>pfm_description</key>
 							<string>Whether notifications can be shown on the lock screen.</string>
 							<key>pfm_description_reference</key>
 							<string>Optional. Whether notifications can be shown in the lock screen. Default is true.</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
 							<key>pfm_name</key>
 							<string>ShowInLockScreen</string>
 							<key>pfm_title</key>
 							<string>Show on Lock Screen</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
-						</dict>
-						<dict>
-							<key>pfm_default</key>
-							<integer>1</integer>
-							<key>pfm_description</key>
-							<string>The type of alert for notifications for this app. None/Banner/Alert</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. The type of alert for notifications for this app:
-- 0: None
-- 1: Banner (default)
-- 2: Modal Alert</string>
-							<key>pfm_name</key>
-							<string>AlertType</string>
-							<key>pfm_range_list</key>
-							<array>
-								<integer>0</integer>
-								<integer>1</integer>
-								<integer>2</integer>
-							</array>
-							<key>pfm_range_list_titles</key>
-							<array>
-								<string>None</string>
-								<string>Banners</string>
-								<string>Alerts</string>
-							</array>
-							<key>pfm_title</key>
-							<string>Alert Type</string>
-							<key>pfm_type</key>
-							<string>integer</string>
 						</dict>
 						<dict>
 							<key>pfm_default</key>
@@ -264,6 +215,69 @@
 							<string>Show in Car Play</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>Whether sounds are allowed for this app.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether sounds are allowed for this app. Default is true.</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
+							<key>pfm_name</key>
+							<string>SoundsEnabled</string>
+							<key>pfm_title</key>
+							<string>Sounds Enabled</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>Whether badges are allowed for this app.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether badges are allowed for this app. Default is true.</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
+							<key>pfm_name</key>
+							<string>BadgesEnabled</string>
+							<key>pfm_title</key>
+							<string>Badges Enabled</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<integer>1</integer>
+							<key>pfm_description</key>
+							<string>The type of alert for notifications for this app. None/Banner/Alert</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. The type of alert for notifications for this app:
+- 0: None
+- 1: Banner (default)
+- 2: Modal Alert</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
+							<key>pfm_name</key>
+							<string>AlertType</string>
+							<key>pfm_range_list</key>
+							<array>
+								<integer>0</integer>
+								<integer>1</integer>
+								<integer>2</integer>
+							</array>
+							<key>pfm_range_list_titles</key>
+							<array>
+								<string>None</string>
+								<string>Banners</string>
+								<string>Alerts</string>
+							</array>
+							<key>pfm_title</key>
+							<string>Alert Type</string>
+							<key>pfm_type</key>
+							<string>integer</string>
 						</dict>
 						<dict>
 							<key>pfm_default</key>
@@ -339,6 +353,6 @@ Availability: Available in iOS 12 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.notificationsettings-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.notificationsettings-macOS.plist
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_description</key>
+	<string>Configures Notification settings for iOS &amp; macOS apps</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/notifications/notificationsettingsitem?changes=latest_minor</string>
+	<key>pfm_domain</key>
+	<string>com.apple.notificationsettings</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_interaction</key>
+	<string>exclusive</string>
+	<key>pfm_last_modified</key>
+	<date>2019-09-24T19:27:52Z</date>
+	<key>pfm_supervised</key>
+	<true/>
+	<key>pfm_platforms</key>
+	<array>
+		<string>macOS</string>
+	</array>
+  <key>pfm_subdomain</key>
+	<string>macOS</string>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures Notification settings for macOS apps</string>
+			<key>pfm_description</key>
+			<string>Description of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Notifications</string>
+			<key>pfm_description</key>
+			<string>Name of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.apple.notificationsettings</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.apple.notificationsettings</string>
+			<key>pfm_description</key>
+			<string>The type of the payload, a reverse dns string</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Notification settings for macOS apps</string>
+			<key>pfm_name</key>
+			<string>NotificationSettings</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>Notification settings for an app</string>
+					<key>pfm_name</key>
+					<string>NotificationSetting</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>Whether notifications are allowed for this app.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether notifications are allowed for this app. Default is true.</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>NotificationsEnabled</string>
+							<key>pfm_title</key>
+							<string>Enable Notifications</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Bundle identifier of the target app</string>
+							<key>pfm_description_reference</key>
+							<string>Required. Bundle identifier of app to which to apply these notification settings</string>
+							<key>pfm_ios_min</key>
+							<string>9.3</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>BundleIdentifier</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>App Bundle Identifier</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>com.domain.app</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>Whether notifications can be shown in notification center.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether notifications can be shown in notification center. Default is true.</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>ShowInNotificationCenter</string>
+							<key>pfm_title</key>
+							<string>Show in Notification Center</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>Whether notifications can be shown on the lock screen.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether notifications can be shown in the lock screen. Default is true.</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>ShowInLockScreen</string>
+							<key>pfm_title</key>
+							<string>Show on Lock Screen</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>Whether sounds are allowed for this app.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether sounds are allowed for this app. Default is true.</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>SoundsEnabled</string>
+							<key>pfm_title</key>
+							<string>Sounds Enabled</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>Whether badges are allowed for this app.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether badges are allowed for this app. Default is true.</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>BadgesEnabled</string>
+							<key>pfm_title</key>
+							<string>Badges Enabled</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<integer>1</integer>
+							<key>pfm_description</key>
+							<string>The type of alert for notifications for this app. None/Banner/Alert</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. The type of alert for notifications for this app:
+- 0: None
+- 1: Banner (default)
+- 2: Modal Alert</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>AlertType</string>
+							<key>pfm_range_list</key>
+							<array>
+								<integer>0</integer>
+								<integer>1</integer>
+								<integer>2</integer>
+							</array>
+							<key>pfm_range_list_titles</key>
+							<array>
+								<string>None</string>
+								<string>Banners</string>
+								<string>Alerts</string>
+							</array>
+							<key>pfm_title</key>
+							<string>Alert Type</string>
+							<key>pfm_type</key>
+							<string>integer</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>Whether an app can mark notifications as 'critical', bypassing Do Not Disturb and ringer settings.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. Whether an app can mark a notification as a critical notification that will ignore Do Not Disturb and ringer settings. Default is false. Availability: Available in iOS 12 and later.</string>
+							<key>pfm_documentation_url</key>
+							<string>https://developer.apple.com/business/documentation/Configuration-Profile-Reference.pdf</string>
+							<key>pfm_macos_min</key>
+							<string>10.15</string>
+							<key>pfm_name</key>
+							<string>CriticalAlertEnabled</string>
+							<key>pfm_title</key>
+							<string>Enable Critical Alerts</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Notification Setting</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Notification Settings</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+	</array>
+	<key>pfm_targets</key>
+	<array>
+		<string>system</string>
+	</array>
+	<key>pfm_title</key>
+	<string>Notifications</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
- Rename existing manifest for iOS and add subdomain
- Reorder `showIn` prefs (lockscreen, carplay, notification center) for iOS
- Add pfm_ios_min at preference level & remove from root level
- Bump iOS manifest version
- Add macOS manifest, cloned from iOS w/ unsupported prefs removed.
- Update pfm_documentation_url