### PR TITLE
DigiDNA Universal Access improvements

### DIFF
--- a/Manifests/ManifestsApple/com.apple.universalaccess.plist
+++ b/Manifests/ManifestsApple/com.apple.universalaccess.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T09:37:17Z</date>
+	<date>2019-11-11T19:15:04Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.universalaccess.plist
+++ b/Manifests/ManifestsApple/com.apple.universalaccess.plist
@@ -6,6 +6,8 @@
 	<string>Accessibility Settings</string>
 	<key>pfm_domain</key>
 	<string>com.apple.universalaccess</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/accessibility</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_interaction</key>
@@ -16,6 +18,8 @@
 	<array>
 		<string>macOS</string>
 	</array>
+	<key>pfm_macos_min</key>
+	<string>10.9</string>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -92,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of the whole configuration profile</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -113,8 +117,10 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Use scroll gesture with modifier keys to zoom" in the zoom options</string>
 			<key>pfm_name</key>
 			<string>closeViewScrollWheelToggle</string>
 			<key>pfm_title</key>
@@ -123,8 +129,10 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Use keyboard shortcuts to zoom" in the zoom options</string>
 			<key>pfm_name</key>
 			<string>closeViewHotkeysEnabled</string>
 			<key>pfm_title</key>
@@ -133,10 +141,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<integer>20</integer>
 			<key>pfm_description</key>
-			<string></string>
+			<string>The maximal zoom magnification that can be set in the Zoom options in an integer value between 1 and 40</string>
 			<key>pfm_name</key>
 			<string>closeViewNearPoint</string>
 			<key>pfm_range_max</key>
@@ -149,10 +155,8 @@
 			<string>integer</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<integer>2</integer>
 			<key>pfm_description</key>
-			<string></string>
+			<string>The minimal zoom magnification that can be set in the Zoom options in an integer value between 1 and 40</string>
 			<key>pfm_name</key>
 			<string>closeViewFarPoint</string>
 			<key>pfm_range_max</key>
@@ -165,8 +169,10 @@
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Show preview rectangle" in the Zoom options</string>
 			<key>pfm_name</key>
 			<string>closeViewShowPreview</string>
 			<key>pfm_title</key>
@@ -176,9 +182,9 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Smooth images" in the Zoom options</string>
 			<key>pfm_name</key>
 			<string>closeViewSmoothImages</string>
 			<key>pfm_title</key>
@@ -187,8 +193,10 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string>Invert colors</string>
+			<string>Turns on "Invert colors" in Display options</string>
 			<key>pfm_name</key>
 			<string>whiteOnBlack</string>
 			<key>pfm_title</key>
@@ -197,8 +205,10 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string>Use Grayscale</string>
+			<string>Turns on "Use grayscale" in the Display options</string>
 			<key>pfm_name</key>
 			<string>grayscale</string>
 			<key>pfm_title</key>
@@ -208,61 +218,39 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<real>0.0</real>
+			<real>0</real>
 			<key>pfm_description</key>
-			<string>Contrasting</string>
+			<string>The amount of display contrast enhancement in a decimal value between 0 and 1, where 0 is none and 1 is the maximum</string>
 			<key>pfm_name</key>
 			<string>contrast</string>
-			<key>pfm_range_list</key>
-			<array>
-				<real>0.0</real>
-				<real>0.10000000000000001</real>
-				<real>0.20000000000000001</real>
-				<real>0.29999999999999999</real>
-				<real>0.40000000000000002</real>
-				<real>0.5</real>
-				<real>0.59999999999999998</real>
-				<real>0.69999999999999996</real>
-				<real>0.80000000000000004</real>
-				<real>0.90000000000000002</real>
-				<real>1</real>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Default</string>
-				<string>1</string>
-				<string>2</string>
-				<string>3</string>
-				<string>4</string>
-				<string>5</string>
-				<string>6</string>
-				<string>7</string>
-				<string>8</string>
-				<string>9</string>
-				<string>10</string>
-			</array>
+			<key>pfm_range_min</key>
+			<real>0</real>
+			<key>pfm_range_max</key>
+			<real>1</real>
 			<key>pfm_title</key>
-			<string>Enhance Contrast</string>
+			<string>Display Contrast</string>
 			<key>pfm_type</key>
 			<string>real</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Mouse Cursor Size. 1 is normal, 4 is maximum.</string>
+			<string>The size of the mouse cursor in a decimal value between 1 and 4, where 1 is normal and 4 is the maximum</string>
 			<key>pfm_name</key>
 			<string>mouseDriverCursorSize</string>
 			<key>pfm_range_max</key>
-			<integer>4</integer>
+			<real>4</real>
 			<key>pfm_range_min</key>
-			<integer>1</integer>
+			<real>1</real>
 			<key>pfm_title</key>
 			<string>Cursor Size</string>
 			<key>pfm_type</key>
-			<string>integer</string>
+			<string>real</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string>VoiceOver provides spoken and brailled descriptions of items on the computer screen and provides control of the computer through the user of the keyboard.</string>
+			<string>VoiceOver provides spoken and brailled descriptions of items on the computer screen and provides control of the computer through the user of the keyboard</string>
 			<key>pfm_name</key>
 			<string>voiceOverOnOffKey</string>
 			<key>pfm_title</key>
