### PR TITLE
DigiDNA default values

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -11,7 +11,7 @@
 		<key>pfm_format_version</key>
 		<integer>1</integer>
 		<key>pfm_last_modified</key>
-		<date>2019-08-26T00:00:00Z</date>
+		<date>2019-11-07T15:29:15Z</date>
 		<key>pfm_platforms</key>
 		<array>
 			<string>macOS</string>

--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -136,6 +136,8 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>Seconds</string>
 			</dict>
 			<dict>
+				<key>pfm_default</key>
+				<true/>
 				<key>pfm_description</key>
 				<string>If set to false, fast user switching is disabled.</string>
 				<key>pfm_description_reference</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.NetworkBrowser.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.NetworkBrowser.plist
@@ -129,6 +129,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.NetworkBrowser.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.NetworkBrowser.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-02-14T08:41:26Z</date>
+	<date>2019-11-07T15:29:15Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
@@ -219,7 +219,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADCreateMobileAccountAtLogin Flag.</string>
 			<key>pfm_description_reference</key>
@@ -279,7 +279,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADWarnUserBeforeCreatingMA Flag.</string>
 			<key>pfm_description_reference</key>
@@ -339,7 +339,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADForceHomeLocal Flag.</string>
 			<key>pfm_description_reference</key>
@@ -353,7 +353,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Force local home directory on startup disk.</string>
 			<key>pfm_description_reference</key>
@@ -399,7 +399,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADUseWindowsUNCPath Flag.</string>
 			<key>pfm_description_reference</key>
@@ -413,7 +413,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Use UNC path from Active Directory to derive network home location</string>
 			<key>pfm_description_reference</key>
@@ -478,7 +478,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADDefaultUserShell Key.</string>
 			<key>pfm_description_reference</key>
@@ -843,7 +843,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADAllowMultiDomainAuth Key.</string>
 			<key>pfm_description_reference</key>
@@ -857,7 +857,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Allow authentication from any domain in the forest.</string>
 			<key>pfm_description_reference</key>
@@ -903,7 +903,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADNamespace Key.</string>
 			<key>pfm_description_reference</key>
@@ -968,7 +968,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADPacketSign Key.</string>
 			<key>pfm_description_reference</key>
@@ -1034,7 +1034,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADPacketEncrypt Key</string>
 			<key>pfm_description_reference</key>
@@ -1174,7 +1174,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable ADTrustChangePassIntervalDays Key.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
@@ -18,7 +18,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:49Z</date>
+	<date>2019-11-07T15:29:15Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
@@ -144,6 +144,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Hides the authentication UI when a mobile account is created.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
@@ -16,7 +16,7 @@ This payload allows controls the authentication UI during mobile account creatio
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:49Z</date>
+	<date>2019-11-07T15:29:15Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
@@ -154,6 +154,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Defer enabling FileVault until the designated user logs out. For details, see fdesetup(8). The person enabling FileVault must be either a local user or a mobile account user.</string>
 			<key>pfm_description_reference</key>
@@ -166,6 +168,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Set to true for manual profile installs to prompt for missing user name or password fields.</string>
 			<key>pfm_description_reference</key>
@@ -270,6 +274,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true and no certificate information is provided in this payload, the keychain already created at /Library/Keychains/FileVaultMaster.keychain will be used when the institutional recovery key is added.</string>
 			<key>pfm_description_reference</key>
@@ -297,6 +303,8 @@ Availability: Available in macOS 10.10 and later.</string>
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>When using the Defer option, set this key to true to not request enabling FileVault at user logout time.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-09-07T08:32:05Z</date>
+	<date>2019-11-07T15:29:15Z</date>
 	<key>pfm_macos_max</key>
 	<string>10.12.6</string>
 	<key>pfm_macos_min</key>

--- a/Manifests/ManifestsApple/com.apple.MCX.TimeMachine.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX.TimeMachine.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:49Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.MCX.TimeMachine.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX.TimeMachine.plist
@@ -138,7 +138,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>System files and folders are skipped by default.</string>
 			<key>pfm_name</key>
