### PR TITLE
menu.nomad.shares

### DIFF
--- a/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
@@ -1,385 +1,385 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-	<dict>
-		<key>pfm_app_url</key>
-		<string>https://nomad.menu</string>
-		<key>pfm_description</key>
-		<string>NoMAD Shares settings</string>
-		<key>pfm_documentation_url</key>
-		<string>https://nomad.menu/help/nomad-shares-menu/</string>
-		<key>pfm_domain</key>
-		<string>menu.nomad.shares</string>
-		<key>pfm_format_version</key>
-		<integer>1</integer>
-		<key>pfm_last_modified</key>
-		<date>2020-01-18T20:48:00Z</date>
-		<key>pfm_platforms</key>
-		<array>
-			<string>macOS</string>
-		</array>
-		<key>pfm_subkeys</key>
-		<array>
-			<dict>
-				<key>pfm_default</key>
-				<string>Configures NoMAD Shares settings</string>
-				<key>pfm_description</key>
-				<string>Description of the payload.</string>
-				<key>pfm_description_reference</key>
-				<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
-				<key>pfm_name</key>
-				<string>PayloadDescription</string>
-				<key>pfm_title</key>
-				<string>Payload Description</string>
-				<key>pfm_type</key>
-				<string>string</string>
-			</dict>
-			<dict>
-				<key>pfm_default</key>
-				<string>NoMAD Shares</string>
-				<key>pfm_description</key>
-				<string>Name of the payload.</string>
-				<key>pfm_description_reference</key>
-				<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
-				<key>pfm_name</key>
-				<string>PayloadDisplayName</string>
-				<key>pfm_require</key>
-				<string>always</string>
-				<key>pfm_title</key>
-				<string>Payload Display Name</string>
-				<key>pfm_type</key>
-				<string>string</string>
-			</dict>
-			<dict>
-				<key>pfm_default</key>
-				<string>menu.nomad.shares</string>
-				<key>pfm_description</key>
-				<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-				<key>pfm_description_reference</key>
-				<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
-				<key>pfm_name</key>
-				<string>PayloadIdentifier</string>
-				<key>pfm_require</key>
-				<string>always</string>
-				<key>pfm_title</key>
-				<string>Payload Identifier</string>
-				<key>pfm_type</key>
-				<string>string</string>
-			</dict>
-			<dict>
-				<key>pfm_default</key>
-				<string>menu.nomad.shares</string>
-				<key>pfm_description</key>
-				<string>The type of the payload, a reverse dns string.</string>
-				<key>pfm_description_reference</key>
-				<string>The payload type.</string>
-				<key>pfm_name</key>
-				<string>PayloadType</string>
-				<key>pfm_require</key>
-				<string>always</string>
-				<key>pfm_title</key>
-				<string>Payload Type</string>
-				<key>pfm_type</key>
-				<string>string</string>
-			</dict>
-			<dict>
-				<key>pfm_default</key>
-				<integer>1</integer>
-				<key>pfm_description</key>
-				<string>The version of the whole configuration profile.</string>
-				<key>pfm_description_reference</key>
-				<string>The version number of the individual payload.
+<dict>
+	<key>pfm_app_url</key>
+	<string>https://nomad.menu</string>
+	<key>pfm_description</key>
+	<string>NoMAD Shares settings</string>
+	<key>pfm_documentation_url</key>
+	<string>https://nomad.menu/help/nomad-shares-menu/</string>
+	<key>pfm_domain</key>
+	<string>menu.nomad.shares</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_last_modified</key>
+	<date>2020-01-18T20:48:00Z</date>
+	<key>pfm_platforms</key>
+	<array>
+		<string>macOS</string>
+	</array>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures NoMAD Shares settings</string>
+			<key>pfm_description</key>
+			<string>Description of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>NoMAD Shares</string>
+			<key>pfm_description</key>
+			<string>Name of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>menu.nomad.shares</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<key>pfm_description_reference</key>
+			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>menu.nomad.shares</string>
+			<key>pfm_description</key>
+			<string>The type of the payload, a reverse dns string.</string>
+			<key>pfm_description_reference</key>
+			<string>The payload type.</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_description_reference</key>
+			<string>The version number of the individual payload.
 A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
