### PR TITLE
Update menu.nomad.login.ad.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -149,6 +149,7 @@
 						<string>DenyLocal</string>
 						<string>DenyLocalExcluded</string>
 						<string>DenyLoginUnlessGroupMember</string>
+						<string>PasswordOverwriteSilent</string>
 						<string>LoginScreen</string>
 						<string>LDAPOverSSL</string>
 						<string>AdditionalADDomains</string>
@@ -261,6 +262,16 @@
 					</dict>
 				</array>
 			</dict>
+			<dict>
+				<key>pfm_app_min</key>
+				<string>1.4</string>
+				<key>pfm_description_reference</key>
+				<string>When DenyLocal and PasswordOverwriteSilent are enabled and the user does not have a secure token NoLo will force overwrite the users password to the new password.</string>
+				<key>pfm_name</key>
+				<string>PasswordOverwriteSilent</string>
+				<key>pfm_type</key>
+				<string>boolean</string>
+			</dict>			
 			<dict>
 				<key>pfm_app_min</key>
 				<string>1.1.0</string>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -17,7 +17,7 @@
 			<string>macOS</string>
 		</array>
 		<key>pfm_last_modified</key>
-		<date>2019-09-17T08:52:31Z</date>
+		<date>2020-01-20T10:24:31Z</date>
 		<key>pfm_subkeys</key>
 		<array>
 			<dict>
@@ -967,6 +967,6 @@
 		<key>pfm_unique</key>
 		<true/>
 		<key>pfm_version</key>
-		<integer>7</integer>
+		<integer>8</integer>
 	</dict>
 </plist>


### PR DESCRIPTION
Added PasswordOverwriteSilent key for 1.4.0 alpha release. From the MacAdmins slack, #nolo-localsyncbeta 

https://macadmins.slack.com/archives/CGD7EPD8Q/p1577809080004100