@@ -151,6 +151,8 @@
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Automatically backup at regulard intervals.</string>
 			<key>pfm_name</key>
@@ -161,6 +163,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Creates local backup snapshots if the backup destination is offline.</string>
 			<key>pfm_macos_min</key>
@@ -174,7 +178,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<integer>5000</integer>
+			<integer>0</integer>
 			<key>pfm_description</key>
 			<string>Enter a limit in MB for the size of the backup. Set to 0 for unlimited.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-29T23:00:51Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
@@ -113,6 +113,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the Choose Your Look window.</string>
 			<key>pfm_macos_min</key>
@@ -125,6 +127,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the Apple ID setup window.</string>
 			<key>pfm_macos_min</key>
@@ -137,6 +141,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the iCloud Storage window.</string>
 			<key>pfm_macos_min</key>
@@ -149,6 +155,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the Privacy consent window.</string>
 			<key>pfm_macos_min</key>
@@ -161,6 +169,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the Siri setup window.</string>
 			<key>pfm_macos_min</key>
@@ -173,6 +183,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the True Tone Display window.</string>
 			<key>pfm_description_reference</key>
@@ -187,6 +199,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the Screen Time window.</string>
 			<key>pfm_macos_min</key>
@@ -199,6 +213,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Skips the TouchID setup window.</string>
 			<key>pfm_macos_min</key>

--- a/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
+++ b/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T18:22:44Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
+++ b/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
@@ -156,6 +156,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_name</key>
 			<string>AutomaticCheckEnabled</string>
 			<key>pfm_title</key>
@@ -164,6 +166,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_name</key>
 			<string>AutomaticDownload</string>
 			<key>pfm_title</key>
@@ -172,6 +176,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_name</key>
 			<string>AutomaticallyInstallMacOSUpdates</string>
 			<key>pfm_macos_min</key>
@@ -182,6 +188,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_name</key>
 			<string>AutomaticallyInstallAppUpdates</string>
 			<key>pfm_macos_min</key>
@@ -192,6 +200,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_name</key>
 			<string>ConfigDataInstall</string>
 			<key>pfm_title</key>
@@ -200,6 +210,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>These are not regular security updates. An example is the OS X NTP Security Update 1.0 update.</string>
 			<key>pfm_name</key>
@@ -210,6 +222,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description_reference</key>
 			<string>Optional. If true, prerelease software can be installed on this computer. Default is true.</string>
 			<key>pfm_description</key>
@@ -234,6 +248,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>This key has the same function as the key restrict-store-require-admin-to-install in the com.apple.appstore payload.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-03-29T15:12:26Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -614,6 +614,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -668,6 +670,8 @@ The payload organization for a payload need not match the payload organization i
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If Allow AirPrint is set to 'false', it also overrides this preference.</string>
 			<key>pfm_description_reference</key>
@@ -754,6 +758,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Deprecated in iOS 11. Use forceClassroomUnpromptedScreenObservation instead.</string>
 			<key>pfm_description_reference</key>
@@ -963,7 +969,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -1035,7 +1041,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -1481,7 +1487,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -1606,6 +1612,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -1918,6 +1926,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If Allow use of Safari is set to 'false', this will override this preference.</string>
 			<key>pfm_description_reference</key>
@@ -2273,6 +2283,8 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -2305,6 +2317,8 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -2352,6 +2366,8 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -13,7 +13,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2019-09-23T23:53:00Z</date>
+		<date>2019-11-07T15:29:16Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -530,6 +530,8 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>boolean</string>
 			</dict>
 			<dict>
+				<key>pfm_default</key>
+				<true/>
 				<key>pfm_description</key>
 				<string/>
 				<key>pfm_description_reference</key>
@@ -578,6 +580,8 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>boolean</string>
 			</dict>
 			<dict>