-				<key>pfm_name</key>
-				<string>PayloadVersion</string>
-				<key>pfm_require</key>
-				<string>always</string>
-				<key>pfm_title</key>
-				<string>Payload Version</string>
-				<key>pfm_type</key>
-				<string>integer</string>
-			</dict>
-			<dict>
-				<key>pfm_description</key>
-				<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-				<key>pfm_description_reference</key>
-				<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
-				<key>pfm_format</key>
-				<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
-				<key>pfm_name</key>
-				<string>PayloadUUID</string>
-				<key>pfm_require</key>
-				<string>always</string>
-				<key>pfm_title</key>
-				<string>Payload UUID</string>
-				<key>pfm_type</key>
-				<string>string</string>
-			</dict>
-			<dict>
-				<key>pfm_app_min</key>
-				<string>1.1</string>
-				<key>pfm_description</key>
-				<string>Required.</string>
-				<key>pfm_documentation_url</key>
-				<string>https://nomad.menu/help/nomad-shares-menu/</string>
-				<key>pfm_hidden</key>
-				<string>all</string>
-				<key>pfm_name</key>
-				<string>Version</string>
-				<key>pfm_range_list</key>
-				<array>
-					<string>1</string>
-				</array>
-				<key>pfm_required</key>
-				<string>always</string>
-				<key>pfm_title</key>
-				<string>NoMAD Shares PLIST Version</string>
-				<key>pfm_type</key>
-				<string>string</string>
-			</dict>
-			<dict>
-				<key>pfm_name</key>
-				<string>PFC_SegmentedControl_0</string>
-				<key>pfm_range_list_titles</key>
-				<array>
-					<string>Home Mount</string>
-					<string>Shares</string>
-				</array>
-				<key>pfm_require</key>
-				<string>always</string>
-				<key>pfm_segments</key>
-				<dict>
-					<key>Home Mount</key>
-					<array>
-						<string>HomeMount</string>
-					</array>
-					<key>Shares</key>
-					<array>
-						<string>Shares</string>
-						<string>IgnoreShareNames</string>
-					</array>
-				</dict>
-				<key>pfm_type</key>
-				<string>string</string>
-			</dict>
-			<dict>
-				<key>pfm_app_min</key>
-				<string>1.1</string>
-				<key>pfm_description</key>
-				<string>This is a dictionary of attributes for scenarios where the user’s home profile should be mounted.</string>
-				<key>pfm_documentation_url</key>
-				<string>https://nomad.menu/help/nomad-shares-menu/</string>
-				<key>pfm_name</key>
-				<string>HomeMount</string>
-				<key>pfm_subkeys</key>
-				<array>
-					<dict>
-						<key>pfm_app_min</key>
-						<string>1.1</string>
-						<key>pfm_description</key>
-						<string>Mount the user's home automatically or not.</string>
-						<key>pfm_description_reference</key>
-						<string>If set to true, will automount the user's home</string>
-						<key>pfm_documentation_url</key>
-						<string>https://nomad.menu/help/nomad-shares-menu/</string>
-						<key>pfm_name</key>
-						<string>Mount</string>
-						<key>pfm_title</key>
-						<string>Auto Mount Home</string>
-						<key>pfm_type</key>
-						<string>boolean</string>
-					</dict>
-					<dict>
-						<key>pfm_app_min</key>
-						<string>1.1</string>
-						<key>pfm_description</key>
-						<string>Only mount the home for members of these AD groups. Enter 'All' to allow all users and groups to mount their home.</string>
-						<key>pfm_documentation_url</key>
-						<string>https://nomad.menu/help/nomad-shares-menu/</string>
-						<key>pfm_name</key>
-						<string>Groups</string>
-						<key>pfm_subkeys</key>
-						<array>
-							<dict>
-								<key>pfm_description</key>
-								<string>Name of group in AD.</string>
-								<key>pfm_name</key>
-								<string>ADGroup</string>
-								<key>pfm_type</key>
-								<string>string</string>
-								<key>pfm_value_placeholder</key>
-								<string>AD Group Name</string>
-							</dict>
-						</array>
-						<key>pfm_type</key>
-						<string>array</string>
-					</dict>
-					<dict>
-						<key>pfm_app_min</key>
-						<string>1.1</string>
-						<key>pfm_description</key>
-						<string>Array of optional mount options. Refer to documentation for more information.</string>
-						<key>pfm_documentation_url</key>
-						<string>https://nomad.menu/help/nomad-shares-menu/</string>
-						<key>pfm_name</key>
-						<string>Options</string>
-						<key>pfm_subkeys</key>
-						<array>
-							<dict>
-								<key>pfm_description</key>
-								<string>Array of optional mount options. Refer to documentation for more information.</string>
-								<key>pfm_name</key>
-								<string>Mount Options</string>
-								<key>pfm_type</key>
-								<string>string</string>
-								<key>pfm_value_placeholder</key>
-								<string>Mount Option</string>
-							</dict>
-						</array>
-						<key>pfm_type</key>
-						<string>array</string>
-					</dict>
-				</array>
-				<key>pfm_type</key>
-				<string>dictionary</string>
-			</dict>
-			<dict>
-				<key>pfm_app_min</key>
-				<string>1.1</string>
-				<key>pfm_description</key>
-				<string>Array of dictionaries of each share and their settings.</string>
-				<key>pfm_documentation_url</key>
-				<string>https://nomad.menu/help/nomad-shares-menu/</string>
-				<key>pfm_name</key>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<key>pfm_description_reference</key>
+			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.1</string>
+			<key>pfm_description</key>
+			<string>Required.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://nomad.menu/help/nomad-shares-menu/</string>
+			<key>pfm_hidden</key>
+			<string>all</string>
+			<key>pfm_name</key>
+			<string>Version</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>1</string>
+			</array>
+			<key>pfm_required</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>NoMAD Shares PLIST Version</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_0</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Home Mount</string>
 				<string>Shares</string>
