### PR TITLE
DigiDNA Dec 2019 Contributions

### DIFF
--- a/Manifests/ManifestsApple/Configuration.plist
+++ b/Manifests/ManifestsApple/Configuration.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T09:37:17Z</date>
+	<date>2019-12-27T17:26:39Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/Configuration.plist
+++ b/Manifests/ManifestsApple/Configuration.plist
@@ -247,6 +247,8 @@ Currently, this value should be 1.</string>
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Specifes if there is a removal passcode for the profile.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.font.plist
+++ b/Manifests/ManifestsApple/com.apple.font.plist
@@ -44,11 +44,6 @@
 			<string>Payload Display Name</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_allowed_file_types</key>
-			<array>
-				<string>otf</string>
-				<string>ttf</string>
-			</array>
 		</dict>
 		<dict>
 			<key>pfm_default</key>

--- a/Manifests/ManifestsApple/com.apple.font.plist
+++ b/Manifests/ManifestsApple/com.apple.font.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:32Z</date>
+	<date>2019-12-27T17:26:39Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.webClip.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.webClip.managed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:52Z</date>
+	<date>2019-12-27T17:26:39Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.webClip.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.webClip.managed.plist
@@ -178,7 +178,7 @@ The payload organization for a payload need not match the payload organization i
 		<dict>
 			<key>pfm_allowed_file_types</key>
 			<array>
-				<string>public.image</string>
+				<string>public.png</string>
 			</array>
 			<key>pfm_description</key>
 			<string>The icon to use for the Web Clip</string>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -128,7 +128,7 @@
 			<key>pfm_excluded</key>
 			<true/>
 			<key>pfm_name</key>
-			<string>Interface</string>
+			<string>PFC_InterfaceSelector</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>BuiltInWireless</string>
@@ -163,7 +163,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -184,7 +184,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -215,13 +215,26 @@
 								<string>Hotspot</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_target</key>
+							<string>DomainName</string>
+							<key>pfm_present</key>
+							<false/>
 						</dict>
 					</array>
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Enter the SSID of the wireless network to connect to.</string>
+			<string>Displayed name of the wireless network</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -233,7 +246,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -241,7 +254,7 @@
 			<key>pfm_name</key>
 			<string>SSID_STR</string>
 			<key>pfm_title</key>
-			<string>SSID</string>
+			<string>Service Set Identifier (SSID)</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
@@ -483,7 +496,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>URL used to receive proxy settings. If no URL is specified, the device uses the web proxy autodiscovery protocol (WPAD) to discover proxies.</string>
+			<string>URL used to receive proxy settings. If no URL is specified, the device uses the web proxy autodiscovery protocol (WPAD) to discover proxies</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -511,7 +524,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enable to allow direct connection if PAC is unreachable.</string>
+			<string>Enable to allow direct connection if PAC is unreachable</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -539,7 +552,7 @@
 			<key>pfm_default</key>
 			<string>Any</string>
 			<key>pfm_description</key>
-			<string>Wireless network encryption to use when connecting. The None value is available in iOS 5.0 and later and the WPA2 value is available in iOS 8.0 and later.</string>
+			<string>Wireless network encryption to use when connecting. The None value is available in iOS 5.0 and later and the WPA2 value is available in iOS 8.0 and later</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_platforms</key>
@@ -612,7 +625,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -638,7 +651,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -673,7 +686,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -699,7 +712,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -750,7 +763,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -799,7 +812,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -859,7 +872,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -917,7 +930,7 @@
 								<string>Hotspot2</string>
 							</array>
 							<key>pfm_target</key>
-							<string>Interface</string>
+							<string>PFC_InterfaceSelector</string>
 						</dict>
 					</array>
 				</dict>
@@ -1660,6 +1673,36 @@
 			<string>Certificate Required</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>Interface</string>
+			<key>pfm_title</key>
+			<string>Interface</string>
+			<key>pfm_description</key>
+			<string>The wireless interface to use</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>AnyEthernet</string>
+				<string>FirstEthernet</string>
+				<string>FirstActiveEthernet</string>
+				<string>SecondEthernet</string>
+				<string>SecondActiveEthernet</string>
+				<string>ThirdEthernet</string>
+				<string>ThirdActiveEthernet</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Any Ethernet</string>
+				<string>First Ethernet</string>
+				<string>First Active Ethernet</string>
+				<string>Second Ethernet</string>
+				<string>Second Active Ethernet</string>
+				<string>Third Ethernet</string>
+				<string>Third Active Ethernet</string>
+			</array>
 		</dict>
 	</array>
 	<key>pfm_targets</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2019-12-27T17:26:39Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -1715,6 +1715,6 @@
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Various tweaks:

- Removed the file-type key from a property it doesn't belong to on the _Fonts_ domain. Note that it is still present on the correct property.
- Added a default value to a top-level property.
- Narrowed allowed file type according to the docs on the _WebClips_ domain.
- On the _WiFi_ domain: new keys added, Interface pseudo-key `Interface` was migrated to `PFC_InterfaceSelector` since Apple introduced a native one by the same name, conditional added to `SSID_STR`, and texts were tweaked.