+				<key>pfm_default</key>
+				<false/>
 				<key>pfm_description</key>
 				<string/>
 				<key>pfm_description_reference</key>
@@ -728,6 +732,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 				<string>boolean</string>
 			</dict>
 			<dict>
+				<key>pfm_default</key>
+				<false/>
 				<key>pfm_description</key>
 				<string/>
 				<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-03-29T12:00:26Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>tvOS</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -425,6 +425,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>When false, explicit music or video content purchased from the iTunes Store is hidden. Explicit content is marked as such by content providers, such as record labels, when sold through the iTunes Store. This key is deprecated on unsupervised devices.</string>
 			<key>pfm_description_reference</key>
@@ -441,6 +443,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>If set to false, the user will not be able to download media from Apple Books that has been tagged as erotica.</string>
 			<key>pfm_description_reference</key>
@@ -539,6 +543,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, delays user visibility of Software Updates.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.appstore.plist
+++ b/Manifests/ManifestsApple/com.apple.appstore.plist
@@ -133,6 +133,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Restrict app installations to admin users</string>
 			<key>pfm_description_reference</key>
@@ -147,6 +149,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Restrict app installations to software updates only</string>
 			<key>pfm_description_reference</key>
@@ -161,6 +165,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Disable App Adoption by users</string>
 			<key>pfm_description_reference</key>
@@ -175,6 +181,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Disable software update notifications</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.appstore.plist
+++ b/Manifests/ManifestsApple/com.apple.appstore.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:50Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-12-10T12:22:47Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -868,6 +868,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Set to true to turn on magnification.</string>
 			<key>pfm_description_reference</key>
@@ -880,6 +882,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Prevent user from changing the enable magnification setting.</string>
 			<key>pfm_description_reference</key>
@@ -926,6 +930,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Prevent user from changing magnification size.</string>
 			<key>pfm_description_reference</key>
@@ -962,6 +968,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Prevent user from changing position.</string>
 			<key>pfm_description_reference</key>
@@ -1007,6 +1015,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Set to true to minimize windows into application icons.</string>
 			<key>pfm_description_reference</key>
@@ -1019,12 +1029,14 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Prevent user from changing the minimize windows into application icon setting.</string>
 			<key>pfm_description_reference</key>
 			<string>Optional. If true, the minimize-to-application checkbox is disabled.</string>
 			<key>pfm_name</key>
-			<string>minimize-to-application-immutable</string>
+			<string>minintoapp-immutable</string>
 			<key>pfm_title</key>
 			<string>Minimize windows into application icon Checkbox Disable</string>
 			<key>pfm_type</key>
@@ -1059,6 +1071,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Set to true to automatically hide and show the dock.</string>
 			<key>pfm_description_reference</key>
@@ -1071,6 +1085,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Prevent user from changing the automatically hide and show the dock setting.</string>
 			<key>pfm_description_reference</key>
@@ -1143,6 +1159,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If true, use the file in /Library/Preferences/com.apple.dockfixup.plist when a new user or migrated user logs in. The format of this file currently has no documentation. This option has no effect for existing users.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.eas.account.plist
+++ b/Manifests/ManifestsApple/com.apple.eas.account.plist
@@ -425,16 +425,34 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 			<string>12.0</string>
 		</dict>
 		<dict>
-			<key>pfm_description</key>
-			<string>The PayloadUUID of the identity certificate used to decrypt messages sent to this account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The PayloadUUID of the identity certificate used to decrypt messages sent to this account. The public certificate is attached to outgoing mail to allow encrypted mail to be sent to this user. When the user sends encrypted mail, the public certificate is used to encrypt the copy of the mail in their Sent mailbox. Availability: Available only in iOS 5.0 and later.</string>
 			<key>pfm_name</key>
 			<string>SMIMEEncryptionCertificateUUID</string>
 			<key>pfm_title</key>
 			<string>S/MIME Encryption Certificate</string>