-				<key>pfm_subkeys</key>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>Home Mount</key>
 				<array>
-					<dict>
-						<key>pfm_description</key>
-						<string>Dictionary of shares and their settings.</string>
-						<key>pfm_name</key>
-						<string>ShareDict</string>
-						<key>pfm_subkeys</key>
-						<array>
-							<dict>
-								<key>pfm_description</key>
-								<string>Name as it will appear in the NoMAD menu item.</string>
-								<key>pfm_name</key>
-								<string>Name</string>
-								<key>pfm_type</key>
-								<string>string</string>
-							</dict>
-							<dict>
-								<key>pfm_description</key>
-								<string>The actual URL of the mount point in the form of "smb://dc1.nomad.test/Homes".
+					<string>HomeMount</string>
+				</array>
+				<key>Shares</key>
+				<array>
+					<string>Shares</string>
+					<string>IgnoreShareNames</string>
+				</array>
+			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.1</string>
+			<key>pfm_description</key>
+			<string>This is a dictionary of attributes for scenarios where the user’s home profile should be mounted.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://nomad.menu/help/nomad-shares-menu/</string>
+			<key>pfm_name</key>
+			<string>HomeMount</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>1.1</string>
+					<key>pfm_description</key>
+					<string>Mount the user's home automatically or not.</string>
+					<key>pfm_description_reference</key>
+					<string>If set to true, will automount the user's home</string>
+					<key>pfm_documentation_url</key>
+					<string>https://nomad.menu/help/nomad-shares-menu/</string>
+					<key>pfm_name</key>
+					<string>Mount</string>
+					<key>pfm_title</key>
+					<string>Auto Mount Home</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>1.1</string>
+					<key>pfm_description</key>
+					<string>Only mount the home for members of these AD groups. Enter 'All' to allow all users and groups to mount their home.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://nomad.menu/help/nomad-shares-menu/</string>
+					<key>pfm_name</key>
+					<string>Groups</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>Name of group in AD.</string>
+							<key>pfm_name</key>
+							<string>ADGroup</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>AD Group Name</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>array</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>1.1</string>
+					<key>pfm_description</key>
+					<string>Array of optional mount options. Refer to documentation for more information.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://nomad.menu/help/nomad-shares-menu/</string>
+					<key>pfm_name</key>
+					<string>Options</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>Array of optional mount options. Refer to documentation for more information.</string>
+							<key>pfm_name</key>
+							<string>Mount Options</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>Mount Option</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>array</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.1</string>
+			<key>pfm_description</key>
+			<string>Array of dictionaries of each share and their settings.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://nomad.menu/help/nomad-shares-menu/</string>
+			<key>pfm_name</key>
+			<string>Shares</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>Dictionary of shares and their settings.</string>
+					<key>pfm_name</key>
+					<string>ShareDict</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>Name as it will appear in the NoMAD menu item.</string>
+							<key>pfm_name</key>
+							<string>Name</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The actual URL of the mount point in the form of "smb://dc1.nomad.test/Homes".
 
 For the URLs, you can use variable substitution to allow for custom mounts without having to create even more XML. NoMAD understands &lt;&lt;domain&gt;&gt;, &lt;&lt;fullname&gt;&gt;, &lt;&lt;serial&gt;&gt;, &lt;&lt;shortname&gt;&gt;, &lt;&lt;upn&gt;&gt; and &lt;&lt;email&gt;&gt;</string>
