### PR TITLE
Overhaul of touristd

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-10-03T17:25:03Z</date>
+	<date>2020-01-07T09:25:03Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -18,7 +18,7 @@
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>"New to Mac" notification settings</string>
+			<string>"New to Mac" tour notification settings</string>
 			<key>pfm_description</key>
 			<string>Description of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -126,73 +126,91 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>PFC_SegmentedControl_0</string>
 			<key>pfm_range_list_titles</key>
 			<array>
+				<string>iMac</string>
+				<string>iMac Pro</string>
+				<string>MacBook</string>
+				<string>MacBook Air</string>
+				<string>MacBook Pro</string>
+				<string>Mac Pro</string>
+				<string>Mac mini</string>
 				<string>macOS</string>
-				<string>Mac</string>
-				<string>Seeds</string>
 			</array>
 			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
-				<key>macOS</key>
-				<array>
-					<string>seed-https://help.apple.com/osx/mac/10.12/new-to-mac</string>
-					<string>seed-https://help.apple.com/macOS/high-sierra/mac-basics</string>
-					<string>seed-https://help.apple.com/macOS/mojave/mac-basics</string>
-					<string>seed-https://help.apple.com/osx/mac/10.12/whats-new</string>
-					<string>seed-https://help.apple.com/macOS/high-sierra/whats-new</string>
-					<string>seed-https://help.apple.com/macOS/mojave/whats-new</string>
-				</array>
-				<key>Mac</key>
-				<array>
-					<string>seed-https://help.apple.com/osx/mac/10.12/imac-21a</string>
-					<string>seed-https://help.apple.com/osx/mac/10.12/imac-21b</string>
-					<string>seed-https://help.apple.com/osx/mac/10.12/imac-21r</string>
-					<string>seed-https://help.apple.com/osx/mac/10.12/imac-27</string>
-					<string>seed-https://help.apple.com/osx/mac/10.12/macbook</string>
-					<string>seed-https://help.apple.com/osx/mac/10.12/macbook-pro-13</string>
-					<string>seed-https://help.apple.com/osx/mac/10.12/macbook-pro-15</string>
-					<string>seed-https://help.apple.com/macOS/mojave/mac-mini</string>
-					<string>seed-https://help.apple.com/macOS/mojave/imac</string>
-				</array>
-				<key>Seeds</key>
+				<key>iMac</key>
 				<array>
 					<string>seed-viewed-+trJt2VsTvK1yfPGwOySDw</string>
-					<string>seed-viewed-/+vP78HsSh+Yeb4xJnUT9A</string>
-					<string>seed-viewed-2+LvxAVyT6qnV1sDMZT0NA</string>
-					<string>seed-viewed-40reAuuYTHOsx4oGcx4qrA</string>
-					<string>seed-viewed-APhNaYV1RxSS41lC7ZJJ9Q</string>
-					<string>seed-viewed-B70mVuHeT0WUgKh/VdUuZQ</string>
-					<string>seed-viewed-ETJeJ9/1QmmWUde7uK8fDg</string>
-					<string>seed-viewed-EWfaSdJwR/6f1BYGiyLpcQ</string>
 					<string>seed-viewed-EeEFv8cyS0CVe3ia2UEehA</string>
-					<string>seed-viewed-FQrkbNP9ThKQQtpqx2saFg</string>
-					<string>seed-viewed-GZAJdmpdSqmfH2PkCr8ebw</string>
-					<string>seed-viewed-JTecrrXDSVut2tSfltty9Q</string>
 					<string>seed-viewed-KwUoo0fRRM2VPmIm0V67xg</string>
-					<string>seed-viewed-LR2P9+rnQ2q9xSUy1ZgWOw</string>
-					<string>seed-viewed-MM3ne3nTR9eXFyVwZ5gN7Q</string>
-					<string>seed-viewed-Pa88nesPSO6POlutVN4/Sg</string>
-					<string>seed-viewed-SdV08ZZQRxOCWq6JBEXmfg</string>
-					<string>seed-viewed-Tu81gKhDTvmNkjyqcPBfKA</string>
 					<string>seed-viewed-UhiR1M79RWmXLIQr4M0AWw</string>
 					<string>seed-viewed-WEyaCPMVRB6HbnmRq9EnNQ</string>
-					<string>seed-viewed-We59wh+OTa6c1yas/yppwg</string>
 					<string>seed-viewed-aytyxqEmTIOvEz3iS4IbkA</string>
-					<string>seed-viewed-b/dLke8ZTQaN9KKrxfwDQw</string>
-					<string>seed-viewed-baXokbqsQ/2KLkzIZrR6ng</string>
-					<string>seed-viewed-bydF6fX5Sp6aBYdEXD0VwQ</string>
+					<string>seed-viewed-catalina_imac</string>
+					<string>seed-viewed-catalina_imac-21a</string>
 					<string>seed-viewed-d+gfl8CNTNeauANKjf9WqA</string>
