### PR TITLE
Fix Passcode payload (#190)

### DIFF
--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2019-12-06T20:38:51Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -105,7 +105,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -117,11 +117,13 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enforce the use of a passcode before using the device</string>
+			<string>Enforce the use of a passcode before using the device.</string>
+			<key>pfm_description_reference</key>
+			<string>If true, forces the user to enter a PIN.</string>
 			<key>pfm_name</key>
 			<string>forcePIN</string>
 			<key>pfm_title</key>
-			<string>Require Passcode on Device</string>
+			<string>Require passcode on device</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -129,11 +131,15 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Permits users to use sequential or repeated characters in their passcodes. For example, “3333” or “DEFG.”.</string>
+			<string>Permits the use of repeating, ascending, and descending character sequences in passcodes. For example, "3333" or "DEFG".</string>
+			<key>pfm_description_reference</key>
+			<string>If true, allows a simple passcode. A simple passcode contains repeated characters, or increasing or decreasing characters (such as 123 or CBA). Setting this value to false has the same result as setting minComplexChars to 1.</string>
 			<key>pfm_name</key>
 			<string>allowSimple</string>
+			<key>pfm_note</key>
+			<string>Setting this value to false has the same result as setting minComplexChars to 1.</string>
 			<key>pfm_title</key>
-			<string>Allow simple value</string>
+			<string>Allow simple passcode</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -141,7 +147,9 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Requires that the passcode contain at least one letter or number.</string>
+			<string>Requires that the passcode contain at least one letter and one number.</string>
+			<key>pfm_documentation_reference</key>
+			<string>If true, requires alphabetic characters (abcd) instead of only numeric characters.</string>
 			<key>pfm_name</key>
 			<string>requireAlphanumeric</string>
 			<key>pfm_title</key>
@@ -154,6 +162,8 @@
 			<integer>0</integer>
 			<key>pfm_description</key>
 			<string>Minimum number of characters a passcode can contain.</string>
+			<key>pfm_description_reference</key>
+			<string>The minimum overall length of the passcode. This parameter is independent of the also optional minComplexChars argument.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -185,7 +195,9 @@
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Minimum number of non-alphanumeric characters (such as $ and !) the passcode must contain.</string>
+			<string>Minimum number of non-alphanumeric characters the passcode must contain.</string>
+			<key>pfm_description_reference</key>
+			<string>The minimum number of complex characters that a passcode must contain. A complex character is a character other than a number or a letter, such as &amp; % $ #.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -215,7 +227,9 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Requires users to change their passcode at the interval you specify. It can be set to “none,” or from 1 to 730 days.</string>
+			<string>Requires users to change their passcode at the specified interval. It can be set to "none," or from 1 to 730 days.</string>
+			<key>pfm_description_reference</key>
+			<string>The number of days for which the passcode can remain unchanged. After this number of days, the user is forced to change the passcode before the device is unlocked.</string>
 			<key>pfm_name</key>
 			<string>maxPINAgeInDays</string>
 			<key>pfm_range_max</key>
@@ -227,11 +241,13 @@
 			<key>pfm_type</key>
 			<string>integer</string>
 			<key>pfm_value_unit</key>
-			<string>Days</string>
+			<string>days</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If the device isn’t used for the period of time you specify, it automatically locks. It can be set to “none,” or set to lock after 1 to 5 minutes.</string>
+			<string>If the device isn’t used for the period of time you specify, it automatically locks. It can be set to "none," or set to lock after 1 to 15 minutes. In macOS, this inactivity value is translated to screen-saver settings.</string>
+			<key>pfm_description_reference</key>
+			<string>The maximum number of minutes for which the device can be idle, without being unlocked by the user, before it gets locked by the system. When this limit is reached, the device is locked and the passcode must be entered. The user can edit this setting, but the value cannot exceed the maxInactivity value. In macOS, this inactivity value is translated to screen-saver settings.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -261,7 +277,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The device refuses a new passcode if it matches a previously used passcode. You can specify how many previous passcodes are remembered and compared. It can be set to “none,” or from 1 to 50 passcodes.</string>
+			<string>The device refuses a new passcode if it matches a previously used passcode. You can specify how many previous passcodes are remembered and compared. It can be set to "none," or from 1 to 50 passcodes.</string>
 			<key>pfm_name</key>
 			<string>pinHistory</string>
 			<key>pfm_range_max</key>
@@ -272,12 +288,16 @@
 			<string>Passcode history</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>passcodes</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>How soon the device can be unlocked again after use, without reprompting again for the passcode. (0 = no grace period, which requires a passcode immediately).</string>
+			<string>How soon the device can be unlocked again after use, without reprompting again for the passcode. (0 = no grace period, which requires a passcode immediately). In macOS, this grace period value is translated to screen-saver settings.</string>
+			<key>pfm_description_reference</key>
+			<string>The maximum grace period, in minutes, to unlock the phone without entering a passcode. The default is 0, which is no grace period and requires a passcode immediately. In macOS, this grace period value is translated to screen-saver settings.</string>
 			<key>pfm_name</key>
 			<string>maxGracePeriod</string>
 			<key>pfm_title</key>
@@ -285,29 +305,29 @@
 			<key>pfm_type</key>
 			<string>integer</string>
 			<key>pfm_value_unit</key>
-			<string>Minutes</string>
+			<string>minutes</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<integer>0</integer>
-			<key>pfm_description</key>
-			<string>The number of failed passcode attempts that can be made before an iOS device is erased or a macOS device is locked.</string>
-			<key>pfm_exclude</key>
+			<key>pfm_conditionals</key>
 			<array>
 				<dict>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
-							<key>pfm_range_list</key>
-							<array>
-								<integer>0</integer>
-							</array>
+							<key>pfm_present</key>
+							<true/>
 							<key>pfm_target</key>
-							<string>maxFailedAttempts</string>
+							<string>minutesUntilFailedLoginReset</string>
 						</dict>
 					</array>
 				</dict>
 			</array>
+			<key>pfm_default</key>
+			<integer>11</integer>
+			<key>pfm_description</key>
+			<string>The number of failed passcode attempts that can be made before an iOS device is erased or a macOS device is locked.</string>
+			<key>pfm_description_reference</key>
+			<string>The number of allowed failed attempts to enter the passcode at the device's lock screen. After six failed attempts, a time delay is imposed before a passcode can be entered again. The delay increases with each attempt. In macOS, set minutesUntilFailedLoginReset to define a delay before the next passcode can be entered. When this number is exceeded in macOS, the device is locked; in iOS, the device is wiped.</string>
 			<key>pfm_name</key>
 			<string>maxFailedAttempts</string>
 			<key>pfm_range_max</key>
@@ -320,20 +340,44 @@
 			<string>integer</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
-			<string>The number of minutes before the login window reappears, after the maximum number of failed attempts is reached.</string>
+			<string>The number of minutes before the login window reappears, after the maximum number of failed attempts is reached. This key requires setting maxFailedAttempts.</string>
+			<key>pfm_description_reference</key>
+			<string>The number of minutes before the login is reset after the maximum number of unsuccessful login attempts is reached. This key requires setting maxFailedAttempts. Available in macOS 10.10 and later.</string>
 			<key>pfm_macos_min</key>
-			<string>10.13.0</string>
+			<string>10.10.0</string>
 			<key>pfm_name</key>
-			<string>changeAtNextAuth</string>
+			<string>minutesUntilFailedLoginReset</string>
 			<key>pfm_platforms</key>
 			<array>
 				<string>macOS</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Delay after failed login attempts</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>minutes</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Causes a password reset to occur the next time the user tries to authenticate.</string>
+			<key>pfm_description_reference</key>
+			<string>If true, causes a password reset to occur the next time the user tries to authenticate. If this key is set in a device profile, the setting takes effect for all users, and admin authentications may fail until the admin user password is also reset. Available in macOS 10.13 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>10.13.0</string>
+			<key>pfm_name</key>
+			<string>changeAtNextAuth</string>
+			<key>pfm_note</key>
+			<string>If this key is set in a device profile, the setting takes effect for all users, and admin authentications may fail until the admin user password is also reset.</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Reset passcode at next login</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>


### PR DESCRIPTION
- Address #190 by fixing minutesUntilFailedLoginReset, which was not present, but the wording for which had been assigned to changeAtNextAuth.
- Add pfm_description_reference to include descriptions from documentation
- Update some descriptions to be clearer
- Add appropriate pfm_notes
- Remove smart quotes
- Add additional pfm_value_units
- Add pfm_conditionals for maxFailedAttempts given documentation states using minutesUntilFailedLoginReset requires this preference