-								<key>pfm_name</key>
-								<string>URL</string>
-								<key>pfm_type</key>
-								<string>string</string>
-								<key>pfm_value_placeholder</key>
-								<string>smb://yourdomain.com/path/to/share</string>
-							</dict>
-							<dict>
-								<key>pfm_description</key>
-								<string>An array of AD groups allowed to mount the share.</string>
-								<key>pfm_name</key>
-								<string>Groups</string>
-								<key>pfm_subkeys</key>
-								<array>
-									<dict>
-										<key>pfm_name</key>
-										<string>Group</string>
-										<key>pfm_type</key>
-										<string>string</string>
-									</dict>
-								</array>
-								<key>pfm_type</key>
-								<string>array</string>
-							</dict>
-							<dict>
-								<key>pfm_description</key>
-								<string>Optional local mount point.</string>
-								<key>pfm_name</key>
-								<string>LocalMount</string>
-								<key>pfm_type</key>
-								<string>string</string>
-							</dict>
-							<dict>
-								<key>pfm_description</key>
-								<string>If enabled, will auto mount share.</string>
-								<key>pfm_name</key>
-								<string>AutoMount</string>
-								<key>pfm_type</key>
-								<string>boolean</string>
-							</dict>
-							<dict>
-								<key>pfm_description</key>
-								<string>If enabled, will only mount on domain.</string>
-								<key>pfm_name</key>
-								<string>ConnectedOnly</string>
-								<key>pfm_type</key>
-								<string>boolean</string>
-							</dict>
-							<dict>
-								<key>pfm_description</key>
-								<string>Array of optional mount options. Refer to documentation for more information.</string>
-								<key>pfm_name</key>
-								<string>Options</string>
-								<key>pfm_subkeys</key>
-								<array>
-									<dict>
-										<key>pfm_name</key>
-										<string>MountOption</string>
-										<key>pfm_type</key>
-										<string>string</string>
-									</dict>
-								</array>
-								<key>pfm_type</key>
-								<string>array</string>
-							</dict>
-						</array>
-						<key>pfm_type</key>
-						<string>dictionary</string>
-					</dict>
-				</array>
-				<key>pfm_type</key>
-				<string>array</string>
-			</dict>
-			<dict>
-				<key>pfm_app_min</key>
-				<string>1.2.1</string>
-				<key>pfm_description</key>
-				<string>Specify a list of shares you'd like to ignore. (Time Machine is now ignored by default.)</string>
-				<key>pfm_documentation_url</key>
-				<string>https://macadmins.slack.com/archives/C1Y2Y14QG/p1578078500046400</string>
-				<key>pfm_name</key>
-				<string>IgnoreShareNames</string>
-				<key>pfm_title</key>
-				<string>Ignored Shares</string>
-				<key>pfm_subkeys</key>
-				<array>
-					<dict>
-						<key>pfm_description</key>
-						<string>Name of share to ignore.</string>
-						<key>pfm_name</key>
-						<string>Ignored Shares</string>
-						<key>pfm_type</key>
-						<string>string</string>
-						<key>pfm_value_placeholder</key>
-						<string>Share Name</string>
-					</dict>
-				</array>
-				<key>pfm_type</key>
-				<string>array</string>
-			</dict>
-		</array>
-		<key>pfm_title</key>
-		<string>NoMAD Shares</string>
-		<key>pfm_unique</key>
-		<true/>
-		<key>pfm_version</key>
-		<integer>4</integer>
-	</dict>
+							<key>pfm_name</key>
+							<string>URL</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>smb://yourdomain.com/path/to/share</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>An array of AD groups allowed to mount the share.</string>
+							<key>pfm_name</key>
+							<string>Groups</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>Group</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
+							<key>pfm_type</key>
+							<string>array</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Optional local mount point.</string>
+							<key>pfm_name</key>
+							<string>LocalMount</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>If enabled, will auto mount share.</string>
+							<key>pfm_name</key>
+							<string>AutoMount</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>If enabled, will only mount on domain.</string>
+							<key>pfm_name</key>
+							<string>ConnectedOnly</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Array of optional mount options. Refer to documentation for more information.</string>
+							<key>pfm_name</key>
+							<string>Options</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>MountOption</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
+							<key>pfm_type</key>
+							<string>array</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.2.1</string>
+			<key>pfm_description</key>
+			<string>Specify a list of shares you'd like to ignore. (Time Machine is now ignored by default.)</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.slack.com/archives/C1Y2Y14QG/p1578078500046400</string>
+			<key>pfm_name</key>
+			<string>IgnoreShareNames</string>
+			<key>pfm_title</key>
+			<string>Ignored Shares</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>Name of share to ignore.</string>
+					<key>pfm_name</key>
+					<string>Ignored Shares</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>Share Name</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+	</array>
+	<key>pfm_title</key>
+	<string>NoMAD Shares</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>4</integer>
+</dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
@@ -1,347 +1,385 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>pfm_app_url</key>
-	<string>https://nomad.menu</string>
-	<key>pfm_description</key>
-	<string>NoMAD Shares settings</string>
-	<key>pfm_documentation_url</key>
-	<string>https://nomad.menu/help/nomad-shares-menu/</string>
-	<key>pfm_domain</key>
-	<string>menu.nomad.shares</string>
-	<key>pfm_format_version</key>
-	<integer>1</integer>
-	<key>pfm_last_modified</key>
-	<date>2018-11-27T16:23:00Z</date>
-	<key>pfm_platforms</key>
-	<array>
-		<string>macOS</string>
-	</array>
-	<key>pfm_subkeys</key>
-	<array>
-		<dict>
-			<key>pfm_default</key>
-			<string>Configures NoMAD Shares settings</string>
-			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
-			<key>pfm_name</key>
-			<string>PayloadDescription</string>
-			<key>pfm_title</key>
-			<string>Payload Description</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string>NoMAD Shares</string>
-			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
-			<key>pfm_name</key>
-			<string>PayloadDisplayName</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Display Name</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string>menu.nomad.shares</string>
-			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
-			<key>pfm_name</key>
-			<string>PayloadIdentifier</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Identifier</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<string>menu.nomad.shares</string>
-			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
-			<key>pfm_name</key>
-			<string>PayloadType</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Type</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
-			<integer>1</integer>
-			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
-			<key>pfm_name</key>
-			<string>PayloadVersion</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload Version</string>
-			<key>pfm_type</key>
-			<string>integer</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
-			<key>pfm_format</key>
-			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
-			<key>pfm_name</key>
-			<string>PayloadUUID</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Payload UUID</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_name</key>
-			<string>PayloadOrganization</string>
-			<key>pfm_title</key>
-			<string>Payload Organization</string>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_name</key>
-			<string>PFC_SegmentedControl_0</string>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Home Mount</string>
-				<string>Shares</string>
-			</array>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_segments</key>
+	<dict>
+		<key>pfm_app_url</key>
+		<string>https://nomad.menu</string>
+		<key>pfm_description</key>
+		<string>NoMAD Shares settings</string>
+		<key>pfm_documentation_url</key>
+		<string>https://nomad.menu/help/nomad-shares-menu/</string>
+		<key>pfm_domain</key>
+		<string>menu.nomad.shares</string>
+		<key>pfm_format_version</key>
+		<integer>1</integer>
+		<key>pfm_last_modified</key>
+		<date>2020-01-18T20:48:00Z</date>
+		<key>pfm_platforms</key>
+		<array>
+			<string>macOS</string>
+		</array>
+		<key>pfm_subkeys</key>
+		<array>
 			<dict>