-					<string>seed-viewed-f/Pn3F4RScOh+GUBKO9sRA</string>
-					<string>seed-viewed-fWRpNw7IR3S3qxX63nmvMw</string>
+					<string>seed-viewed-pDWyREoARJm5V1mJYr9GKg</string>
+				</array>
+				<key>iMac Pro</key>
+				<array>
+					<string>seed-viewed-40reAuuYTHOsx4oGcx4qrA</string>
+					<string>seed-viewed-APhNaYV1RxSS41lC7ZJJ9Q</string>
+					<string>seed-viewed-catalina_imac-pro</string>
+				</array>
+				<key>MacBook</key>
+				<array>
+					<string>seed-viewed-FQrkbNP9ThKQQtpqx2saFg</string>
+					<string>seed-viewed-Pa88nesPSO6POlutVN4/Sg</string>
+					<string>seed-viewed-SdV08ZZQRxOCWq6JBEXmfg</string>
+					<string>seed-viewed-We59wh+OTa6c1yas/yppwg</string>
+					<string>seed-viewed-b/dLke8ZTQaN9KKrxfwDQw</string>
 					<string>seed-viewed-hP2OZh+MTEKeFcjgec2gZw</string>
+				</array>
+				<key>MacBook Air</key>
+				<array>
+					<string>seed-viewed-SkI/dLAkQu6k/qpzSOG6Iw</string>
+					<string>seed-viewed-Tu81gKhDTvmNkjyqcPBfKA</string>
+					<string>seed-viewed-catalina_macbook-air</string>
+				</array>
+				<key>MacBook Pro</key>
+				<array>
+					<string>seed-viewed-/+vP78HsSh+Yeb4xJnUT9A</string>
+					<string>seed-viewed-2+LvxAVyT6qnV1sDMZT0NA</string>
+					<string>seed-viewed-B70mVuHeT0WUgKh/VdUuZQ</string>
+					<string>seed-viewed-EBFV2ZqnQiaqrZhvyifLeQ</string>
+					<string>seed-viewed-ETJeJ9/1QmmWUde7uK8fDg</string>
+					<string>seed-viewed-EWfaSdJwR/6f1BYGiyLpcQ</string>
+					<string>seed-viewed-GZAJdmpdSqmfH2PkCr8ebw</string>
+					<string>seed-viewed-JTecrrXDSVut2tSfltty9Q</string>
+					<string>seed-viewed-MM3ne3nTR9eXFyVwZ5gN7Q</string>
+					<string>seed-viewed-catalina_late-2019_macbook-pro</string>
+					<string>seed-viewed-catalina_macbook-pro</string>
+					<string>seed-viewed-catalina_macbook-pro-13</string>
+					<string>seed-viewed-fWRpNw7IR3S3qxX63nmvMw</string>
 					<string>seed-viewed-krdWS8DSQIqJSqQFXW1/pw</string>
 					<string>seed-viewed-kti4ZkMKQFyCL2kbgCY23A</string>
 					<string>seed-viewed-lEDfW5O+SZe8KTQ93HGOPA</string>
-					<string>seed-viewed-lQlm1yrMS0GPVyAL44id+A</string>
 					<string>seed-viewed-n87FVu1TSwGzble8vqBvsg</string>
-					<string>seed-viewed-pDWyREoARJm5V1mJYr9GKg</string>
 					<string>seed-viewed-srluh6uOQiuWCzxguqhDNw</string>
