### PR TITLE
Update com.apple.DirectoryService.managed.plist

### DIFF
--- a/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
@@ -18,7 +18,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:15Z</date>
+	<date>2019-12-10T13:51:15Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -232,6 +232,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADCreateMobileAccountAtLoginFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
@@ -292,6 +308,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADWarnUserBeforeCreatingMAFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
@@ -352,6 +384,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADForceHomeLocalFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
@@ -412,6 +460,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADUseWindowsUNCPathFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
@@ -455,6 +519,11 @@ The payload organization for a payload need not match the payload organization i
 				<string>afp</string>
 				<string>smb</string>
 			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>AFP</string>
+				<string>SMB</string>
+			</array>
 			<key>pfm_title</key>
 			<string>Mount Style</string>
 			<key>pfm_type</key>
@@ -491,6 +560,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADDefaultUserShellFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<string>/bin/bash</string>
 			<key>pfm_description</key>
@@ -551,6 +636,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADMapUIDAttributeFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_description</key>
 			<string>Map UID to attribute.</string>
 			<key>pfm_description_reference</key>
@@ -609,6 +710,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADMapGIDAttributeFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_description</key>
 			<string>Map user GID to attribute.</string>
 			<key>pfm_description_reference</key>
@@ -667,6 +784,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADMapGGIDAttributeFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_description</key>
 			<string>Map group GID to attribute.</string>
 			<key>pfm_description_reference</key>
@@ -725,6 +858,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADPreferredDCServerFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_description</key>
 			<string>Preferred domain server.</string>
 			<key>pfm_description_reference</key>
@@ -783,6 +932,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADDomainAdminGroupListFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_description</key>
 			<string>Allow administration by specified Active Directory groups.</string>
 			<key>pfm_description_reference</key>
@@ -856,6 +1021,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADAllowMultiDomainAuthFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
@@ -916,6 +1097,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADNamespaceFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<string>domain</string>
 			<key>pfm_description</key>
@@ -981,6 +1178,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADPacketSignFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<string>allow</string>
 			<key>pfm_description</key>
@@ -1047,6 +1260,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADPacketEncryptFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<string>allow</string>
 			<key>pfm_description</key>
@@ -1114,6 +1343,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADRestrictDDNSFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_description</key>
 			<string>Restrict Dynamic DNS updates to the specified interfaces (e.g. en0, en1, etc).</string>
 			<key>pfm_description_reference</key>
@@ -1187,6 +1432,22 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+							<string>ADTrustChangePassIntervalDaysFlag</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<integer>14</integer>
 			<key>pfm_description</key>
@@ -1215,6 +1476,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>Password trust interval</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>days</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>


### PR DESCRIPTION
- Add pfm_conditionals for user experience purposes.  Now when one of the flag preferences is added and enabled it automatically adds the corresponding preference.  Up till now the behavior has been based on the non-flag key being added first.
- Add pfm_value_unit for ADTrustChangePassIntervalDays