### PR TITLE
Update com.apple.SoftwareUpdate prefs for Catalina

### DIFF
--- a/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
+++ b/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-11-16T18:22:44Z</date>
+	<date>2019-10-10T18:22:44Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -175,7 +175,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>AutomaticallyInstallMacOSUpdates</string>
 			<key>pfm_macos_min</key>
-			<string>10.14</string>
+			<string>10.15</string>
 			<key>pfm_title</key>
 			<string>Automatically install macOS updates</string>
 			<key>pfm_type</key>
@@ -183,9 +183,19 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_name</key>
+			<string>AutomaticallyInstallAppUpdates</string>
+			<key>pfm_macos_min</key>
+			<string>10.15</string>
+			<key>pfm_title</key>
+			<string>Automatically install App Store app updates</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
 			<string>ConfigDataInstall</string>
 			<key>pfm_title</key>
-			<string>Install XProtect and Gatekeeper updates automatically</string>
+			<string>Install XProtect, MRT, &amp; Gatekeeper updates automatically</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -300,6 +310,6 @@ Availability: Available in macOS 10.14 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Add AutomaticallyInstallAppUpdates, which works now in 10.15

- Update AutomaticallyInstallMacOSUpdates pfm_macos_min given pref wasn't previously managed via profile per https://derflounder.wordpress.com/2019/10/10/enable-automatic-macos-and-app-store-updates-on-macos-catalina-with-a-profile/

- Add MRT to pfm_title for ConfigDataInstall

- Bump pfm_version and pfm_modified_date