+			<key>pfm_description</key>
+			<string>The PayloadUUID of the identity certificate used to decrypt messages sent to this account.</string>
+			<key>pfm_description_reference</key>
+			<string>Optional. The PayloadUUID of the identity certificate used to decrypt messages sent to this account. The public certificate is attached to outgoing mail to allow encrypted mail to be sent to this user. When the user sends encrypted mail, the public certificate is used to encrypt the copy of the mail in their Sent mailbox. Availability: Available only in iOS 5.0 and later.</string>
 			<key>pfm_type</key>
-			<string>boolean</string>
+			<string>string</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_target</key>
+							<string>SMIMEEnabled</string>
+							<key>pfm_n_range_list</key>
+							<array>
+								<true/>
+							</array>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 		</dict>

--- a/Manifests/ManifestsApple/com.apple.eas.account.plist
+++ b/Manifests/ManifestsApple/com.apple.eas.account.plist
@@ -302,6 +302,8 @@ Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, messages may not be moved out of this email account into another account. Also prevents forwarding or replying from a different account than the message was originated from.</string>
 			<key>pfm_description_reference</key>
@@ -318,6 +320,8 @@ Availability: Available in iOS 5.0 and later.</string>
 			<string>5.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, this account will not be available for sending mail in any app other than the Apple Mail app.</string>
 			<key>pfm_description_reference</key>
@@ -348,6 +352,8 @@ Availability: Available in iOS 5.0 and later.</string>
 			<string>5.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If true, this account supports S/MIME.</string>
 			<key>pfm_description_reference</key>
@@ -368,6 +374,8 @@ Availability: Available only in iOS 5.0 through 9.3.3.</string>
 			<string>9.3.3</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, S/MIME signing is enabled for this account.</string>
 			<key>pfm_description_reference</key>
@@ -398,6 +406,8 @@ Availability: Available only in iOS 5.0 and later.</string>
 			<string>5.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, S/MIME encryption is on by default for this account. As of iOS 12.0, this key is deprecated. It is recommended to use SMIMEEncryptByDefault instead.</string>
 			<key>pfm_description_reference</key>
@@ -429,6 +439,8 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 			<string>5.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, displays the per-message encryption switch in the Mail Compose UI. As of iOS 12.0, this key is deprecated. It is recommended to use SMIMEEnableEncryptionPerMessageSwitch instead.</string>
 			<key>pfm_description_reference</key>
@@ -445,6 +457,8 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 			<string>12.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, the user can toggle S/MIME signing on or off in Settings.</string>
 			<key>pfm_description_reference</key>
@@ -459,6 +473,8 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 			<string>12.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, the user can select the signing identity.</string>
 			<key>pfm_description_reference</key>
@@ -474,6 +490,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<string>12.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, S/MIME encryption is enabled by default.</string>
 			<key>pfm_description_reference</key>
@@ -488,6 +506,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<string>12.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, the user can toggle the encryption by default setting.</string>
 			<key>pfm_description_reference</key>
@@ -502,6 +522,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<string>12.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, the user can select the S/MIME encryption identity and encryption is enabled.</string>
 			<key>pfm_description_reference</key>
@@ -517,6 +539,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<string>12.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set to true, displays the per-message encryption switch in the Mail Compose UI.</string>
 			<key>pfm_description_reference</key>
@@ -531,6 +555,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<string>12.0</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If true, this account is excluded from address Recents syncing.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.eas.account.plist
+++ b/Manifests/ManifestsApple/com.apple.eas.account.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:32Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.education.plist
+++ b/Manifests/ManifestsApple/com.apple.education.plist
@@ -17,7 +17,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-04-10T10:42:49Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_ios_min</key>

--- a/Manifests/ManifestsApple/com.apple.education.plist
+++ b/Manifests/ManifestsApple/com.apple.education.plist
@@ -667,6 +667,8 @@ With one-to-one member devices, this key should include only the device user and
 			<string>array</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>To allow students enrolled in managed classes to modify teacher permission for screen observation, set to 'true'.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.familycontrols.contentfilter.plist