+				</array>
+				<key>Mac Pro</key>
+				<array>
+					<string>seed-viewed-catalina_mac-pro</string>
+				</array>
+				<key>Mac mini</key>
+				<array>
+					<string>seed-viewed-baXokbqsQ/2KLkzIZrR6ng</string>
+					<string>seed-viewed-catalina_mac-mini</string>
+				</array>
+				<key>macOS</key>
+				<array>
+					<string>seed-viewed-LR2P9+rnQ2q9xSUy1ZgWOw</string>
+					<string>seed-viewed-bydF6fX5Sp6aBYdEXD0VwQ</string>
+					<string>seed-viewed-catalina_mac-basics</string>
+					<string>seed-viewed-catalina_whats-new</string>
+					<string>seed-viewed-f/Pn3F4RScOh+GUBKO9sRA</string>
+					<string>seed-viewed-lQlm1yrMS0GPVyAL44id+A</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
@@ -202,219 +220,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/imac-21a</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - iMac 21"a</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/imac-21b</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - iMac 21"b</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/imac-21r</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - iMac 21"r</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/imac-27</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - iMac 27"</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/macbook</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - MacBook</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/macbook-pro-13</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - MacBook Pro 13"</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/macbook-pro-15</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - MacBook Pro 15"</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/new-to-mac</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - New to Mac</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.13</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/macOS/high-sierra/mac-basics</string>
-			<key>pfm_title</key>
-			<string>macOS High Sierra - New to Mac</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.14</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/macOS/mojave/mac-basics</string>
-			<key>pfm_title</key>
-			<string>macOS Mojave - New to Mac</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.12</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/osx/mac/10.12/whats-new</string>
-			<key>pfm_title</key>
-			<string>macOS Sierra - What's New</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.13</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/macOS/high-sierra/whats-new</string>
-			<key>pfm_title</key>
-			<string>macOS High Sierra - What's New</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.14</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/macOS/mojave/whats-new</string>
-			<key>pfm_title</key>
-			<string>macOS Mojave - What's New</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.14</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/macOS/mojave/mac-mini</string>
-			<key>pfm_title</key>
-			<string>macOS Mojave - Mac Mini</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_macos_min</key>
-			<string>10.14</string>
-			<key>pfm_name</key>
-			<string>seed-https://help.apple.com/macOS/mojave/imac</string>
-			<key>pfm_title</key>
-			<string>macOS Mojave - iMac 2019</string>
-			<key>pfm_type</key>
-			<string>date</string>
-		</dict>
-		<dict>
-			<key>pfm_date_allow_past</key>
-			<true/>
-			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/imac-21a</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-+trJt2VsTvK1yfPGwOySDw</string>
+			<key>pfm_title</key>
+			<string>iMac 21a: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -422,9 +232,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/osx/mac/10.12/macbook-pro-15</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-/+vP78HsSh+Yeb4xJnUT9A</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 15: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -432,9 +244,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/osx/mac/10.12/macbook-pro-13d</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-2+LvxAVyT6qnV1sDMZT0NA</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13d: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -442,9 +256,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/imac-pro</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-40reAuuYTHOsx4oGcx4qrA</string>
+			<key>pfm_title</key>
+			<string>iMac Pro: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -452,9 +268,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/imac-pro</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-APhNaYV1RxSS41lC7ZJJ9Q</string>
+			<key>pfm_title</key>
+			<string>iMac Pro: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -462,9 +280,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/osx/mac/10.12/macbook-pro-13c</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-B70mVuHeT0WUgKh/VdUuZQ</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13c: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -472,9 +292,23 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macos/mojave/mid-2019/macbook-pro-13/</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-EBFV2ZqnQiaqrZhvyifLeQ</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13 Mid 2019: 10.14</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macOS/high-sierra/macbook-pro-13</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-ETJeJ9/1QmmWUde7uK8fDg</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -482,9 +316,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/osx/mac/10.12/macbook-pro-15d</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-EWfaSdJwR/6f1BYGiyLpcQ</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 15d: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -492,9 +328,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/imac-21a</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-EeEFv8cyS0CVe3ia2UEehA</string>
+			<key>pfm_title</key>
+			<string>iMac 21a: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -502,9 +340,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/Sierra/macbook</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-FQrkbNP9ThKQQtpqx2saFg</string>
+			<key>pfm_title</key>
+			<string>MacBook: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -512,9 +352,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/Sierra/macbook-pro-13d</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-GZAJdmpdSqmfH2PkCr8ebw</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13d: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -522,9 +364,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/Sierra/macbook-pro-13c</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-JTecrrXDSVut2tSfltty9Q</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13c: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -532,9 +376,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/imac</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-KwUoo0fRRM2VPmIm0V67xg</string>
+			<key>pfm_title</key>
+			<string>iMac: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -542,9 +388,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/mac-basics</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-LR2P9+rnQ2q9xSUy1ZgWOw</string>
+			<key>pfm_title</key>
+			<string>New to Mac: 10.13</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -552,9 +400,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/macbook-pro-15</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-MM3ne3nTR9eXFyVwZ5gN7Q</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 15: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -562,9 +412,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/osx/mac/10.12/macbook</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-Pa88nesPSO6POlutVN4/Sg</string>
+			<key>pfm_title</key>
+			<string>MacBook: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -572,9 +424,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/osx-elcapitan/get-to-know-your-mac-book</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-SdV08ZZQRxOCWq6JBEXmfg</string>
+			<key>pfm_title</key>
+			<string>MacBook: 10.11 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -582,9 +436,23 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macos/mojave/mid-2019/macbook-air</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-SkI/dLAkQu6k/qpzSOG6Iw</string>
+			<key>pfm_title</key>
+			<string>MacBook Air Mid 2019: 10.14</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/mojave/macbook-air/</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-Tu81gKhDTvmNkjyqcPBfKA</string>
+			<key>pfm_title</key>
+			<string>MacBook Air: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -592,9 +460,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/Sierra/mid-2017/imac-21r</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-UhiR1M79RWmXLIQr4M0AWw</string>
+			<key>pfm_title</key>
+			<string>iMac 21r: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -602,9 +472,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/Sierra/mid-2017/imac-21a</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-WEyaCPMVRB6HbnmRq9EnNQ</string>
+			<key>pfm_title</key>
+			<string>iMac 21a: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -612,9 +484,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/macbook</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-We59wh+OTa6c1yas/yppwg</string>
+			<key>pfm_title</key>
+			<string>MacBook: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -622,9 +496,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>iMac19,1</string>
+			<string>https://help.apple.com/macos/mojave/early-2019/imac</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-aytyxqEmTIOvEz3iS4IbkA</string>
+			<key>pfm_title</key>
+			<string>iMac Early 2019: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -632,9 +508,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/macbook</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-b/dLke8ZTQaN9KKrxfwDQw</string>
+			<key>pfm_title</key>
+			<string>MacBook: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -642,9 +520,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macos/mojave/mac-mini/</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-baXokbqsQ/2KLkzIZrR6ng</string>
+			<key>pfm_title</key>
+			<string>Mac mini: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -652,9 +532,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/mac-basics</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-bydF6fX5Sp6aBYdEXD0VwQ</string>
+			<key>pfm_title</key>
+			<string>New to Mac: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -662,9 +544,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/Sierra/mid-2017/imac-27</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-d+gfl8CNTNeauANKjf9WqA</string>
+			<key>pfm_title</key>
+			<string>iMac 27: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -672,9 +556,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/whats-new</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-f/Pn3F4RScOh+GUBKO9sRA</string>
+			<key>pfm_title</key>
+			<string>What's New: 10.13</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -682,9 +568,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/macbook-pro-13</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-fWRpNw7IR3S3qxX63nmvMw</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -692,9 +580,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macos/mojave/late-2018/macbook/</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-hP2OZh+MTEKeFcjgec2gZw</string>
+			<key>pfm_title</key>
+			<string>MacBook Late 2018: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -702,9 +592,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/mid-2018/macbook-pro</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-krdWS8DSQIqJSqQFXW1/pw</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro Mid 2018: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -712,9 +604,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/Sierra/macbook-pro-15d</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-kti4ZkMKQFyCL2kbgCY23A</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 15d: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -722,9 +616,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/high-sierra/macbook-pro</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-lEDfW5O+SZe8KTQ93HGOPA</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro: 10.13 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -732,9 +628,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/whats-new</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-lQlm1yrMS0GPVyAL44id+A</string>
+			<key>pfm_title</key>
+			<string>What's New: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -742,9 +640,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/osx/mac/10.12/macbook-pro-15</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-n87FVu1TSwGzble8vqBvsg</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 15: 10.12 - 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -752,9 +652,11 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/imac</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-pDWyREoARJm5V1mJYr9GKg</string>
+			<key>pfm_title</key>
+			<string>iMac: 10.14</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -762,9 +664,143 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_date_allow_past</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>https://help.apple.com/macOS/mojave/macbook-pro</string>
 			<key>pfm_name</key>
 			<string>seed-viewed-srluh6uOQiuWCzxguqhDNw</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro: 10.14</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/imac</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_imac</string>