-				<key>Home Mount</key>
+				<key>pfm_default</key>
+				<string>Configures NoMAD Shares settings</string>
+				<key>pfm_description</key>
+				<string>Description of the payload.</string>
+				<key>pfm_description_reference</key>
+				<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+				<key>pfm_name</key>
+				<string>PayloadDescription</string>
+				<key>pfm_title</key>
+				<string>Payload Description</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>NoMAD Shares</string>
+				<key>pfm_description</key>
+				<string>Name of the payload.</string>
+				<key>pfm_description_reference</key>
+				<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+				<key>pfm_name</key>
+				<string>PayloadDisplayName</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Display Name</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>menu.nomad.shares</string>
+				<key>pfm_description</key>
+				<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+				<key>pfm_description_reference</key>
+				<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+				<key>pfm_name</key>
+				<string>PayloadIdentifier</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Identifier</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>menu.nomad.shares</string>
+				<key>pfm_description</key>
+				<string>The type of the payload, a reverse dns string.</string>
+				<key>pfm_description_reference</key>
+				<string>The payload type.</string>
+				<key>pfm_name</key>
+				<string>PayloadType</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Type</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<integer>1</integer>
+				<key>pfm_description</key>
+				<string>The version of the whole configuration profile.</string>
+				<key>pfm_description_reference</key>
+				<string>The version number of the individual payload.
+A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+				<key>pfm_name</key>
+				<string>PayloadVersion</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Version</string>
+				<key>pfm_type</key>
+				<string>integer</string>
+			</dict>
+			<dict>
+				<key>pfm_description</key>
+				<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+				<key>pfm_description_reference</key>
+				<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+				<key>pfm_format</key>
+				<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+				<key>pfm_name</key>
+				<string>PayloadUUID</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload UUID</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_app_min</key>
+				<string>1.1</string>
+				<key>pfm_description</key>
+				<string>Required.</string>
+				<key>pfm_documentation_url</key>
+				<string>https://nomad.menu/help/nomad-shares-menu/</string>
+				<key>pfm_hidden</key>
+				<string>all</string>
+				<key>pfm_name</key>
+				<string>Version</string>
+				<key>pfm_range_list</key>
 				<array>
-					<string>HomeMount</string>
+					<string>1</string>
 				</array>
-				<key>Shares</key>
+				<key>pfm_required</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>NoMAD Shares PLIST Version</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_name</key>
+				<string>PFC_SegmentedControl_0</string>
+				<key>pfm_range_list_titles</key>
 				<array>