+++ b/Manifests/ManifestsApple/com.apple.familycontrols.contentfilter.plist
@@ -125,6 +125,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Set to true to use the filterWhiteList and filterBlackList lists.</string>
 			<key>pfm_name</key>
@@ -197,6 +199,8 @@
 			<string>array</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Set to true to try to automatically filter content.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.familycontrols.contentfilter.plist
+++ b/Manifests/ManifestsApple/com.apple.familycontrols.contentfilter.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:50Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.gamed.plist
+++ b/Manifests/ManifestsApple/com.apple.gamed.plist
@@ -113,6 +113,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Set to false to disable Game Center.</string>
 			<key>pfm_name</key>
@@ -123,6 +125,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Set to false to disable account modifications.</string>
 			<key>pfm_name</key>
@@ -133,6 +137,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Set to false to disable adding Game Center friends.</string>
 			<key>pfm_name</key>
@@ -143,6 +149,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Set to false to disable multiplayer gaming.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.gamed.plist
+++ b/Manifests/ManifestsApple/com.apple.gamed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:50Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.ironwood.support.plist
+++ b/Manifests/ManifestsApple/com.apple.ironwood.support.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.ironwood.support.plist
+++ b/Manifests/ManifestsApple/com.apple.ironwood.support.plist
@@ -113,6 +113,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Set to false to disable dictation.</string>
 			<key>pfm_name</key>
@@ -123,6 +125,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Set to false to suppress profanity.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -251,6 +251,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -281,6 +283,8 @@ The payload organization for a payload need not match the payload organization i
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -311,6 +315,8 @@ The payload organization for a payload need not match the payload organization i
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -339,6 +345,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -369,6 +377,8 @@ The payload organization for a payload need not match the payload organization i
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -397,6 +407,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -411,6 +423,8 @@ The payload organization for a payload need not match the payload organization i
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -425,6 +439,8 @@ The payload organization for a payload need not match the payload organization i
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -439,6 +455,8 @@ The payload organization for a payload need not match the payload organization i
 			<true/>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -451,6 +469,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -463,6 +483,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -475,6 +497,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -490,6 +514,8 @@ Availability: Available in macOS 10.13 and later.</string>
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -759,6 +785,8 @@ Availability: Available in macOS 10.13 and later.</string>
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -14,7 +14,7 @@ window payloads may be installed together.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-04-23T21:02:29Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.mail.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.mail.managed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:32Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.mail.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.mail.managed.plist
@@ -272,6 +272,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Send outgoing mail from this account only from Mail app</string>
 			<key>pfm_ios_min</key>

--- a/Manifests/ManifestsApple/com.apple.screensaver.plist
+++ b/Manifests/ManifestsApple/com.apple.screensaver.plist
@@ -135,6 +135,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.screensaver.plist
+++ b/Manifests/ManifestsApple/com.apple.screensaver.plist
@@ -15,7 +15,7 @@ password function.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.11</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.firewall.plist
+++ b/Manifests/ManifestsApple/com.apple.security.firewall.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-23T17:14:15Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.firewall.plist
+++ b/Manifests/ManifestsApple/com.apple.security.firewall.plist
@@ -127,6 +127,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Blocks all incoming connections except those required for basic Internet services, such as DHCP, Bonjour and IPSec.</string>
 			<key>pfm_name</key>
@@ -137,6 +139,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Don't respond to or acknowledge attempts to access this computer from the network by test applications using ICMP, such as Ping.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.security.scep.plist
+++ b/Manifests/ManifestsApple/com.apple.security.scep.plist
@@ -966,6 +966,8 @@
 					<string>integer</string>
 				</dict>
 				<dict>
+					<key>pfm_default</key>
+					<false/>
 					<key>pfm_description</key>
 					<string>Allow all apps to access the certificate in the keychain</string>
 					<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.security.scep.plist