@@ -271,8 +259,10 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string>Flash the screen when an alert sound occurs</string>
+			<string>Turns on "Flash the screen when an alert sound occurs" in the Audio options</string>
 			<key>pfm_name</key>
 			<string>flashScreen</string>
 			<key>pfm_title</key>
@@ -281,8 +271,10 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Play stereo audio as mono" in the Audio options</string>
 			<key>pfm_name</key>
 			<string>stereoAsMono</string>
 			<key>pfm_title</key>
@@ -291,8 +283,10 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string>Sticky keys allows modifier keys to be set without having to hold the key down.</string>
+			<string>Turns on "Sticky Keys" in the Keyboard options. Sticky keys allows modifier keys to be set without having to hold the key down</string>
 			<key>pfm_name</key>
 			<string>stickyKey</string>
 			<key>pfm_title</key>
@@ -302,9 +296,9 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Display pressed keys on screen" for Sticky Keys in Keyboard options</string>
 			<key>pfm_name</key>
 			<string>stickyKeyShowWindow</string>
 			<key>pfm_title</key>
@@ -314,17 +308,21 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Beep when a modifier key is set" for Sticky Keys in Keyboard options</string>
 			<key>pfm_name</key>
 			<string>stickyKeyBeepOnModifier</string>
 			<key>pfm_title</key>
 			<string>Beep when a modifier key is set</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string>Slow keys adjusts the amount of time between when a key is pressed and when it is activated</string>
+			<string>Turns on "Slow Keys" in the Keyboard options. Slow keys adjusts the amount of time between when a key is pressed and when it is activated</string>
 			<key>pfm_name</key>
 			<string>slowKey</string>
 			<key>pfm_title</key>
@@ -334,9 +332,9 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Use click key sounds" for Slow Keys in the Keyboard options</string>
 			<key>pfm_name</key>
 			<string>slowKeyBeepOn</string>
 			<key>pfm_title</key>
@@ -348,7 +346,7 @@
 			<key>pfm_default</key>
 			<integer>250</integer>
 			<key>pfm_description</key>
-			<string></string>
+			<string>The acceptance delay for Slow Keys in miliseconds</string>
 			<key>pfm_name</key>
 			<string>slowKeyDelay</string>
 			<key>pfm_title</key>
@@ -359,8 +357,10 @@
 			<string>milliseconds</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string>Mouse Keys allows the mouse pointer to be controlled using the keyboard number pad.</string>
+			<string>Turns on "Enable Mouse Keys" in the Pointer Control options. Mouse Keys allows the mouse pointer to be controlled using the keyboard number pad</string>
 			<key>pfm_name</key>
 			<string>mouseDriver</string>
 			<key>pfm_title</key>
@@ -372,61 +372,35 @@
 			<key>pfm_default</key>
 			<real>1</real>
 			<key>pfm_description</key>
-			<string></string>
+			<string>The initial delay before moving the mouse cursor with Mouse Keys in a decimal value representing seconds</string>
 			<key>pfm_name</key>
 			<string>mouseDriverInitialDelay</string>
-			<key>pfm_range_list</key>
-			<array>
-				<real>0.25</real>
-				<real>0.5</real>
-				<real>0.75</real>
-				<real>1</real>
-				<real>1.25</real>
-				<real>1.5</real>
-				<real>1.75</real>
-				<real>2</real>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>0.25 seconds</string>
-				<string>0.5 seconds</string>
-				<string>0.75 seconds</string>
-				<string>1 second</string>
-				<string>1.25 seconds</string>
-				<string>1.5 seconds</string>
-				<string>1.75 seconds</string>
-				<string>2 seconds</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Initial delay</string>
 			<key>pfm_type</key>
 			<string>real</string>
+			<key>pfm_value_unit</key>
+			<string>seconds</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string></string>
+			<string>The maximum speed for the cursor when using Mouse Keys in an integer value between 1 and 32, where 1 is the slowest and 32 is the fastest</string>
 			<key>pfm_name</key>
 			<string>mouseDriverMaxSpeed</string>
-			<key>pfm_range_list</key>
-			<array>
-				<integer>3</integer>
-				<integer>11</integer>
-				<integer>24</integer>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Slow</string>
-				<string>Medium</string>
-				<string>Fast</string>
-			</array>
+			<key>pfm_range_max</key>
+			<integer>32</integer>
+			<key>pfm_range_min</key>
+			<integer>1</integer>
 			<key>pfm_title</key>
 			<string>Maximum speed</string>
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>Turns on "Ignore built-in trackpad when mouse or wireless trackpad is present" in the Mouse &amp; Trackpad options</string>
 			<key>pfm_name</key>
 			<string>mouseDriverIgnoreTrackpad</string>
 			<key>pfm_title</key>


### PR DESCRIPTION
Domain com.apple.universalaccess brought closer in line with the documentation.

The properties _contrast_, _mouseDriverCursorSize_, and _mouseDriverInitialDelay_ were left with type 'real' as the documentation contradicts practice.