+					<string>Home Mount</string>
 					<string>Shares</string>
 				</array>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_segments</key>
+				<dict>
+					<key>Home Mount</key>
+					<array>
+						<string>HomeMount</string>
+					</array>
+					<key>Shares</key>
+					<array>
+						<string>Shares</string>
+						<string>IgnoreShareNames</string>
+					</array>
+				</dict>
+				<key>pfm_type</key>
+				<string>string</string>
 			</dict>
-			<key>pfm_type</key>
-			<string>string</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>1.1</string>
-			<key>pfm_description</key>
-			<string>This is a dictionary of attributes for scenarios where the user’s home profile should be mounted.</string>
-			<key>pfm_name</key>
-			<string>HomeMount</string>
-			<key>pfm_subkeys</key>
-			<array>
-				<dict>
-					<key>pfm_description</key>
-					<string>Mount the user's home automatically or not.</string>
-					<key>pfm_description_reference</key>
-					<string>If set to true, will automount the user's home</string>
-					<key>pfm_name</key>
-					<string>Mount</string>
-					<key>pfm_title</key>
-					<string>Auto Mount Home</string>
-					<key>pfm_type</key>
-					<string>boolean</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Only mount the home for members of these AD groups. Enter 'All' to allow all users and groups to mount their home.</string>
-					<key>pfm_name</key>
-					<string>Groups</string>
-					<key>pfm_subkeys</key>
-					<array>
-						<dict>
-							<key>pfm_description</key>
-							<string>Name of group in AD.</string>
-							<key>pfm_name</key>
-							<string>ADGroup</string>
-							<key>pfm_type</key>
-							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>AD Group Name</string>
-						</dict>
-					</array>
-					<key>pfm_type</key>
-					<string>array</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Array of optional mount options. Refer to "Options" @ https://nomad.menu/help/nomad-shares-menu/ for more information.</string>
-					<key>pfm_name</key>
-					<string>Options</string>
-					<key>pfm_subkeys</key>
-					<array>
-						<dict>
-							<key>pfm_description</key>
-							<string>Array of optional mount options. Refer to "Options" @ https://nomad.menu/help/nomad-shares-menu/ for more information.</string>
-							<key>pfm_name</key>
-							<string>MountOption</string>
-							<key>pfm_type</key>
-							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>Mount Option</string>
-						</dict>
-					</array>
-					<key>pfm_type</key>
-					<string>array</string>
-				</dict>
-			</array>
-			<key>pfm_type</key>
-			<string>dictionary</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>1.1</string>
-			<key>pfm_description</key>
-			<string>Array of dictionaries of each share and their settings.</string>
-			<key>pfm_name</key>
-			<string>Shares</string>
-			<key>pfm_subkeys</key>
-			<array>
-				<dict>
-					<key>pfm_description</key>
-					<string>Dictionary of shares and their settings.</string>
-					<key>pfm_name</key>
-					<string>ShareDict</string>
-					<key>pfm_subkeys</key>
-					<array>
-						<dict>
-							<key>pfm_description</key>
-							<string>Name as it will appear in the NoMAD menu item.</string>
-							<key>pfm_name</key>
-							<string>Name</string>
-							<key>pfm_type</key>
-							<string>string</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
-							<string>The actual URL of the mount point in the form of "smb://dc1.nomad.test/Homes".
+			<dict>
+				<key>pfm_app_min</key>
+				<string>1.1</string>
+				<key>pfm_description</key>
+				<string>This is a dictionary of attributes for scenarios where the user’s home profile should be mounted.</string>
+				<key>pfm_documentation_url</key>
+				<string>https://nomad.menu/help/nomad-shares-menu/</string>
+				<key>pfm_name</key>
+				<string>HomeMount</string>
+				<key>pfm_subkeys</key>
+				<array>
+					<dict>
+						<key>pfm_app_min</key>
+						<string>1.1</string>
+						<key>pfm_description</key>
+						<string>Mount the user's home automatically or not.</string>
+						<key>pfm_description_reference</key>
+						<string>If set to true, will automount the user's home</string>
+						<key>pfm_documentation_url</key>
+						<string>https://nomad.menu/help/nomad-shares-menu/</string>
+						<key>pfm_name</key>
+						<string>Mount</string>
+						<key>pfm_title</key>
+						<string>Auto Mount Home</string>
+						<key>pfm_type</key>
+						<string>boolean</string>
+					</dict>
+					<dict>
+						<key>pfm_app_min</key>
+						<string>1.1</string>
+						<key>pfm_description</key>
+						<string>Only mount the home for members of these AD groups. Enter 'All' to allow all users and groups to mount their home.</string>
+						<key>pfm_documentation_url</key>
+						<string>https://nomad.menu/help/nomad-shares-menu/</string>
+						<key>pfm_name</key>
+						<string>Groups</string>
+						<key>pfm_subkeys</key>
+						<array>
+							<dict>
+								<key>pfm_description</key>
+								<string>Name of group in AD.</string>
+								<key>pfm_name</key>
+								<string>ADGroup</string>
+								<key>pfm_type</key>
+								<string>string</string>
+								<key>pfm_value_placeholder</key>
+								<string>AD Group Name</string>
+							</dict>
+						</array>
+						<key>pfm_type</key>
+						<string>array</string>
+					</dict>
+					<dict>
+						<key>pfm_app_min</key>
+						<string>1.1</string>
+						<key>pfm_description</key>
+						<string>Array of optional mount options. Refer to documentation for more information.</string>
+						<key>pfm_documentation_url</key>
+						<string>https://nomad.menu/help/nomad-shares-menu/</string>
+						<key>pfm_name</key>
+						<string>Options</string>
+						<key>pfm_subkeys</key>
+						<array>
+							<dict>
+								<key>pfm_description</key>
+								<string>Array of optional mount options. Refer to documentation for more information.</string>
+								<key>pfm_name</key>
+								<string>Mount Options</string>
+								<key>pfm_type</key>
+								<string>string</string>
+								<key>pfm_value_placeholder</key>
+								<string>Mount Option</string>
+							</dict>
+						</array>
+						<key>pfm_type</key>
+						<string>array</string>
+					</dict>
+				</array>
+				<key>pfm_type</key>
+				<string>dictionary</string>
+			</dict>
+			<dict>
+				<key>pfm_app_min</key>
+				<string>1.1</string>
+				<key>pfm_description</key>
+				<string>Array of dictionaries of each share and their settings.</string>
+				<key>pfm_documentation_url</key>
+				<string>https://nomad.menu/help/nomad-shares-menu/</string>
+				<key>pfm_name</key>
+				<string>Shares</string>
+				<key>pfm_subkeys</key>
+				<array>
+					<dict>
+						<key>pfm_description</key>
+						<string>Dictionary of shares and their settings.</string>
+						<key>pfm_name</key>
+						<string>ShareDict</string>
+						<key>pfm_subkeys</key>
+						<array>
+							<dict>
+								<key>pfm_description</key>
+								<string>Name as it will appear in the NoMAD menu item.</string>
+								<key>pfm_name</key>
+								<string>Name</string>
+								<key>pfm_type</key>
+								<string>string</string>
+							</dict>
+							<dict>
+								<key>pfm_description</key>
+								<string>The actual URL of the mount point in the form of "smb://dc1.nomad.test/Homes".
 
 For the URLs, you can use variable substitution to allow for custom mounts without having to create even more XML. NoMAD understands &lt;&lt;domain&gt;&gt;, &lt;&lt;fullname&gt;&gt;, &lt;&lt;serial&gt;&gt;, &lt;&lt;shortname&gt;&gt;, &lt;&lt;upn&gt;&gt; and &lt;&lt;email&gt;&gt;</string>