+++ b/Manifests/ManifestsApple/com.apple.security.scep.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-11T01:10:32Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.systempolicy.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.systempolicy.managed.plist
@@ -14,7 +14,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
         <key>pfm_version</key>
         <integer>1</integer>
 		<key>pfm_last_modified</key>
-		<date>2018-08-30T17:54:12Z</date>
+        <date>2019-11-07T15:29:16Z</date>
         <key>pfm_domain</key>
         <string>com.apple.systempolicy.managed</string>
         <key>pfm_macos_min</key>

--- a/Manifests/ManifestsApple/com.apple.systempolicy.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.systempolicy.managed.plist
@@ -145,6 +145,8 @@ This payload allows control to disable the Finderʼs contextual menu that allows
                 <string>string</string>
             </dict>
             <dict>
+                <key>pfm_default</key>
+                <false/>
                 <key>pfm_name</key>
                 <string>DisableOverride</string>
                 <key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.universalaccess.plist
+++ b/Manifests/ManifestsApple/com.apple.universalaccess.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T09:37:17Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.universalaccess.plist
+++ b/Manifests/ManifestsApple/com.apple.universalaccess.plist
@@ -113,6 +113,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -123,6 +125,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -165,6 +169,8 @@
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -176,7 +182,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -187,6 +193,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Invert colors</string>
 			<key>pfm_name</key>
@@ -197,6 +205,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Use Grayscale</string>
 			<key>pfm_name</key>
@@ -247,6 +257,8 @@
 			<string>real</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Mouse Cursor Size. 1 is normal, 4 is maximum.</string>
 			<key>pfm_name</key>
@@ -261,6 +273,8 @@
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>VoiceOver provides spoken and brailled descriptions of items on the computer screen and provides control of the computer through the user of the keyboard.</string>
 			<key>pfm_name</key>
@@ -271,6 +285,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Flash the screen when an alert sound occurs</string>
 			<key>pfm_name</key>
@@ -281,6 +297,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -291,6 +309,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Sticky keys allows modifier keys to be set without having to hold the key down.</string>
 			<key>pfm_name</key>
@@ -302,7 +322,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -323,6 +343,8 @@
 			<string>Beep when a modifier key is set</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Slow keys adjusts the amount of time between when a key is pressed and when it is activated</string>
 			<key>pfm_name</key>
@@ -334,7 +356,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -359,6 +381,8 @@
 			<string>milliseconds</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Mouse Keys allows the mouse pointer to be controlled using the keyboard number pad.</string>
 			<key>pfm_name</key>
@@ -425,6 +449,8 @@
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T09:37:17Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -537,7 +537,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>None</string>
+			<string>Any</string>
 			<key>pfm_description</key>
 			<string>Wireless network encryption to use when connecting. The None value is available in iOS 5.0 and later and the WPA2 value is available in iOS 8.0 and later.</string>
 			<key>pfm_ios_min</key>
@@ -1179,6 +1179,8 @@
 					<string>array</string>
 				</dict>
 				<dict>
+					<key>pfm_default</key>
+					<true/>
 					<key>pfm_description</key>
 					<string>Allows a dynamic trust decision by the user.</string>
 					<key>pfm_ios_deprecated</key>
@@ -1646,6 +1648,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>If set, force a non-default authentication method. (if YES, uses certificate from PayloadCertificateUUID).</string>
 			<key>pfm_ios_min</key>

--- a/Manifests/ManifestsApple/loginwindow.plist
+++ b/Manifests/ManifestsApple/loginwindow.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:52Z</date>
+	<date>2019-11-07T15:29:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/loginwindow.plist
+++ b/Manifests/ManifestsApple/loginwindow.plist
@@ -113,6 +113,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Prevent users from disabling login items launching using the Shift key.</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
This PR adds missing default values to (mostly-) boolean keys in Apple domains

It also contains a few corrections to preexisting default values which by chance were found to be wrong, but this is not an exhaustive verification of all of them.