+			<key>pfm_title</key>
+			<string>iMac: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/imac-21a</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_imac-21a</string>
+			<key>pfm_title</key>
+			<string>iMac 21a: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/imac-pro</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_imac-pro</string>
+			<key>pfm_title</key>
+			<string>iMac Pro: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/late-2019/macbook-pro</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_late-2019_macbook-pro</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro Late 2019: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/mac-mini</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_mac-mini</string>
+			<key>pfm_title</key>
+			<string>Mac mini: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/mac-pro</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_mac-pro</string>
+			<key>pfm_title</key>
+			<string>Mac Pro: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/mac-basics</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_mac-basics</string>
+			<key>pfm_title</key>
+			<string>New to Mac: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/macbook-air</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_macbook-air</string>
+			<key>pfm_title</key>
+			<string>MacBook Air: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/macbook-pro</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_macbook-pro</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/macbook-pro-13</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_macbook-pro-13</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/whats-new</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_whats-new</string>
+			<key>pfm_title</key>
+			<string>What's New: 10.15</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -775,10 +811,10 @@ A profile can consist of payloads with different version numbers. For example, c
 		<string>user</string>
 	</array>
 	<key>pfm_title</key>
-	<string>New to Mac</string>
+	<string>New to Mac / Tours</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
All data pulled from com.apple.touristd.plist on Catalina machine (~/Library/Application Support/com.apple.touristd/com.apple.touristd.plist) - #183 

- Add new Catalina seeds
- Reorganize items based on hardware type
- Update pfm_title to reflect hardware model and included OS versions
- Add direct URLs to all seeds in the description
- Bump pfm_version and modified date