-							<key>pfm_name</key>
-							<string>URL</string>
-							<key>pfm_type</key>
-							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>smb://yourdomain.com/path/to/share</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
-							<string>An array of AD groups allowed to mount the share.</string>
-							<key>pfm_name</key>
-							<string>Groups</string>
-							<key>pfm_subkeys</key>
-							<array>
-								<dict>
-									<key>pfm_name</key>
-									<string>Group</string>
-									<key>pfm_type</key>
-									<string>string</string>
-								</dict>
-							</array>
-							<key>pfm_type</key>
-							<string>array</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
-							<string>Optional local mount point.</string>
-							<key>pfm_name</key>
-							<string>LocalMount</string>
-							<key>pfm_type</key>
-							<string>string</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
-							<string>If enabled, will auto mount share.</string>
-							<key>pfm_name</key>
-							<string>AutoMount</string>
-							<key>pfm_type</key>
-							<string>boolean</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
-							<string>If enabled, will only mount on domain.</string>
-							<key>pfm_name</key>
-							<string>ConnectedOnly</string>
-							<key>pfm_type</key>
-							<string>boolean</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
-							<string>Array of optional mount options. Refer to "Options" @ https://nomad.menu/help/nomad-shares-menu/ for more information.</string>
-							<key>pfm_name</key>
-							<string>Options</string>
-							<key>pfm_subkeys</key>
-							<array>
-								<dict>
-									<key>pfm_name</key>
-									<string>MountOption</string>
-									<key>pfm_type</key>
-									<string>string</string>
-								</dict>
-							</array>
-							<key>pfm_type</key>
-							<string>array</string>
-						</dict>
-					</array>
-					<key>pfm_type</key>
-					<string>dictionary</string>
-				</dict>
-			</array>
-			<key>pfm_type</key>
-			<string>array</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>Required.</string>
-			<key>pfm_name</key>
-			<string>Version</string>
-			<key>pfm_range_list</key>
-			<array>
-				<string>1</string>
-			</array>
-			<key>pfm_required</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>NoMAD Shares PLIST Version</string>
-			<key>pfm_type</key>
-			<string>string</string>
-			<key>pfm_hidden</key>
-			<string>all</string>
-		</dict>
-	</array>
-	<key>pfm_title</key>
-	<string>NoMAD Shares</string>
-	<key>pfm_unique</key>
-	<true/>
-	<key>pfm_version</key>
-	<integer>3</integer>
-</dict>
+								<key>pfm_name</key>
+								<string>URL</string>
+								<key>pfm_type</key>
+								<string>string</string>
+								<key>pfm_value_placeholder</key>
+								<string>smb://yourdomain.com/path/to/share</string>
+							</dict>
+							<dict>
+								<key>pfm_description</key>
+								<string>An array of AD groups allowed to mount the share.</string>
+								<key>pfm_name</key>
+								<string>Groups</string>
+								<key>pfm_subkeys</key>
+								<array>
+									<dict>
+										<key>pfm_name</key>
+										<string>Group</string>
+										<key>pfm_type</key>
+										<string>string</string>
+									</dict>
+								</array>
+								<key>pfm_type</key>
+								<string>array</string>
+							</dict>
+							<dict>
+								<key>pfm_description</key>
+								<string>Optional local mount point.</string>
+								<key>pfm_name</key>
+								<string>LocalMount</string>
+								<key>pfm_type</key>
+								<string>string</string>
+							</dict>
+							<dict>
+								<key>pfm_description</key>
+								<string>If enabled, will auto mount share.</string>
+								<key>pfm_name</key>
+								<string>AutoMount</string>
+								<key>pfm_type</key>
+								<string>boolean</string>
+							</dict>
+							<dict>
+								<key>pfm_description</key>
+								<string>If enabled, will only mount on domain.</string>
+								<key>pfm_name</key>
+								<string>ConnectedOnly</string>
+								<key>pfm_type</key>
+								<string>boolean</string>
+							</dict>
+							<dict>
+								<key>pfm_description</key>
+								<string>Array of optional mount options. Refer to documentation for more information.</string>
+								<key>pfm_name</key>
+								<string>Options</string>
+								<key>pfm_subkeys</key>
+								<array>
+									<dict>
+										<key>pfm_name</key>
+										<string>MountOption</string>
+										<key>pfm_type</key>
+										<string>string</string>
+									</dict>
+								</array>
+								<key>pfm_type</key>
+								<string>array</string>
+							</dict>
+						</array>
+						<key>pfm_type</key>
+						<string>dictionary</string>
+					</dict>
+				</array>
+				<key>pfm_type</key>
+				<string>array</string>
+			</dict>
+			<dict>
+				<key>pfm_app_min</key>
+				<string>1.2.1</string>
+				<key>pfm_description</key>
+				<string>Specify a list of shares you'd like to ignore. (Time Machine is now ignored by default.)</string>
+				<key>pfm_documentation_url</key>
+				<string>https://macadmins.slack.com/archives/C1Y2Y14QG/p1578078500046400</string>
+				<key>pfm_name</key>
+				<string>IgnoreShareNames</string>
+				<key>pfm_title</key>
+				<string>Ignored Shares</string>
+				<key>pfm_subkeys</key>
+				<array>
+					<dict>
+						<key>pfm_description</key>
+						<string>Name of share to ignore.</string>
+						<key>pfm_name</key>
+						<string>Ignored Shares</string>
+						<key>pfm_type</key>
+						<string>string</string>
+						<key>pfm_value_placeholder</key>
+						<string>Share Name</string>
+					</dict>
+				</array>
+				<key>pfm_type</key>
+				<string>array</string>
+			</dict>
+		</array>
+		<key>pfm_title</key>
+		<string>NoMAD Shares</string>
+		<key>pfm_unique</key>
+		<true/>
+		<key>pfm_version</key>
+		<integer>4</integer>
+	</dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
@@ -363,7 +363,7 @@ For the URLs, you can use variable substitution to allow for custom mounts witho
 				<dict>
 					<key>pfm_description</key>
 					<string>Name of share to ignore.</string>
-					<key>pfm_name</key>
+					<key>pfm_title</key>
 					<string>Ignored Shares</string>
 					<key>pfm_type</key>
 					<string>string</string>


### PR DESCRIPTION
Adds new `IgnoreShareNames` option coming in NoMAD 1.2.1 (announced by Joel in Slack).
Also some cleanup.