### PR TITLE
Remove FilesOnDemandPolicy and clarify description for FileOnDemandEn…

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.OneDrive.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.OneDrive.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_app_url</key>
-	<string>https://www.office.com</string>
+	<string>https://products.office.com/en-us/onedrive-for-business/online-cloud-storage</string>
 	<key>pfm_description</key>
 	<string>Microsoft OneDrive settings</string>
 	<key>pfm_documentation_url</key>
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2020-01-13T18:19:31Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -144,6 +144,8 @@
 DefaultFolderPath (String): DefaultFolder specifies the default folder location. 
 Mac App Store: The path must already exist when users set up the sync client. 
 Standalone: The path will be created on users' computers if it doesn't already exist. Only with the Standalone sync client can you prevent users from changing the location.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>Tenants</string>
 			<key>pfm_type</key>
@@ -210,6 +212,8 @@ Standalone: The path will be created on users' computers if it doesn't already e
 			<string>Enables the sync client to automatically set the amount of bandwidth used based on available bandwidth for uploading files.</string>
 			<key>pfm_description_extended</key>
 			<string>Determines the percentage of local upload bandwidth that the sync client can use. Accepted values are from 1 through 99.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>AutomaticUploadBandwidthPercentage</string>
 			<key>pfm_type</key>
@@ -230,6 +234,8 @@ Standalone: The path will be created on users' computers if it doesn't already e
 			<string>Sets the maximum upload throughput rate in kilobytes (KB)/sec for computers running the OneDrive sync client.</string>
 			<key>pfm_description_extended</key>
 			<string>Determines the upload throughput in KB/sec that the sync client can use. The minimum rate is 50 KB/sec and the maximum rate is 100,000 KB/sec.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>UploadBandwidthLimited</string>
 			<key>pfm_type</key>
@@ -250,6 +256,8 @@ Standalone: The path will be created on users' computers if it doesn't already e
 			<string>Sets the maximum download throughput rate in kilobytes (KB)/sec for computers running the OneDrive sync client.</string>
 			<key>pfm_description_extended</key>
 			<string>Determines the download throughput in KB/sec that the sync client can use. The minimum rate is 50 KB/sec and the maximum rate is 100,000 KB/sec.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>DownloadBandwidthLimited</string>
 			<key>pfm_type</key>
@@ -270,6 +278,8 @@ Standalone: The path will be created on users' computers if it doesn't already e
 			<string>Specifies whether a dock icon for OneDrive is shown.</string>
 			<key>pfm_description_extended</key>
 			<string>When set to true, this parameter hides the OneDrive dock icon even when the application is running.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>HideDockIcon</string>
 			<key>pfm_type</key>
@@ -286,6 +296,8 @@ Standalone: The path will be created on users' computers if it doesn't already e
 			<string>Specifies the SharePoint Server 2019 Public Preview on-premises URL that the OneDrive sync client should try to authenticate and sync against.</string>
 			<key>pfm_description_extended</key>
 			<string>When set to true, OneDrive will start automatically when the user logs in on the Mac.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>OpenAtLogin</string>
 			<key>pfm_type</key>
@@ -324,6 +336,8 @@ OneDrive – TenantName
 TenantName
 If not specified, the folder names will use the first segment of the FrontDoorURL as the Tenant Name.
 Example - https://Contoso.SharePoint.com will use Contoso as the Tenant Name.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>SharePointOnPremTenantName</string>
 			<key>pfm_type</key>
@@ -343,6 +357,8 @@ Example - https://Contoso.SharePoint.com will use Contoso as the Tenant Name.</s
 			<key>pfm_description_extended</key>
 			<string>This parameter determines which service to attempt to authenticate against for setting up sync.
 1 indicates OneDrive should setup SharePoint Server on-premises first, followed by SharePoint Online.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>SharePointOnPremPrioritzationPolicy</string>
 			<key>pfm_type</key>
@@ -365,6 +381,8 @@ Example - https://Contoso.SharePoint.com will use Contoso as the Tenant Name.</s
 			<string>Default to OneDrive Business</string>
 			<key>pfm_description_reference</key>
 			<string>Default to OneDrive Business instead of OneDrive Personal.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>DefaultToBusinessFRE</string>
 			<key>pfm_type</key>
@@ -377,48 +395,18 @@ Example - https://Contoso.SharePoint.com will use Contoso as the Tenant Name.</s
 			<string>Allow users to add accounts to OneDrive</string>
 			<key>pfm_description_reference</key>
 			<string>Allow users to add accounts to OneDrive.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_name</key>
 			<string>EnableAddAccounts</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_description</key>
-			<string>When set to true, Files On-Demand will be enabled or disabled based on FilesOnDemandEnabled.</string>
 			<key>pfm_description_reference</key>
-			<string>This setting determines whether Files On-Demand should be enabled based on the OneDrive controlled rollout or the FilesOnDemandEnabled setting.</string>
+			<string>When set to true, new users who set up the sync app will download online-only files by default. When set to false, Files On-Demand will be disabled and users won't be able to turn it on.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://docs.microsoft.com/en-us/OneDrive/files-on-demand-mac</string>
-			<key>pfm_macos_min</key>
-			<string>10.14</string>
-			<key>pfm_name</key>
-			<string>FilesOnDemandPolicy</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_conditionals</key>
-			<array>
-				<dict>
-					<key>pfm_target_conditions</key>
-					<array>
-						<dict>
-							<key>pfm_range_list</key>
-							<array>
-								<true/>
-							</array>
-							<key>pfm_target</key>
-							<string>FilesOnDemandPolicy</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
-			<key>pfm_description</key>
-			<string>When set to true, Files On-Demand will be enabled or disabled.</string>
-			<key>pfm_description_reference</key>
-			<string>This setting determines whether Files On-Demand should be enabled.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://docs.microsoft.com/en-us/OneDrive/files-on-demand-mac</string>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>
@@ -432,7 +420,7 @@ Example - https://Contoso.SharePoint.com will use Contoso as the Tenant Name.</s
 			<key>pfm_description_reference</key>
 			<string>This setting determines if a toast should appear when an application causes file contents to be downloaded.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://docs.microsoft.com/en-us/OneDrive/files-on-demand-mac</string>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>
@@ -448,7 +436,7 @@ MaxBundleVersion denotes the maximum bundle version of the application that will
 			<key>pfm_description_reference</key>
 			<string>Applications will not be allowed to trigger the download of cloud-only files. You can use this setting to lock down applications that don't work correctly with your deployment of Files On-Demand.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://docs.microsoft.com/en-us/OneDrive/files-on-demand-mac</string>
+			<string>https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
…abled

- `FilesOnDemandPolicy` not listed on Office for Mac sheet or on OneDrive docs page
- Update description for FileOnDemandEnabled
- Add main documentation page link to all preferences for easier access
- Add direct app page on Office website
- Update last modified date