### PR TITLE
Update Microsoft Edge

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -70,7 +70,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.microsoft.Edgee</string>
+			<string>com.microsoft.Edge</string>
 			<key>pfm_description</key>
 			<string>The type of the payload, a reverse dns string.</string>
 			<key>pfm_description_reference</key>
@@ -159,6 +159,7 @@
 					<string>PFC_SegmentedControl_ContentSettings</string>
 					<string>AutoSelectCertificateForUrls</string>
 					<string>AutoplayAllowed</string>
+					<string>BackgroundTemplateListUpdatesEnabled</string>
 					<string>BlockThirdPartyCookies</string>
 					<string>CookiesAllowedForUrls</string>
 					<string>CookiesBlockedForUrls</string>
@@ -228,6 +229,7 @@
 					<string>AuthServerWhitelist</string>
 					<string>DisableAuthNegotiateCnameLookup</string>
 					<string>EnableAuthNegotiatePort</string>
+					<string>NtlmV2Enabled</string>
 				</array>
 				<key>Legacy Browser Support</key>
 				<array>
@@ -250,11 +252,14 @@
 					<string>AllowFileSelectionDialogs</string>
 					<string>AllowOutdatedPlugins</string>
 					<string>AllowPopupsDuringPageUnload</string>
+					<string>AllowSyncXHRInPageDismissal</string>
+					<string>AllowTrackingForUrls</string>
 					<string>AllowedDomainsForApps</string>
 					<string>AlternateErrorPagesEnabled</string>
 					<string>AlwaysOpenPdfExternally</string>
 					<string>AudioCaptureAllowed</string>
 					<string>AudioCaptureAllowedUrls</string>
+					<string>AutoImportAtFirstRun</string>
 					<string>AutoFillEnabled</string>
 					<string>AutofillAddressEnabled</string>
 					<string>AutofillCreditCardEnabled</string>
@@ -269,11 +274,16 @@
 					<string>CertificateTransparencyEnforcementDisabledForCas</string>
 					<string>CertificateTransparencyEnforcementDisabledForLegacyCas</string>
 					<string>CertificateTransparencyEnforcementDisabledForUrls</string>
+					<string>ClearBrowsingDataOnExit</string>
 					<string>CloudManagementEnrollmentMandatory</string>
 					<string>CloudManagementEnrollmentToken</string>
 					<string>CloudPolicyOverridesPlatformPolicy</string>
 					<string>CommandLineFlagSecurityWarningsEnabled</string>
 					<string>ComponentUpdatesEnabled</string>
+					<string>ConfigureDoNotTrack</string>
+					<string>ConfigureOnlineTextToSpeech</string>
+					<string>CustomHelpLink</string>
+					<string>DNSInterceptionChecksEnabled</string>
 					<string>DefaultBrowserSettingEnabled</string>
 					<string>DefaultDownloadDirectory</string>
 					<string>DeveloperToolsAvailability</string>
@@ -288,24 +298,33 @@
 					<string>DiskCacheSize</string>
 					<string>DownloadDirectory</string>
 					<string>DownloadRestrictions</string>
+					<string>EdgeCollectionsEnabled</string>
 					<string>EditBookmarksEnabled</string>
 					<string>EnableDeprecatedWebPlatformFeatures</string>
+					<string>EnableDomainActionsDownload</string>
 					<string>EnableOnlineRevocationChecks</string>
 					<string>EnabledPlugins</string>
 					<string>EnterpriseHardwarePlatformAPIEnabled</string>
+					<string>ExternalProtocolDialogShowAlwaysOpenCheckbox</string>
 					<string>ForceBrowserSignin</string>
 					<string>ForceEphemeralProfiles</string>
 					<string>ForceGoogleSafeSearch</string>
 					<string>ForceSafeSearch</string>
 					<string>ForceYouTubeRestrict</string>
 					<string>ForceYouTubeSafetyMode</string>
+					<string>GoToIntranetSiteForSingleWordEntryInAddressBar</string>
+					<string>HSTSPolicyBypassList</string>
 					<string>HardwareAccelerationModeEnabled</string>
+					<string>HideFirstRunExperience</string>
 					<string>HideWebStoreIcon</string>
 					<string>Http09OnNonDefaultPortsEnabled</string>
 					<string>ImportAutofillFormData</string>
+					<string>ImportBrowserSettings</string>
 					<string>ImportBookmarks</string>
 					<string>ImportHistory</string>
 					<string>ImportHomepage</string>
+					<string>ImportOpenTabs</string>
+					<string>ImportPaymentInfo</string>
 					<string>ImportSavedPasswords</string>
 					<string>ImportSearchEngine</string>
 					<string>IncognitoEnabled</string>
@@ -318,6 +337,10 @@
 					<string>MaxInvalidationFetchDelay</string>
 					<string>MediaRouterCastAllowAllIPs</string>
 					<string>MetricsReportingEnabled</string>
+					<string>OmniboxMSBProviderEnabled</string>
+					<string>PaymentMethodQueryEnabled</string>
+					<string>PersonalizationReportingEnabled</string>
+					<string>ProactiveAuthEnabled</string>
 					<string>NetworkPredictionOptions</string>
 					<string>OverrideSecurityRestrictionsOnInsecureOrigin</string>
 					<string>PolicyDictionaryMultipleSourceMergeList</string>
@@ -328,6 +351,7 @@
 					<string>QuicAllowed</string>
 					<string>RelaunchNotification</string>
 					<string>RelaunchNotificationPeriod</string>
+					<string>ResolveNavigationErrorsUseWebService</string>
 					<string>RestrictSigninToPattern</string>
 					<string>RunAllFlashInAllowMode</string>
 					<string>SSLErrorOverrideAllowed</string>
@@ -336,6 +360,8 @@
 					<string>SavingBrowserHistoryDisabled</string>
 					<string>SearchSuggestEnabled</string>
 					<string>SecurityKeyPermitAttestation</string>
+					<string>SendSiteInfoToImproveServices</string>
+					<string>ShowOfficeShortcutInFavoritesBar</string>
 					<string>ShowAppsShortcutInBookmarkBar</string>
 					<string>SignedHTTPExchangeEnabled</string>
 					<string>SigninAllowed</string>
@@ -344,7 +370,9 @@
 					<string>SpellcheckEnabled</string>
 					<string>SuppressUnsupportedOSWarning</string>
 					<string>SyncDisabled</string>
+					<string>TabFreezingEnabled</string>
 					<string>TaskManagerEndProcessEnabled</string>
+					<string>TotalMemoryLimitMb</string>
 					<string>TranslateEnabled</string>
 					<string>URLBlacklist</string>
 					<string>URLWhitelist</string>
@@ -379,6 +407,7 @@
 					<string>PrintHeaderFooter</string>
 					<string>PrintPreviewUseSystemDefaultPrinter</string>
 					<string>PrintingEnabled</string>
+					<string>UseSystemPrintDialog</string>
 				</array>
 				<key>Proxy Server</key>
 				<array>
@@ -420,6 +449,7 @@
 				<array>
 					<string>HomepageIsNewTabPage</string>
 					<string>HomepageLocation</string>
+					<string>NewTabPageHideDefaultTopSites</string>
 					<string>NewTabPageLocation</string>
 					<string>RestoreOnStartup</string>
 					<string>RestoreOnStartupURLs</string>
@@ -765,7 +795,7 @@ If this policy is left not set, '3' will be used, and the user will be able to c
 			<string>Control use of the WebUSB API</string>
 			<key>pfm_type</key>
 			<string>integer</string>
-		</dict>	
+		</dict>
 		<dict>
 			<key>pfm_app_min</key>
 			<string>11</string>
@@ -1050,7 +1080,7 @@ If this policy is left not set, 'AskGeolocation' will be used and the user will 
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>25</string>
 			<key>pfm_app_min</key>
@@ -1082,7 +1112,7 @@ If this policy is left not set, 'AskGeolocation' will be used and the user will 
 			<string>Default mediastream setting</string>
 			<key>pfm_type</key>
 			<string>integer</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>37</string>
@@ -1226,7 +1256,7 @@ Note that if Google Chrome is running and this policy changes, it will be applie
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>66</string>
 			<key>pfm_description</key>
@@ -1260,6 +1290,24 @@ Note that if Google Chrome is running and this policy changes, it will be applie
 			<string>Allow media autoplay on a whitelist of URL patterns</string>
 			<key>pfm_type</key>
 			<string>array</string>
+		</dict> -->
+		<dict>
+			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>If you enable this setting or the setting is unconfigured, the list of available templates will be downloaded in the background from a Microsoft service every 24 hours.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this setting or the setting is unconfigured, the list of available templates will be downloaded in the background from a Microsoft service every 24 hours.
+
+If you disable this setting the list of available templates will be downloaded on demand. This type of download might result in small performance penalties for Collections and other features.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#backgroundtemplatelistupdatesenabled</string>
+			<key>pfm_name</key>
+			<string>BackgroundTemplateListUpdatesEnabled</string>
+			<key>pfm_title</key>
+			<string>Enable background updates for templates</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -1349,7 +1397,7 @@ If this policy is left not set the global default value will be used for all sit
 			<string>array</string>
 		</dict>
 		<!-- START ContentSettings/DefaultSearchProvider -->
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>24</string>
 			<key>pfm_description</key>
@@ -1377,7 +1425,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 			<string>List of alternate URLs for the default search provider</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>8</string>
@@ -1436,7 +1484,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>8</string>
 			<key>pfm_description</key>
@@ -1457,7 +1505,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>https://search.my.company/favicon.ico</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>29</string>
@@ -1544,7 +1592,7 @@ This policy is only considered if the 'DefaultSearchProviderEnabled' policy is e
 			<key>pfm_value_placeholder</key>
 			<string>Google</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>30</string>
 			<key>pfm_description</key>
@@ -1565,7 +1613,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>https://search.my.company/newtab</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>8</string>
@@ -1588,7 +1636,7 @@ This option must be set when the 'DefaultSearchProviderEnabled' policy is enable
 			<key>pfm_value_placeholder</key>
 			<string>https://search.my.company/search?q={searchTerms}</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>29</string>
 			<key>pfm_description</key>
@@ -1609,7 +1657,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>q={searchTerms},ie=utf-8,oe=utf-8</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>8</string>
@@ -1634,7 +1682,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 			<key>pfm_value_placeholder</key>
 			<string>https://search.my.company/suggest?q={searchTerms}</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>29</string>
 			<key>pfm_description</key>
@@ -1655,7 +1703,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>q={searchTerms},ie=utf-8,oe=utf-8</string>
-		</dict>
+		</dict> -->
 		<!-- END ContentSettings/DefaultSearchProvider -->
 		<!-- START ContentSettings/Extensions -->
 		<dict>
@@ -2116,7 +2164,7 @@ For a full description of possible settings and structure of this policy please 
 			<key>pfm_type</key>
 			<string>dictionary</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>78</string>
 			<key>pfm_app_min</key>
@@ -2139,7 +2187,7 @@ Starting in Google Chrome 78, this policy will be ignored and treated as disable
 			<string>Allow insecure extension updates</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<!-- END ContentSettings/Extensions -->
 		<!-- START ContentSettings/GoogleCast -->
 		<dict>
@@ -2311,6 +2359,22 @@ If you disable this setting or leave it not set, the generated Kerberos SPN will
 		<!-- START ContentSettings/LegacyBrowserSupport -->
 		<dict>
 			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>If you don't configure this policy, NTLMv2 is enabled by default.</string>
+			<key>pfm_description_reference</key>
+			<string>All recent versions of Samba and Windows servers support NTLMv2. You should only disable NTLMv2 to address issues with backwards compatibility as it reduces the security of authentication.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#ntlmv2enabled</string>
+			<key>pfm_name</key>
+			<string>NtlmV2Enabled</string>
+			<key>pfm_title</key>
+			<string>Enable NTLMv2 authentication</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<!-- <dict>
+			<key>pfm_app_min</key>
 			<string>73</string>
 			<key>pfm_description</key>
 			<string>This policy controls whether to enable Legacy Browser Support. When this policy is set to true, Chrome will attempt to launch some URLs in an alternate browser.</string>
@@ -2330,8 +2394,8 @@ This feature is a replacement for the 'Legacy Browser Support' extension. Config
 			<string>Browser Switcher Enabled</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>71</string>
 			<key>pfm_description</key>
@@ -2367,8 +2431,8 @@ Environment variables are expanded. On Windows, %ABC% is replaced with the value
 			<string>Alternative Browser Parameters</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>71</string>
 			<key>pfm_description</key>
@@ -2400,8 +2464,8 @@ When this policy is set to a file path, that file is used as an executable file.
 			<string>Alternative Browser Path</string>
 			<key>pfm_type</key>
 			<string>string</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>74</string>
 			<key>pfm_description</key>
@@ -2422,8 +2486,8 @@ When this policy is set to a number, Chrome shows a message for that many millis
 			<string>integer</string>
 			<key>pfm_value_unit</key>
 			<string>milliseconds</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>74</string>
 			<key>pfm_description</key>
@@ -2444,8 +2508,8 @@ When this policy is set to false, Chrome will close the tab after switching to a
 			<string>Keep Chrome open when the last tab switches to another browser</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>71</string>
 			<key>pfm_description</key>
@@ -2483,8 +2547,8 @@ If rules contradict eachother, Google Chrome uses the most specific rule.</strin
 			<string>Browser Switcher URL List</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>71</string>
 			<key>pfm_description</key>
@@ -2520,8 +2584,8 @@ Unlike BrowserSwitcherUrlList, rules apply to both directions. That is, when the
 			<string>Browser Switcher URL Greylist</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>77</string>
 			<key>pfm_description</key>
@@ -2552,8 +2616,8 @@ For more information on Internet Explorer's SiteList policy: https://docs.micros
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>http://example.com/greylist.xml</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>72</string>
 			<key>pfm_description</key>
@@ -2582,10 +2646,10 @@ For more information on Internet Explorer's SiteList policy: https://docs.micros
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>http://example.com/sitelist.xml</string>
-		</dict>
+		</dict> -->
 		<!-- END ContentSettings/LegacyBrowserSupport -->
 		<!-- START ContentSettings/Misc -->
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>65</string>
 			<key>pfm_description</key>
@@ -2605,8 +2669,8 @@ If this policy is left not set, True will be used.</string>
 			<string>Abusive Experience Intervention Enforce</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>65</string>
 			<key>pfm_description</key>
@@ -2638,7 +2702,7 @@ If this policy is left not set, 2 will be used.</string>
 			<string>Ads setting for sites with intrusive ads</string>
 			<key>pfm_type</key>
 			<string>integer</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>57</string>
@@ -2661,7 +2725,7 @@ If this setting is disabled, browsing and download history cannot be deleted.</s
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>48</string>
 			<key>pfm_description</key>
@@ -2678,7 +2742,7 @@ If this policy is set to False, users will not be able to play the dinosaur east
 			<string>Allow Dinosaur Easter Egg Game</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>12</string>
@@ -2701,7 +2765,7 @@ If this setting is not set, users can open file selection dialogs as normal.</st
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>12</string>
 			<key>pfm_description</key>
@@ -2720,7 +2784,7 @@ If this setting is not set, users will be asked for permission to run outdated p
 			<string>Allow running plugins that are outdated</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_deprecated</key>
 			<string>82</string>
@@ -2746,6 +2810,53 @@ This policy will be removed in Chrome 82.</string>
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>This policy lets you specify that a page can send synchronous XHR requests during page dismissal.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this policy, pages can send synchronous XHR requests during page dismissal.
+
+If you disable this policy or don't configure this policy, pages aren't allowed to send synchronous XHR requests during page dismissal.
+
+This policy is temporary and will be removed in a future release.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#allowsyncxhrinpagedismissal</string>
+			<key>pfm_name</key>
+			<string>AllowSyncXHRInPageDismissal</string>
+			<key>pfm_title</key>
+			<string>Allow pages to send synchronous XHR requests during page dismissal</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>78</string>
+			<key>pfm_description</key>
+			<string>Configure the list of URL patterns that are excluded from tracking prevention.</string>
+			<key>pfm_description_reference</key>
+			<string>If you configure this policy, the list of configured URL patterns is excluded from tracking prevention.
+
+	If you don't configure this policy, the global default value from the "Block tracking of users' web-browsing activity" policy (if set) or the user's personal configuration is used for all sites.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#allowtrackingforurls</string>
+			<key>pfm_name</key>
+			<string>AllowTrackingForUrls</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>example.com</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Configure tracking prevention exceptions for specific sites</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>51</string>
 			<key>pfm_description</key>
@@ -2780,7 +2891,7 @@ Users cannot change or override this setting.</string>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>managedchrome.com,example.com</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>8</string>
@@ -2875,6 +2986,40 @@ NOTE: Until version 45, this policy was only supported in Kiosk mode.</string>
 			<string>array</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>If you enable this policy, Microsoft Edge automatically imports all supported datatypes and settings from either the default browser or another specified browser. This also forces Microsoft Edge to skip the import section of the first-run experience.</string>
+			<key>pfm_description_reference</key>
+			<string>0 - Automatically imports all supported datatypes and settings from the default browser
+1 - Automatically imports all supported datatypes and settings from Internet Explorer
+2 - Automatically imports all supported datatypes and settings from Google Chrome
+3 - Automatically imports all supported datatypes and settings from Safari
+4 - Disables automatic import, and the import section of the first-run experience is skipped</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#autoimportatfirstrun</string>
+			<key>pfm_name</key>
+			<string>AutoImportAtFirstRun</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Import all supported datatypes and settings from the default browser</string>
+				<string>Import all supported datatypes and settings from Google Chrome</string>
+				<string>Import all supported datatypes and settings from Safari</string>
+				<string>Disable automatic import &amp; skip import section of the first-run experience</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Automatically import browser data and settings at first run</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>70</string>
 			<key>pfm_app_min</key>
@@ -2897,7 +3042,7 @@ If you enable this setting or do not set a value, AutoFill will remain under the
 			<string>Enable AutoFill</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>69</string>
@@ -2998,7 +3143,7 @@ If this policy is set to false, Google Chrome will not allow guest profiles to b
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>77</string>
 			<key>pfm_description</key>
@@ -3015,7 +3160,7 @@ If this policy is set to disabled or not set or browser guest mode is disabled b
 			<string>Force guest mode in browser</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
@@ -3196,6 +3341,28 @@ If this policy is not set, any certificate that is required to be disclosed via 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>78</string>
+			<key>pfm_description</key>
+			<string>If you enable this policy, all browsing data is deleted each time Microsoft Edge closes.</string>
+			<key>pfm_description_reference</key>
+			<string>Microsoft Edge doesn't clear the browsing data by default when it closes. Browsing data includes information entered in forms, passwords, and even the websites visited.
+
+If you enable this policy, all browsing data is deleted each time Microsoft Edge closes.
+
+If you disable or don't configure this policy, users can configure the Clear browsing data option in Settings.</string>
+			<key>pfm_note</key>
+			<string>If you enable this policy, don't enable the AllowDeletingBrowserHistory policy, because they both deal with deleting data. If you enable both, this policy takes precedence and deletes all data when Microsoft Edge closes, regardless of how you configured AllowDeletingBrowserHistory.</string>
+			<key>pfm_documentation_url</key>
+		 	<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#clearbrowsingdataonexit</string>
+			<key>pfm_name</key>
+			<string>ClearBrowsingDataOnExit</string>
+			<key>pfm_title</key>
+			<string>Clear browsing data when Microsoft Edge closes</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<!-- <dict>
+			<key>pfm_app_min</key>
 			<string>72</string>
 			<key>pfm_description</key>
 			<string>If this policy is set, Google Chrome will try to register itself and apply associated cloud policy for all profiles.</string>
@@ -3213,8 +3380,8 @@ The value of this policy is an Enrollment token that can be retrieved from the G
 			<string>Cloud Management Enrollment Token</string>
 			<key>pfm_type</key>
 			<string>string</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>72</string>
 			<key>pfm_description</key>
@@ -3233,8 +3400,8 @@ This policy is used by machine scope cloud policy enrollment on desktop and can 
 			<string>Make cloud managment enrollment mandatory</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>75</string>
 			<key>pfm_description</key>
@@ -3253,7 +3420,7 @@ This policy is only available as a mandatory machine platform policy and it only
 			<string>Cloud Policy Overrides Platform Policy</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>76</string>
@@ -3298,6 +3465,86 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Specify whether to send Do Not Track requests to websites that ask for tracking info.</string>
+			<key>pfm_description_reference</key>
+			<string>Do Not Track requests let the websites you visit know that you don't want your browsing activity to be tracked. By default, Microsoft Edge doesn't send Do Not Track requests, but users can turn on this feature to send them.
+
+If you enable this policy, Do Not Track requests are always sent to websites asking for tracking info.
+
+If you disable this policy, requests are never sent.
+
+If you don't configure this policy, users can choose whether to send these requests.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#configuredonottrack</string>
+			<key>pfm_name</key>
+			<string>ConfigureDoNotTrack</string>
+			<key>pfm_title</key>
+			<string>Configure Do Not Track</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>If you enable or don't configure this policy, web-based applications that use the SpeechSynthesis API can use Online Text to Speech voice fonts.</string>
+			<key>pfm_description_reference</key>
+			<string>Set whether the browser can leverage Online Text to Speech voice fonts, part of Azure Cognitive Services. These voice fonts are higher quality than the pre-installed system voice fonts.
+
+If you disable this policy, the voice fonts aren't available.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#configureonlinetexttospeech</string>
+			<key>pfm_name</key>
+			<string>ConfigureOnlineTextToSpeech</string>
+			<key>pfm_title</key>
+			<string>Configure Online Text To Speech</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>Specify a link for the Help menu or the F1 key.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this policy, an admin can specify a link for the Help menu or the F1 key.
+
+If you disable or don't configure this policy, the default link for the Help menu or the F1 key is used.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#customhelplink</string>
+			<key>pfm_name</key>
+			<string>CustomHelpLink</string>
+			<key>pfm_title</key>
+			<string>Specify custom help link</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>https://example.com</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>This policy configures a local switch that can be used to disable DNS interception checks. These checks attempt to discover whether the browser is behind a proxy that redirects unknown host names.</string>
+			<key>pfm_description_reference</key>
+			<string>This detection might not be necessary in an enterprise environment where the network configuration is known. It can be disabled to avoid additional DNS and HTTP traffic on start-up and each DNS configuration change.
+
+If you enable or don’t set this policy, the DNS interception checks are performed.
+
+If you disable this policy, DNS interception checks aren’t performed.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#dnsinterceptionchecksenabled</string>
+			<key>pfm_name</key>
+			<string>DNSInterceptionChecksEnabled</string>
+			<key>pfm_title</key>
+			<string>DNS interception checks enabled</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>11</string>
 			<key>pfm_description</key>
 			<string>Configures the default browser checks in Google Chrome and prevents users from changing them.</string>
@@ -3318,7 +3565,7 @@ If this setting is not set, Google Chrome will allow the user to control whether
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>64</string>
 			<key>pfm_description</key>
@@ -3343,7 +3590,7 @@ See https://www.chromium.org/administrators/policy-list-3/user-data-directory-va
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>/Users/${user_name}/Downloads</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>68</string>
@@ -3399,7 +3646,7 @@ If HardwareAccelerationModeEnabled is set to false, Disable3DAPIs is ignored and
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>22</string>
 			<key>pfm_description</key>
@@ -3418,7 +3665,7 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 			<string>Disable proceeding from the Safe Browsing warning page</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>22</string>
@@ -3437,8 +3684,7 @@ If disabled or not specified, taking screenshots is allowed.</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>10</string>
 			<key>pfm_app_min</key>
@@ -3474,9 +3720,8 @@ If this policy is left not set the user can use any plugin installed on the syst
 			<string>Disabled Plugins</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>12</string>
 			<key>pfm_app_min</key>
@@ -3514,9 +3759,8 @@ If this policy is left not set any plugin that matches the patterns in the 'Disa
 			<string>Disabled Plugins Exceptions</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>13</string>
 			<key>pfm_app_min</key>
@@ -3550,7 +3794,7 @@ If this policy is left not set or the list is empty all schemes will be accessib
 			<string>Disabled URL Protocol Schemes</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>13</string>
@@ -3676,6 +3920,24 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 			<string>integer</string>
 		</dict>
 		<dict>
+		  <key>pfm_app_min</key>
+		  <string>78</string>
+		  <key>pfm_description</key>
+		  <string>Lets you allow users to access the Collections feature, where they can collect, organize, share, and export content more efficiently and with Office integration.</string>
+		  <key>pfm_description_reference</key>
+		  <string>If you enable or don't configure this policy, users can access and use the Collections feature in Microsoft Edge.
+
+		If you disable this policy, users can't access and use Collections in Microsoft Edge.</string>
+		  <key>pfm_documentation_url</key>
+		  <string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#edgecollectionsenabled</string>
+		  <key>pfm_name</key>
+		  <string>EdgeCollectionsEnabled</string>
+		  <key>pfm_title</key>
+		  <string>Enable the Collections feature</string>
+		  <key>pfm_type</key>
+		  <string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>12</string>
 			<key>pfm_description</key>
@@ -3727,6 +3989,32 @@ While the policy itself is supported on the above platforms, the feature it is e
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>If you enable this policy, the list of Domain Actions will continue to be downloaded from the Experimentation and Configuration Service.</string>
+			<key>pfm_description_reference</key>
+			<string>In Microsoft Edge, Domain Actions represent a series of compatibility features that help the browser work correctly on the web.
+
+Microsoft keeps a list of actions to take on certain domains for compatibility reasons. For example, the browser may override the User Agent string on a website if that website is broken due to the new User Agent string on Microsoft Edge. Each of these actions is intended to be temporary while Microsoft tries to resolve the issue with the site owner.
+
+When the browser starts up and then periodically afterwards, the browser will contact the Experimentation and Configuration Service that contains the most up to date list of compatibility actions to perform. This list is saved locally after it is first retrieved so that subsequent requests will only update the list if the server's copy has changed.
+
+If you enable this policy, the list of Domain Actions will continue to be downloaded from the Experimentation and Configuration Service.
+
+If you disable this policy, the list of Domain Actions will no longer be downloaded from the Experimentation and Configuration Service.
+
+If you don't configure this policy, the list of Domain Actions will continue to be downloaded from the Experimentation and Configuration Service.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#enabledomainactionsdownload</string>
+			<key>pfm_name</key>
+			<string>EnableDomainActionsDownload</string>
+			<key>pfm_title</key>
+			<string>Enable Domain Actions Download from Microsoft</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>19</string>
 			<key>pfm_description</key>
 			<string>In light of the fact that soft-fail, online revocation checks provide no effective security benefit, they are disabled by default in Google Chrome version 19 and later. By setting this policy to true, the previous behavior is restored and online OCSP/CRL checks will be performed.</string>
@@ -3743,8 +4031,7 @@ If the policy is not set, or is set to false, then Google Chrome will not perfor
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>15</string>
 			<key>pfm_app_min</key>
@@ -3773,7 +4060,7 @@ If this policy is left not set the user can disable any plugin installed on the 
 			<string>Enabled Plugins</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>71</string>
@@ -3793,6 +4080,26 @@ If this policy is left not set the user can disable any plugin installed on the 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>If you set to True, when an external protocol confirmation prompt is shown, the user can select "Always open". The user won’t get any future confirmation prompts for this protocol.</string>
+			<key>pfm_description_reference</key>
+			<string>This policy controls whether the "Always open" checkbox is shown on external protocol launch confirmation prompts.
+
+If you set this policy to True, when an external protocol confirmation prompt is shown, the user can select "Always open". The user won’t get any future confirmation prompts for this protocol.
+
+If you set this policy to False, or the policy is unset, the "Always open" checkbox isn’t displayed. The user will be prompted for confirmation every time an external protocol is invoked.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#externalprotocoldialogshowalwaysopencheckbox</string>
+			<key>pfm_name</key>
+			<string>ExternalProtocolDialogShowAlwaysOpenCheckbox</string>
+			<key>pfm_title</key>
+			<string>Show an "Always open" checkbox in external protocol dialog</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>70</string>
 			<key>pfm_app_min</key>
@@ -3813,7 +4120,7 @@ If this policy is set to false or not configured, user can use the browser witho
 			<string>Enable force sign in for Google Chrome</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>32</string>
@@ -3876,8 +4183,7 @@ If you disable this setting or do not set a value, SafeSearch in Google Search i
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>30</string>
 			<key>pfm_app_min</key>
@@ -3900,7 +4206,7 @@ If you disable this setting or do not set a value, SafeSearch in Google Search a
 			<string>Force SafeSearch</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>55</string>
@@ -3938,8 +4244,7 @@ If this setting is set to Off or no value is set, Restricted Mode on YouTube is 
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>45</string>
 			<key>pfm_app_min</key>
@@ -3964,6 +4269,55 @@ If this setting is disabled or no value is set, Restricted Mode on YouTube is no
 			<string>Force YouTube Safety Mode</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict> -->
+		<dict>
+			<key>pfm_app_min</key>
+			<string>78</string>
+			<key>pfm_description</key>
+			<string>If you enable this policy, the top auto-suggest result in the address bar suggestion list will navigate to intranet sites if the text entered in the address bar is a single word without punctuation.</string>
+			<key>pfm_description_reference</key>
+			<string>Default navigation when typing a single word without punctuation will conduct a navigation to an intranet site matching the entered text.
+
+If you enable this policy, the second auto-suggest result in the address bar suggestion list will conduct a web search exactly as it was entered, provided that this text is a single word without punctuation. The default search provider will be used unless a policy to prevent web search is also enabled.
+
+Two effects of enabling this policy are:
+
+Navigation to sites in response to single word queries that would typically resolve to a history item will no longer happen. Instead, the browser will attempt navigate to internal sites that may not exist in an organization’s intranet. This will result in a 404 error.
+
+Popular, single-word search terms will require manual selection of search suggestions to properly conduct a search.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#gotointranetsiteforsinglewordentryinaddressbar</string>
+			<key>pfm_name</key>
+			<string>GoToIntranetSiteForSingleWordEntryInAddressBar</string>
+			<key>pfm_title</key>
+			<string>Force direct intranet site navigation instead of searching on single word entries in the Address Bar</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>Hostnames specified in this list will be exempt from the HSTS policy check that could potentially upgrade requests from "http://" to "https://". Only single-label hostnames are allowed in this policy.</string>
+			<key>pfm_description_reference</key>
+			<string>Hostnames must be canonicalized. Any IDNs must be converted to their A-label format, and all ASCII letters must be lowercase. This policy only applies to the specific hostnames specified; it doesn't apply to subdomains of the names in the list.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#hstspolicybypasslist</string>
+			<key>pfm_name</key>
+			<string>HSTSPolicyBypassList</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>example</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Configure the list of names that will bypass the HSTS policy check</string>
+			<key>pfm_type</key>
+			<string>array</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -3985,6 +4339,22 @@ If this policy is set to false, hardware acceleration will be disabled.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>If you enable this policy, the First-run experience and the splash screen will not be shown to users when they run Microsoft Edge for the first time.</string>
+			<key>pfm_description_reference</key>
+			<string>If you disable or don't configure this policy, the First-run experience and the Splash screen will be shown.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#disable3dapis</string>
+			<key>pfm_name</key>
+			<string>HideFirstRunExperience</string>
+			<key>pfm_title</key>
+			<string>Hide the First-run experience and splash screen</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<!-- <dict>
+			<key>pfm_app_min</key>
 			<string>26</string>
 			<key>pfm_description</key>
 			<string>Hide the Chrome Web Store app and footer link from the New Tab Page and Google Chrome OS app launcher.</string>
@@ -4002,8 +4372,8 @@ When this policy is set to false or is not configured, the icons are visible.</s
 			<string>Hide the web store from the New Tab Page and app launcher</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>78</string>
 			<key>pfm_app_min</key>
@@ -4026,7 +4396,7 @@ If this policy is not set, HTTP/0.9 will be disabled on non-default ports.</stri
 			<string>Enable HTTP/0.9 support on non-default ports</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>39</string>
@@ -4044,6 +4414,30 @@ If it is not set, the user may be asked whether to import, or importing may happ
 			<string>ImportAutofillFormData</string>
 			<key>pfm_title</key>
 			<string>Import autofill form data from default browser on first run</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>78</string>
+			<key>pfm_description</key>
+			<string>Allows users to import browser settings from another browser into Microsoft Edge.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this policy, the Browser settings check box is automatically selected in the Import browser data dialog box.
+
+If you disable this policy, browser settings aren't imported at first run, and users can’t import them manually.
+
+If you don’t configure this policy, browser settings are imported at first run, and users can choose whether to import them manually during later browsing sessions.
+
+You can also set this policy as a recommendation. This means that Microsoft Edge imports the settings on first run, but users can select or clear the browser settings option during manual import.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#importbrowsersettings</string>
+			<key>pfm_name</key>
+			<string>ImportBrowserSettings</string>
+			<key>pfm_note</key>
+			<string>This policy currently manages importing Google Chrome</string>
+			<key>pfm_title</key>
+			<string>Allow importing of browser settings</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -4110,6 +4504,56 @@ If it is not set, the user may be asked whether to import, or importing may happ
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>Allows users to import open and pinned tabs from another browser into Microsoft Edge.</string>
+			<key>pfm_description_reference</key>
+			<string>Allows users to import open and pinned tabs from another browser into Microsoft Edge.
+
+If you enable this policy, the Open tabs check box is automatically selected in the Import browser data dialog box.
+
+If you disable this policy, open tabs aren't imported at first run, and users can't import them manually.
+
+If you don't configure this policy, open tabs are imported at first run, and users can choose whether to import them manually during later browsing sessions.
+
+You can also set this policy as a recommendation. This means that Microsoft Edge imports open tabs on first run, but users can select or clear the Open tabs option during manual import.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#importopentabs</string>
+			<key>pfm_name</key>
+			<string>ImportOpenTabs</string>
+			<key>pfm_note</key>
+			<string>This policy currently manages importing Google Chrome</string>
+			<key>pfm_title</key>
+			<string>Allow importing of open tabs</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Allows users to import payment info from another browser into Microsoft Edge.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this policy, the payment info check box is automatically selected in the Import browser data dialog box.
+
+If you disable this policy, payment info isn’t imported at first run, and users can’t import it manually.
+
+If you don’t configure this policy, payment info is imported at first run, and users can choose whether to import it manually during later browsing sessions.
+
+You can also set this policy as a recommendation. This means that Microsoft Edge imports payment info on first run, but users can select or clear the payment info option during manual import.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#importpaymentinfo</string>
+			<key>pfm_name</key>
+			<string>ImportPaymentInfo</string>
+			<key>pfm_note</key>
+			<string>This policy currently manages importing Google Chrome</string>
+			<key>pfm_title</key>
+			<string>Allow importing of payment info</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>15</string>
 			<key>pfm_description</key>
 			<string>This policy forces the saved passwords to be imported from the previous default browser if enabled. If enabled, this policy also affects the import dialog.</string>
@@ -4148,8 +4592,7 @@ If it is not set, the user may be asked whether to import, or importing may happ
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>15</string>
 			<key>pfm_app_min</key>
@@ -4174,7 +4617,7 @@ If this policy is left not set, this will be enabled and the user will be able t
 			<string>Enable Incognito</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>14</string>
@@ -4231,8 +4674,7 @@ NOTE: This policy does not apply on Android. To enable IsolateOrigins on Android
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>15</string>
 			<key>pfm_app_min</key>
@@ -4257,8 +4699,8 @@ If this setting is enabled or not set, web pages can use JavaScript but the user
 			<string>Javascript Enabled</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>72</string>
 			<key>pfm_app_min</key>
@@ -4277,7 +4719,7 @@ If this setting is enabled or not set, web pages can use JavaScript but the user
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>ex. 37185d02-e055-11e7-80c1-9a214cf093ae</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>37</string>
@@ -4411,7 +4853,7 @@ If this policy is left not set the default value will be used which is 32.</stri
 			<key>pfm_value_unit</key>
 			<string>connections</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>30</string>
 			<key>pfm_default</key>
@@ -4438,7 +4880,7 @@ Leaving this policy not set will make Google Chrome use the default value of 500
 			<string>integer</string>
 			<key>pfm_value_unit</key>
 			<string>milliseconds</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>67</string>
@@ -4483,6 +4925,80 @@ This policy is not available on Windows instances that are not joined to a Micro
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>81</string>
+			<key>pfm_description</key>
+			<string>Enables the display of relevant MSB suggestions in omnibox when user types a search string in the addressbar</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable or don't configure this policy, users may see business results in in Microsoft Edge omnibox, if proper authenticated.
+
+If you disable this policy, users can't see business results in Microsoft Edge omnibox.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#omniboxmsbproviderenabled</string>
+			<key>pfm_name</key>
+			<string>OmniboxMSBProviderEnabled</string>
+			<key>pfm_title</key>
+			<string>Enable Microsoft Search for Business provider in omnibox</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Allows you to set whether websites can check if the user has payment methods saved.</string>
+			<key>pfm_description_reference</key>
+			<string>If you disable this policy, websites that use PaymentRequest.canMakePayment or PaymentRequest.hasEnrolledInstrument API will be informed that no payment methods are available.
+
+If you enable this policy or don't set this policy, websites can check if the user has payment methods saved.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#paymentmethodqueryenabled</string>
+			<key>pfm_name</key>
+			<string>PaymentMethodQueryEnabled</string>
+			<key>pfm_title</key>
+			<string>Allow websites to query for available payment methods</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>This policy prevents Microsoft from collecting a user's Microsoft Edge browsing history to be used for personalizing advertising, search, news and other Microsoft services.</string>
+			<key>pfm_description_reference</key>
+			<string>This setting is only available for users with a Microsoft account. This setting is not available for child accounts or enterprise accounts.
+
+If you disable this policy, users can't change or override the setting. If this policy is enabled or not configured, Microsoft Edge will default to the user’s preference.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#personalizationreportingenabled</string>
+			<key>pfm_name</key>
+			<string>PersonalizationReportingEnabled</string>
+			<key>pfm_title</key>
+			<string>Allow personalization of ads, search and news by sending browsing history to Microsoft</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Lets you configure whether to turn on Proactive Authentication.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this policy, Microsoft Edge tries to proactively authenticate the signed-in user with Microsoft services. At regular intervals, Microsoft Edge checks with an online service for an updated manifest that contains the configuration that governs how to do this.
+
+If you disable this policy, Microsoft Edge doesn't try to proactively authenticate the signed-in user with Microsoft services. Microsoft Edge no longer checks with an online service for an updated manifest that contains the configuration for doing this.
+
+If you don't configure this policy, Proactive Authentication is turned on.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#proactiveauthenabled</string>
+			<key>pfm_name</key>
+			<string>ProactiveAuthEnabled</string>
+			<key>pfm_title</key>
+			<string>Enable Proactive Authentication</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>38</string>
 			<key>pfm_description</key>
 			<string>(Deprecated in 50, removed in 52. After 52, if value 1 is set, it will be treated as 0 - predict network actions on any network connection.)
@@ -4520,7 +5036,7 @@ If this policy is left not set, network prediction will be enabled but the user 
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>69</string>
 			<key>pfm_description</key>
@@ -4550,8 +5066,8 @@ For more information on secure contexts, see https://www.w3.org/TR/secure-contex
 			<string>Origins or hostname patterns to be treated as secure context.</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>76</string>
 			<key>pfm_description</key>
@@ -4597,8 +5113,8 @@ If a policy is not in the list, in case there is any conflict between sources, s
 			<string>Allow merging dictionary policies from different sources</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>75</string>
 			<key>pfm_description</key>
@@ -4634,7 +5150,7 @@ If a policy is not in the list, in case there is any conflict between sources, s
 			<string>Allow merging list policies from different sources</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>69</string>
@@ -4872,6 +5388,26 @@ If not set, the default period of 345600000 milliseconds (four days) is used for
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Allow Microsoft Edge to issue a dataless connection to a web service to probe networks for connectivity in cases like hotel and airport Wi-Fi.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this policy, a web service is used for network connectivity tests.
+
+If you disable this policy, Microsoft Edge uses native APIs to try to resolve network connectivity and navigation issues.
+
+If you don't configure this policy, Microsoft Edge respects the user preference that's set under Services at edge://settings/privacy. Specifically, there's a Use a web service to help resolve navigation errors toggle, which the user can switch on or off. Be aware that if you have enabled this policy (ResolveNavigationErrorsUseWebService), the Use a web service to help resolve navigation errors setting is turned on, but the user can't change the setting by using the toggle. If you have disabled this policy, the Use a web service to help resolve navigation errors setting is turned off, and the user can't change the setting by using the toggle.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#resolvenavigationerrorsusewebservice</string>
+			<key>pfm_name</key>
+			<string>ResolveNavigationErrorsUseWebService</string>
+			<key>pfm_title</key>
+			<string>Enable resolution of navigation errors using a web service</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>21</string>
 			<key>pfm_description</key>
 			<string>Contains a regular expression which is used to determine which users can sign in to Google Chrome.</string>
@@ -4963,7 +5499,7 @@ Otherwise it may be set to one of the following values: "tls1", "tls1.1" or "tls
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>69</string>
 			<key>pfm_description</key>
@@ -4996,7 +5532,7 @@ When this policy is set to "Filter top level sites for adult content", sites cla
 			<string>Control SafeSites adult content filtering.</string>
 			<key>pfm_type</key>
 			<string>integer</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>8</string>
@@ -5068,6 +5604,42 @@ URLs (like https://example.com/some/path) will only match as U2F appIDs. Domains
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>This policy enables sending info about websites visited in Microsoft Edge to Microsoft to improve services like search.</string>
+			<key>pfm_description_reference</key>
+			<string>Enable this policy to send info about websites visited in Microsoft Edge to Microsoft. Disable this policy to not send info about websites visited in Microsoft Edge to Microsoft. In both cases, users can't change or override the setting.
+
+This policy controls sending info about websites visited. If this policy is not configured, Microsoft Edge will default to the user’s preference.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#sendsiteinfotoimproveservices</string>
+			<key>pfm_name</key>
+			<string>SendSiteInfoToImproveServices</string>
+			<key>pfm_title</key>
+			<string>Send site information to improve Microsoft services</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Specifies whether to include a shortcut to Office.com in the favorites bar. For users signed into Microsoft Edge the shortcut takes users to their Microsoft Office apps and docs.</string>
+			<key>pfm_description_reference</key>
+			<string>If this policy is enabled or not configure, users can choose whether to see the shortcut by changing the toggle in the favorites bar context menu.
+
+If the policy is disabled, the shortcut won't be shown.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#showofficeshortcutinfavoritesbar</string>
+			<key>pfm_name</key>
+			<string>ShowOfficeShortcutInFavoritesBar</string>
+			<key>pfm_title</key>
+			<string>Show Microsoft Office shortcut in favorites bar</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<!-- <dict>
+			<key>pfm_app_min</key>
 			<string>37</string>
 			<key>pfm_description</key>
 			<string>Enables or disables the apps shortcut in the bookmark bar.</string>
@@ -5085,7 +5657,7 @@ If this policy is configured then the user can't change it, and the apps shortcu
 			<string>Show the apps shortcut in the bookmark bar</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>75</string>
@@ -5106,8 +5678,7 @@ If this policy is set to Disabled, Signed HTTP Exchanges cannot be loaded.</stri
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>30</string>
 			<key>pfm_app_min</key>
@@ -5130,7 +5701,7 @@ If you set this policy, you can configure whether a user is allowed to sign in t
 			<string>Allow sign in</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>63</string>
@@ -5209,6 +5780,26 @@ This policy should not be enabled when RoamingProfileSupportEnabled policy is se
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>Controls whether Microsoft Edge can freeze tabs that are in the background for at least 5 minutes.</string>
+			<key>pfm_description_reference</key>
+			<string>Tab freezing reduces CPU, battery, and memory usage. Microsoft Edge uses heuristics to avoid freezing tabs that do useful work in the background, such as display notifications, play sound, and stream video.
+
+If you enable or don't configure this policy, tabs that have been in the background for at least 5 minutes might be frozen.
+
+If you disable this policy, no tabs will be frozen.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#tabfreezingenabled</string>
+			<key>pfm_name</key>
+			<string>TabFreezingEnabled</string>
+			<key>pfm_title</key>
+			<string>Allow freezing of background tabs</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>52</string>
 			<key>pfm_description</key>
 			<string>If set to false, the 'End process' button is disabled in the Task Manager.</string>
@@ -5224,6 +5815,28 @@ If set to true or not configured, the user can end processes in the Task Manager
 			<string>Enable ending processes in Task Manager</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Configures the amount of memory that a single Microsoft Edge instance can use before tabs start getting discarded to save memory. The memory used by the tab will be freed and the tab will have to be reloaded when switched to.</string>
+			<key>pfm_description_reference</key>
+			<string>If you enable this policy, the browser will start to discard tabs to save memory once the limitation is exceeded. However, there is no guarantee that the browser is always running under the limit. Any value under 1024 will be rounded up to 1024.
+
+If you don't set this policy, the browser will only attempt to save memory when it has detected that the amount of physical memory on its machine is low.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#totalmemorylimitmb</string>
+			<key>pfm_name</key>
+			<string>TotalMemoryLimitMb</string>
+			<key>pfm_title</key>
+			<string>Set limit on megabytes of memory a single Microsoft Edge instance can use.</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+			<key>pfm_value_placeholder</key>
+			<string>1024</string>
+			<key>pfm_value_unit</key>
+			<string>bytes</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -5319,7 +5932,7 @@ If this policy is not set there will be no exceptions to the blacklist from the 
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>69</string>
 			<key>pfm_app_min</key>
@@ -5357,8 +5970,8 @@ For more information on secure contexts, see https://www.w3.org/TR/secure-contex
 			<string>Origins or hostname patterns for which restrictions on insecure origins should not apply</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>69</string>
 			<key>pfm_description</key>
@@ -5381,7 +5994,7 @@ If this policy is left not set, URL-keyed anonymized data collection will be ena
 			<string>Enable URL-keyed anonymized data collection</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>77</string>
@@ -5582,7 +6195,7 @@ If the policy is enabled, WebDriver will be able to override incomaptible polici
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>70</string>
 			<key>pfm_description</key>
@@ -5609,7 +6222,7 @@ Google may associate these logs, by means of a session ID, with other logs colle
 			<string>Allow collection of WebRTC event logs from Google services</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>54</string>
@@ -5739,7 +6352,7 @@ If this policy is enabled or disabled, users cannot change or override it in Goo
 		</dict>
 		<!-- END PasswordManager -->
 		<!-- START Printing -->
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>17</string>
 			<key>pfm_description</key>
@@ -5758,8 +6371,8 @@ If this setting is disabled, users cannot enable the proxy, and the machine will
 			<string>Enable Google Cloud Print proxy</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>17</string>
 			<key>pfm_description</key>
@@ -5778,7 +6391,7 @@ If this setting is disabled, users cannot print to Google Cloud Print from the G
 			<string>Enable submission of documents to Google Cloud Print</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>48</string>
@@ -5795,22 +6408,22 @@ If this policy is not set or matching printer is not found within the timeout, t
 
 The value is parsed as JSON object, conforming to the following schema:
 {
-  "type": "object",
-  "properties": {
-    "kind": {
-      "description": "Whether to limit the search of the matching printer to a specific set of printers.",
-      "type": "string",
-      "enum": [ "local", "cloud" ]
-    },
-    "idPattern": {
-      "description": "Regular expression to match printer id.",
-      "type": "string"
-    },
-    "namePattern": {
-      "description": "Regular expression to match printer display name.",
-      "type": "string"
-    }
-  }
+	"type": "object",
+	"properties": {
+		"kind": {
+			"description": "Whether to limit the search of the matching printer to a specific set of printers.",
+			"type": "string",
+			"enum": [ "local", "cloud" ]
+		},
+		"idPattern": {
+			"description": "Regular expression to match printer id.",
+			"type": "string"
+		},
+		"namePattern": {
+			"description": "Regular expression to match printer display name.",
+			"type": "string"
+		}
+	}
 }
 
 Printers connected to Google Cloud Print are considered "cloud", the rest of the printers are classified as "local".
@@ -5825,7 +6438,7 @@ Regular expression patterns must follow the JavaScript RegExp syntax and matches
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>18</string>
 			<key>pfm_description</key>
@@ -5844,7 +6457,7 @@ If this policy is not set or is set to false, print commands trigger the print p
 			<string>Disable Print Preview</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>70</string>
@@ -5884,6 +6497,22 @@ If this setting is disabled, users cannot print from Google Chrome. Printing is 
 			<string>PrintingEnabled</string>
 			<key>pfm_title</key>
 			<string>Enable printing</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>If you enable this policy, Microsoft Edge opens the system print dialog instead of the built-in print preview when a user prints a page.</string>
+			<key>pfm_description_reference</key>
+			<string>If you don't configure or disable this policy, print commands trigger the Microsoft Edge print preview screen.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#usesystemprintdialog</string>
+			<key>pfm_name</key>
+			<string>UseSystemPrintDialog</string>
+			<key>pfm_title</key>
+			<string>Print using system print dialog</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -6090,7 +6719,7 @@ Leaving this policy not set will allow the users to choose the proxy settings on
 		</dict>
 		<!-- END ProxyServer -->
 		<!-- START RemoteAccess -->
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>30</string>
 			<key>pfm_description</key>
@@ -6107,8 +6736,8 @@ If this setting is disabled, then this feature will not be available.</string>
 			<string>Enable or disable PIN-less authentication for remote access hosts</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>35</string>
 			<key>pfm_description</key>
@@ -6125,8 +6754,8 @@ If this setting is disabled or not configured, gnubby authentication requests wi
 			<string>Allow gnubby authentication for remote access hosts</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>36</string>
 			<key>pfm_description</key>
@@ -6147,8 +6776,8 @@ If this policy is left not set the setting will be enabled.</string>
 			<string>Enable the use of relay servers by the remote access host</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>60</string>
 			<key>pfm_app_min</key>
@@ -6174,8 +6803,8 @@ If this policy is left not set the setting will be enabled.</string>
 			<string>Configure the required domain names for remote access clients</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
 			<key>pfm_description</key>
@@ -6207,8 +6836,8 @@ See also RemoteAccessHostDomainList.</string>
 			<string>Configure the required domain names for remote access clients</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>60</string>
 			<key>pfm_app_min</key>
@@ -6234,8 +6863,8 @@ See also RemoteAccessHostDomainList.</string>
 			<string>Configure the required domain names for remote access hosts</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
 			<key>pfm_description</key>
@@ -6265,8 +6894,8 @@ See also RemoteAccessHostClientDomainList.</string>
 			<string>Configure the required domain names for remote access hosts</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>14</string>
 			<key>pfm_description</key>
@@ -6287,8 +6916,8 @@ If this policy is left not set the setting will be enabled.</string>
 			<string>Enable firewall traversal from remote access host</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>25</string>
 			<key>pfm_description</key>
@@ -6305,8 +6934,8 @@ If this setting is disabled or not set, then the remote access host can be assoc
 			<string>Require that the name of the local user and the remote access host owner match</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>23</string>
 			<key>pfm_description</key>
@@ -6325,8 +6954,8 @@ If this setting is disabled or not set, then both local and remote users can int
 			<string>Enable curtaining of remote access hosts</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>22</string>
 			<key>pfm_description</key>
@@ -6351,8 +6980,8 @@ Remote access clients are not affected by this policy setting. They will always 
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>chromoting-host</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>28</string>
 			<key>pfm_description</key>
@@ -6371,8 +7000,8 @@ This feature is currently disabled server-side.</string>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>https://example.com/issue</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>28</string>
 			<key>pfm_description</key>
@@ -6391,8 +7020,8 @@ This feature is currently disabled server-side.</string>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>Example Certificate Authority</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>28</string>
 			<key>pfm_description</key>
@@ -6411,8 +7040,8 @@ This feature is currently disabled server-side.</string>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>https://example.com/validate</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>36</string>
 			<key>pfm_description</key>
@@ -6433,7 +7062,7 @@ If this policy is left not set, or if it is set to an empty string, the remote a
 			<string>12400-12409</string>
 			<key>pfm_value_unit</key>
 			<string>port range</string>
-		</dict>
+		</dict> -->
 		<!-- END RemoteAccess -->
 		<!-- START SafeBrowsing -->
 		<!-- Documentation does not have an explicit version listed for deprecation -->
@@ -6530,7 +7159,7 @@ If this policy is left unset, password protection service will only protect Goog
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>8</string>
 			<key>pfm_description</key>
@@ -6557,8 +7186,8 @@ This policy is not available on Windows instances that are not joined to a Micro
 			<string>Enable Safe Browsing</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>66</string>
 			<key>pfm_description</key>
@@ -6585,8 +7214,8 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 			<string>Enable Safe Browsing Extended Reporting</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>68</string>
 			<key>pfm_description</key>
@@ -6620,8 +7249,8 @@ This policy is not available on Windows instances that are not joined to a Micro
 			<string>Configure the list of domains on which Safe Browsing will not trigger warnings.</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict>
-		<dict>
+		</dict> -->
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string></string>
 			<key>pfm_app_min</key>
@@ -6642,7 +7271,7 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 			<string>Allow users to opt in to Safe Browsing extended reporting</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 		<!-- END SafeBrowsing -->
 		<!-- START StartupHomepageNewTabPage -->
 		<dict>
@@ -6698,6 +7327,24 @@ to a Microsoft® Active Directory® domain.</string>
 			<string>Home page URL</string>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Hides the default top sites from the new tab page in Microsoft Edge.</string>
+			<key>pfm_description_reference</key>
+			<string>If you set this policy to true, the default top site tiles are hidden.
+
+If you set this policy to false or don't configure it, the default top site tiles remain visible.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#newtabpagehidedefaulttopsites</string>
+			<key>pfm_name</key>
+			<string>NewTabPageHideDefaultTopSites</string>
+			<key>pfm_title</key>
+			<string>Hide the default top sites from the new tab page</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -6877,7 +7524,7 @@ URL patterns in this policy should not clash with ones configured via WebUsbAskF
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
-		<dict>
+		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>68</string>
 			<key>pfm_app_min</key>
@@ -6902,7 +7549,7 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 			<string>Control where Developer Tools can be used</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-		</dict>
+		</dict> -->
 	</array>
 	<key>pfm_targets</key>
 	<array>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -140,14 +140,15 @@
 				<string>Extensions</string>
 				<string>Google Cast</string>
 				<string>HTTP Authentication</string>
-				<string>Legacy Browser Support</string>
+				<!-- <string>Legacy Browser Support</string> -->
 				<string>Misc.</string>
 				<string>Native Messaging</string>
 				<string>Password Manager</string>
 				<string>Printing</string>
 				<string>Proxy Server</string>
-				<string>Remote Access</string>
+				<!-- <string>Remote Access</string> -->
 				<string>Safe Browsing Settings</string>
+				<string>SmartScreen</string>
 				<string>Startup, Home &amp; New Tab Page</string>
 			</array>
 			<key>pfm_require</key>
@@ -159,6 +160,7 @@
 					<string>PFC_SegmentedControl_ContentSettings</string>
 					<string>AutoSelectCertificateForUrls</string>
 					<string>AutoplayAllowed</string>
+					<string>BackgroundModeEnabled</string>
 					<string>BackgroundTemplateListUpdatesEnabled</string>
 					<string>BlockThirdPartyCookies</string>
 					<string>CookiesAllowedForUrls</string>
@@ -167,6 +169,7 @@
 					<string>DefaultCookiesSetting</string>
 					<string>DefaultGeolocationSetting</string>
 					<string>DefaultImagesSetting</string>
+					<string>DefaultInsecureContentSetting</string>
 					<string>DefaultJavaScriptSetting</string>
 					<string>DefaultMediaStreamSetting</string>
 					<string>DefaultNotificationsSetting</string>
@@ -176,8 +179,12 @@
 					<string>DefaultWebUsbGuardSetting</string>
 					<string>ImagesAllowedForUrls</string>
 					<string>ImagesBlockedForUrls</string>
+					<string>InsecureContentAllowedForUrls</string>
+					<string>InsecureContentBlockedForUrls</string>
 					<string>JavaScriptAllowedForUrls</string>
 					<string>JavaScriptBlockedForUrls</string>
+					<string>LegacySameSiteCookieBehaviorEnabled</string>
+					<string>LegacySameSiteCookieBehaviorEnabledForDomainList</string>
 					<string>NotificationsAllowedForUrls</string>
 					<string>NotificationsBlockedForUrls</string>
 					<string>PluginsAllowedForUrls</string>
@@ -205,33 +212,35 @@
 					<string>DefaultSearchProviderSearchURLPostParams</string>
 					<string>DefaultSearchProviderSuggestURLPostParams</string>
 					<string>DefaultSearchProviderSuggestURL</string>
+					<string>ManagedSearchEngines</string>
 				</array>
 				<key>Extensions</key>
 				<array>
 					<string>ExtensionAllowInsecureUpdates</string>
 					<string>ExtensionAllowedTypes</string>
-					<string>ExtensionInstallBlacklist</string>
+					<string>ExtensionInstallAllowlist</string>
+					<string>ExtensionInstallBlocklist</string>
 					<string>ExtensionInstallForcelist</string>
 					<string>ExtensionInstallSources</string>
-					<string>ExtensionInstallWhitelist</string>
 					<string>ExtensionSettings</string>
 				</array>
 				<key>Google Cast</key>
 				<array>
 					<string>EnableMediaRouter</string>
+					<string>MediaRouterCastAllowAllIPs</string>
 					<string>ShowCastIconInToolbar</string>
 				</array>
 				<key>HTTP Authentication</key>
 				<array>
 					<string>AllowCrossOriginAuthPrompt</string>
-					<string>AuthNegotiateDelegateWhitelist</string>
+					<string>AuthNegotiateDelegateAllowlist</string>
 					<string>AuthSchemes</string>
-					<string>AuthServerWhitelist</string>
+					<string>AuthServerAllowlist</string>
 					<string>DisableAuthNegotiateCnameLookup</string>
 					<string>EnableAuthNegotiatePort</string>
 					<string>NtlmV2Enabled</string>
 				</array>
-				<key>Legacy Browser Support</key>
+				<!-- <key>Legacy Browser Support</key>
 				<array>
 					<string>AlternativeBrowserParameters</string>
 					<string>AlternativeBrowserPath</string>
@@ -242,7 +251,7 @@
 					<string>BrowserSwitcherKeepLastChromeTab</string>
 					<string>BrowserSwitcherUrlGreylist</string>
 					<string>BrowserSwitcherUrlList</string>
-				</array>
+				</array> -->
 				<key>Misc.</key>
 				<array>
 					<string>AbusiveExperienceInterventionEnforce</string>
@@ -257,6 +266,7 @@
 					<string>AllowedDomainsForApps</string>
 					<string>AlternateErrorPagesEnabled</string>
 					<string>AlwaysOpenPdfExternally</string>
+					<string>ApplicationLocaleValue</string>
 					<string>AudioCaptureAllowed</string>
 					<string>AudioCaptureAllowedUrls</string>
 					<string>AutoImportAtFirstRun</string>
@@ -264,8 +274,8 @@
 					<string>AutofillAddressEnabled</string>
 					<string>AutofillCreditCardEnabled</string>
 					<string>AutoplayWhitelist</string>
-					<string>BookmarkBarEnabled</string>
-					<string>BrowserAddPersonEnabled</string>
+					<string>FavoritesBarEnabled</string>
+					<string>BrowserAddProfileEnabled</string>
 					<string>BrowserGuestModeEnabled</string>
 					<string>BrowserGuestModeEnforced</string>
 					<string>BrowserNetworkTimeQueriesEnabled</string>
@@ -299,19 +309,21 @@
 					<string>DownloadDirectory</string>
 					<string>DownloadRestrictions</string>
 					<string>EdgeCollectionsEnabled</string>
-					<string>EditBookmarksEnabled</string>
+					<string>EditFavoritesEnabled</string>
 					<string>EnableDeprecatedWebPlatformFeatures</string>
 					<string>EnableDomainActionsDownload</string>
 					<string>EnableOnlineRevocationChecks</string>
 					<string>EnabledPlugins</string>
 					<string>EnterpriseHardwarePlatformAPIEnabled</string>
+					<string>ExperimentationAndConfigurationServiceControl</string>
 					<string>ExternalProtocolDialogShowAlwaysOpenCheckbox</string>
+					<string>ForceBingSafeSearch</string>
 					<string>ForceBrowserSignin</string>
 					<string>ForceEphemeralProfiles</string>
 					<string>ForceGoogleSafeSearch</string>
-					<string>ForceSafeSearch</string>
 					<string>ForceYouTubeRestrict</string>
 					<string>ForceYouTubeSafetyMode</string>
+					<string>FullscreenAllowed</string>
 					<string>GoToIntranetSiteForSingleWordEntryInAddressBar</string>
 					<string>HSTSPolicyBypassList</string>
 					<string>HardwareAccelerationModeEnabled</string>
@@ -320,7 +332,7 @@
 					<string>Http09OnNonDefaultPortsEnabled</string>
 					<string>ImportAutofillFormData</string>
 					<string>ImportBrowserSettings</string>
-					<string>ImportBookmarks</string>
+					<string>ImportFavorites</string>
 					<string>ImportHistory</string>
 					<string>ImportHomepage</string>
 					<string>ImportOpenTabs</string>
@@ -328,14 +340,13 @@
 					<string>ImportSavedPasswords</string>
 					<string>ImportSearchEngine</string>
 					<string>IncognitoEnabled</string>
-					<string>IncognitoModeAvailability</string>
+					<string>InPrivateModeAvailability</string>
 					<string>IsolateOrigins</string>
 					<string>JavascriptEnabled</string>
 					<string>MachineLevelUserCloudPolicyEnrollmentToken</string>
-					<string>ManagedBookmarks</string>
+					<string>ManagedFavorites</string>
 					<string>MaxConnectionsPerProxy</string>
 					<string>MaxInvalidationFetchDelay</string>
-					<string>MediaRouterCastAllowAllIPs</string>
 					<string>MetricsReportingEnabled</string>
 					<string>OmniboxMSBProviderEnabled</string>
 					<string>PaymentMethodQueryEnabled</string>
@@ -373,9 +384,10 @@
 					<string>TabFreezingEnabled</string>
 					<string>TaskManagerEndProcessEnabled</string>
 					<string>TotalMemoryLimitMb</string>
+					<string>TrackingPrevention</string>
 					<string>TranslateEnabled</string>
-					<string>URLBlacklist</string>
-					<string>URLWhitelist</string>
+					<string>URLAllowlist</string>
+					<string>URLBlocklist</string>
 					<string>UnsafelyTreatInsecureOriginAsSecure</string>
 					<string>UrlKeyedAnonymizedDataCollectionEnabled</string>
 					<string>UserDataDir</string>
@@ -386,13 +398,15 @@
 					<string>WebAppInstallForceList</string>
 					<string>WebDriverOverridesIncompatiblePolicies</string>
 					<string>WebRtcEventLogCollectionAllowed</string>
+					<string>WebRtcLocalIpsAllowedUrls</string>
+					<string>WebRtcLocalhostIpHandling</string>
 					<string>WebRtcUdpPortRange</string>
 				</array>
 				<key>Native Messaging</key>
 				<array>
-					<string>NativeMessagingBlacklist</string>
+					<string>NativeMessagingAllowlist</string>
+					<string>NativeMessagingBlocklist</string>
 					<string>NativeMessagingUserLevelHosts</string>
-					<string>NativeMessagingWhitelist</string>
 				</array>
 				<key>Password Manager</key>
 				<array>
@@ -417,7 +431,7 @@
 					<string>ProxyServer</string>
 					<string>ProxyServerMode</string>
 				</array>
-				<key>Remote Access</key>
+				<!-- <key>Remote Access</key>
 				<array>
 					<string>RemoteAccessHostAllowClientPairing</string>
 					<string>RemoteAccessHostAllowGnubbyAuth</string>
@@ -434,7 +448,7 @@
 					<string>RemoteAccessHostTokenValidationCertificateIssuer</string>
 					<string>RemoteAccessHostTokenValidationUrl</string>
 					<string>RemoteAccessHostUdpPortRange</string>
-				</array>
+				</array> -->
 				<key>Safe Browsing Settings</key>
 				<array>
 					<string>PasswordProtectionChangePasswordURL</string>
@@ -445,12 +459,23 @@
 					<string>SafeBrowsingExtendedReportingOptInAllowed</string>
 					<string>SafeBrowsingWhitelistDomains</string>
 				</array>
+				<key>SmartScreen</key>
+				<array>
+					<string>PreventSmartScreenPromptOverride</string>
+					<string>PreventSmartScreenPromptOverrideForFiles</string>
+					<string>SmartScreenAllowListDomains</string>
+					<string>SmartScreenEnabled</string>
+					<string>SmartScreenForTrustedDownloadsEnabled</string>
+					<string>SmartScreenPuaEnabled</string>
+				</array>
 				<key>Startup, Home &amp; New Tab Page</key>
 				<array>
 					<string>HomepageIsNewTabPage</string>
 					<string>HomepageLocation</string>
+					<string>NewTabPageCompanyLogo</string>
 					<string>NewTabPageHideDefaultTopSites</string>
 					<string>NewTabPageLocation</string>
+					<string>NewTabPageManagedQuickLinks</string>
 					<string>RestoreOnStartup</string>
 					<string>RestoreOnStartupURLs</string>
 					<string>ShowHomeButton</string>
@@ -461,7 +486,7 @@
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to set local data. Setting local data can be either allowed for all websites or denied for all websites.</string>
 			<key>pfm_description_reference</key>
@@ -496,7 +521,7 @@ If this policy is left not set, 'AllowCookies' will be used and the user will be
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Enabling this setting prevents cookies from being set by web page elements that are not from the domain that is in the browser's address bar.</string>
 			<key>pfm_description_reference</key>
@@ -516,7 +541,7 @@ If this policy is left not set, third party cookies will be enabled but the user
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are allowed to set cookies.</string>
 			<key>pfm_description_reference</key>
@@ -545,7 +570,7 @@ See also policies 'CookiesBlockedForUrls' and 'CookiesSessionOnlyForUrls'. Note 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are not allowed to set cookies.</string>
 			<key>pfm_description_reference</key>
@@ -574,7 +599,7 @@ See also policies 'CookiesAllowedForUrls' and 'CookiesSessionOnlyForUrls'. Note 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Cookies set by pages matching these URL patterns will be limited to the current session, i.e. they will be deleted when the browser exits.</string>
 			<key>pfm_description_reference</key>
@@ -607,7 +632,7 @@ If the "RestoreOnStartup" policy is set to restore URLs from previous sessions t
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to display images. Displaying images can be either allowed for all websites or denied for all websites.</string>
 			<key>pfm_description_reference</key>
@@ -639,7 +664,93 @@ Note that previously this policy was erroneously enabled on Android, but this fu
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Control use of insecure content exceptions</string>
+			<key>pfm_description_reference</key>
+			<string>Allows you to set whether users can add exceptions to allow mixed content for specific sites.
+
+This policy can be overridden for specific URL patterns using the InsecureContentAllowedForUrls and InsecureContentBlockedForUrls policies.
+
+If this policy isn't set, users will be allowed to add exceptions to allow blockable mixed content and disable autoupgrades for optionally blockable mixed content.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#defaultinsecurecontentsetting</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>0</string>
+				<string>1</string>
+				<string>2</string>
+			</array>
+			<key>pfm_name</key>
+			<string>DefaultInsecureContentSetting</string>
+			<key>pfm_title</key>
+			<string>Default insecure content setting</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>List of URLs to allow insecure content</string>
+			<key>pfm_description_reference</key>
+			<string>Create a list of URL patterns to specify sites that can display insecure mixed content (that is, HTTP content on HTTPS sites).
+
+If you don't configure this policy, blockable mixed content will be blocked and optionally blockable mixed content will be upgraded. However, users will be allowed to set exceptions to allow insecure mixed content for specific sites.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#insecurecontentallowedforurls</string>
+			<key>pfm_name</key>
+			<string>InsecureContentAllowedForUrls</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_title</key>
+					<string>Allowed URLs</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>[*.]example.edu</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>List of URLs to block insecure content</string>
+			<key>pfm_description_reference</key>
+			<string>Create a list of URL patterns to specify sites that aren't allowed to display blockable (i.e. active) mixed content (that is, HTTP content on HTTPS sites) and for which optionally blockable mixed content upgrades will be disabled.
+
+If you don't configure this policy, blockable mixed content will be blocked and optionally blockable mixed content will be upgraded. However, users will be allowed to set exceptions to allow insecure mixed content for specific sites.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#insecurecontentblockedforurls</string>
+			<key>pfm_name</key>
+			<string>InsecureContentBlockedForUrls</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_title</key>
+					<string>Blocked URLs</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>[*.]example.edu</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to run JavaScript. Running JavaScript can be either allowed for all websites or denied for all websites.</string>
 			<key>pfm_description_reference</key>
@@ -669,7 +780,7 @@ If this policy is left not set, 'AllowJavaScript' will be used and the user will
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to automatically run the Flash plugin. Automatically running the Flash plugin can be either allowed for all websites or denied for all websites.</string>
 			<key>pfm_description_reference</key>
@@ -706,7 +817,7 @@ If this policy is left not set, the user will be able to change this setting man
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to show pop-ups. Showing popups can be either allowed for all websites or denied for all websites.</string>
 			<key>pfm_description_reference</key>
@@ -735,8 +846,10 @@ If this policy is left not set, 'BlockPopups' will be used and the user will be 
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<integer>3</integer>
 			<key>pfm_app_min</key>
-			<string>50</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to get access to nearby Bluetooth devices. Access can be completely blocked, or the user can be asked every time a website wants to get access to nearby Bluetooth devices.</string>
 			<key>pfm_description_reference</key>
@@ -765,8 +878,10 @@ If this policy is left not set, '3' will be used, and the user will be able to c
 			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<integer>3</integer>
 			<key>pfm_app_min</key>
-			<string>67</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to get access to connected USB devices. Access can be completely blocked, or the user can be asked every time a website wants to get access to connected USB devices.</string>
 			<key>pfm_description_reference</key>
@@ -798,7 +913,7 @@ If this policy is left not set, '3' will be used, and the user will be able to c
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are allowed to display images.</string>
 			<key>pfm_description_reference</key>
@@ -827,7 +942,7 @@ Note that previously this policy was erroneously enabled on Android, but this fu
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are not allowed to display images.</string>
 			<key>pfm_description_reference</key>
@@ -856,7 +971,7 @@ Note that previously this policy was erroneously enabled on Android, but this fu
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are allowed to run JavaScript.</string>
 			<key>pfm_description_reference</key>
@@ -883,7 +998,7 @@ If this policy is left not set the global default value will be used for all sit
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are not allowed to run JavaScript.</string>
 			<key>pfm_description_reference</key>
@@ -910,7 +1025,76 @@ If this policy is left not set the global default value will be used for all sit
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Enable default legacy SameSite cookie behavior setting</string>
+			<key>pfm_description_reference</key>
+			<string>Lets you revert all cookies to legacy SameSite behavior. Reverting to legacy behavior causes cookies that don't specify a SameSite attribute to be treated as if they were "SameSite=None", and removes the requirement for "SameSite=None" cookies to carry the "Secure" attribute.
+
+You can set the following values for this policy:
+
+1 = Revert to legacy SameSite behavior for cookies on all sites
+
+2 = Use SameSite-by-default behavior for cookies on all sites
+
+If you don't set this policy, the default behavior for cookies that don't specify a SameSite attribute will depend on other configuration sources for the SameSite-by-default feature. This feature might be set by a field trial or by enabling the same-site-by-default-cookies flag in edge://flags.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#legacysamesitecookiebehaviorenabled</string>
+			<key>pfm_name</key>
+			<string>LegacySameSiteCookieBehaviorEnabled</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Revert to legacy SameSite behavior for cookies on all sites</string>
+				<string>Use SameSite-by-default behavior for cookies on all sites</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Legacy SameSite cookie behavior</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Revert to legacy SameSite behavior for cookies on specified sites</string>
+			<key>pfm_description_reference</key>
+			<string>Cookies set for domains match specified patterns will revert to legacy SameSite behavior.
+
+Reverting to legacy behavior causes cookies that don't specify a SameSite attribute to be treated as if they were "SameSite=None", and removes the requirement for "SameSite=None" cookies to carry the "Secure" attribute.
+
+If you don't set this policy, the global default value will be used. The global default will also be used for cookies on domains not covered by the patterns you specify.
+
+The global default value can be configured using the LegacySameSiteCookieBehaviorEnabled policy. If LegacySameSiteCookieBehaviorEnabled is unset, the global default value falls back to other configuration sources.
+
+Note that patterns you list in this policy are treated as domains, not URLs, so you should not specify a scheme or port.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#legacysamesitecookiebehaviorenabledfordomainlist</string>
+			<key>pfm_name</key>
+			<string>LegacySameSiteCookieBehaviorEnabledForDomainList</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_title</key>
+					<string>Allowed URLs</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>[*.]example.edu</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Legacy SameSite cookie allowed list</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are allowed to run the Flash plugin.</string>
 			<key>pfm_description_reference</key>
@@ -937,7 +1121,7 @@ If this policy is left not set the global default value will be used for all sit
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are not allowed to run the Flash plugin.</string>
 			<key>pfm_description_reference</key>
@@ -964,7 +1148,7 @@ If this policy is left not set the global default value will be used for all sit
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are allowed to open popups.</string>
 			<key>pfm_description_reference</key>
@@ -991,7 +1175,7 @@ If this policy is left not set the global default value will be used for all sit
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are not allowed to open popups.</string>
 			<key>pfm_description_reference</key>
@@ -1018,7 +1202,7 @@ If this policy is left not set the global default value will be used for all sit
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to specify a list of url patterns that specify sites for which Google Chrome should automatically select a client certificate, if the site requests a certificate.</string>
 			<key>pfm_description_reference</key>
@@ -1049,7 +1233,7 @@ If this policy is left not set, no auto-selection will be done for any site.</st
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to track the users' physical location. Tracking the users' physical location can be allowed by default, denied by default or the user can be asked every time a website requests the physical location.</string>
 			<key>pfm_description_reference</key>
@@ -1115,7 +1299,7 @@ If this policy is left not set, 'AskGeolocation' will be used and the user will 
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>37</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to register a list of protocol handlers. This can only be a recommended policy. The property |protocol| should be set to the scheme such as 'mailto' and the property |url| should be set to the URL pattern of the application that handles the scheme. The pattern can include a '%s', which if present will be replaced by the handled URL.</string>
 			<key>pfm_description_reference</key>
@@ -1167,7 +1351,7 @@ The protocol handlers registered by policy are merged with the ones registered b
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
-		<!-- <dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>74</string>
 			<key>pfm_description</key>
@@ -1185,7 +1369,9 @@ URL patterns in this policy should not clash with the ones configured via WebUsb
 			<key>pfm_name</key>
 			<string>WebUsbAllowDevicesForUrls</string>
 			<key>pfm_note</key>
-			<string>Each item in devices can contain a vendor ID and product ID field. Any ID that is omitted is treated as a wildcard with one exception, and that exception is that a product ID cannot be specified without a vendor ID also being specified. Otherwise, the policy will not be valid and will be ignored.</string>
+			<string>Microsoft's doc example XML indicate this dictionary lives within an array, which ProfileCreator cannot handle. If you use this preference in your exported file, you'll likely need to add surrounding array tags.
+
+Each item in devices can contain a vendor ID and product ID field. Any ID that is omitted is treated as a wildcard with one exception, and that exception is that a product ID cannot be specified without a vendor ID also being specified. Otherwise, the policy will not be valid and will be ignored.</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
@@ -1196,6 +1382,8 @@ URL patterns in this policy should not clash with the ones configured via WebUsb
 						<dict>
 							<key>pfm_format</key>
 							<string>https?://.*</string>
+							<key>pfm_title</key>
+							<string>URL</string>
 							<key>pfm_type</key>
 							<string>string</string>
 						</dict>
@@ -1213,12 +1401,16 @@ URL patterns in this policy should not clash with the ones configured via WebUsb
 						<dict>
 							<key>pfm_name</key>
 							<string>product_id</string>
+							<key>pfm_title</key>
+							<string>Product ID</string>
 							<key>pfm_type</key>
 							<string>integer</string>
 						</dict>
 						<dict>
 							<key>pfm_name</key>
 							<string>vendor_id</string>
+							<key>pfm_title</key>
+							<string>Vendor ID</string>
 							<key>pfm_type</key>
 							<string>integer</string>
 						</dict>
@@ -1233,10 +1425,10 @@ URL patterns in this policy should not clash with the ones configured via WebUsb
 			<string>Automatically grant permission to these sites to connect to USB devices with the given vendor and product IDs</string>
 			<key>pfm_type</key>
 			<string>dictionary</string>
-		</dict> -->
+		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>66</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to control if videos can play automatically (without user consent) with audio content in Google Chrome.</string>
 			<key>pfm_description_reference</key>
@@ -1253,6 +1445,28 @@ Note that if Google Chrome is running and this policy changes, it will be applie
 			<string>AutoplayAllowed</string>
 			<key>pfm_title</key>
 			<string>Allow media autoplay</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Continue running background apps after Microsoft Edge closes.</string>
+			<key>pfm_description_reference</key>
+			<string>Allows Microsoft Edge processes to start at OS sign-in and keep running after the last browser window is closed. In this scenario, background apps and the current browsing session remain active, including any session cookies. An open background process displays an icon in the system tray and can always be closed from there.
+
+If you enable this policy, background mode is turned on.
+
+If you disable this policy, background mode is turned off.
+
+If you don't configure this policy, background mode is initially turned off, and the user can configure its behavior in edge://settings/system.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#autoplayallowed</string>
+			<key>pfm_name</key>
+			<string>BackgroundModeEnabled</string>
+			<key>pfm_title</key>
+			<string>Enable background mode</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -1311,7 +1525,7 @@ If you disable this setting the list of available templates will be downloaded o
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether websites are allowed to display desktop notifications. Displaying desktop notifications can be allowed by default, denied by default or the user can be asked every time a website wants to show desktop notifications.</string>
 			<key>pfm_description_reference</key>
@@ -1344,7 +1558,7 @@ If this policy is left not set, 'AskNotifications' will be used and the user wil
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>16</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are allowed to display notifications.</string>
 			<key>pfm_description_reference</key>
@@ -1371,7 +1585,7 @@ If this policy is left not set the global default value will be used for all sit
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>16</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are not allowed to display notifications.</string>
 			<key>pfm_description_reference</key>
@@ -1428,7 +1642,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Enables the use of a default search provider.</string>
 			<key>pfm_description_reference</key>
@@ -1457,7 +1671,7 @@ to a Microsoft® Active Directory® domain.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the character encodings supported by the search provider. Encodings are code page names like UTF-8, GB2312, and ISO-8859-1. They are tried in the order provided.</string>
 			<key>pfm_description_reference</key>
@@ -1508,7 +1722,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>29</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the URL of the search engine used to provide image search. Search requests will be sent using the GET method. If the DefaultSearchProviderImageURLPostParams policy is set then image search requests will use the POST method instead.</string>
 			<key>pfm_description_reference</key>
@@ -1530,7 +1744,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>29</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the parameters used when doing image search with POST. It consists of comma-separated name/value pairs. If a value is a template parameter, like {imageThumbnail} in above example, it will be replaced with real image thumbnail data.</string>
 			<key>pfm_description_reference</key>
@@ -1552,7 +1766,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the keyword, which is the shortcut used in the omnibox to trigger the search for this provider.</string>
 			<key>pfm_description_reference</key>
@@ -1574,7 +1788,7 @@ This policy is only considered if the 'DefaultSearchProviderEnabled' policy is e
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the name of the default search provider. If left empty or not set, the host name specified by the search URL will be used.</string>
 			<key>pfm_description_reference</key>
@@ -1616,7 +1830,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the URL of the search engine used when doing a default search. The URL should contain the string '{searchTerms}', which will be replaced at query time by the terms the user is searching for.</string>
 			<key>pfm_description_reference</key>
@@ -1660,7 +1874,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the URL of the search engine used to provide search suggestions. The URL should contain the string '{searchTerms}', which will be replaced at query time by the text the user has entered so far.</string>
 			<key>pfm_description_reference</key>
@@ -1708,7 +1922,7 @@ This policy is only respected if the 'DefaultSearchProviderEnabled' policy is en
 		<!-- START ContentSettings/Extensions -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>25</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Controls which app/extension types are allowed to be installed and limits runtime access.</string>
 			<key>pfm_description_reference</key>
@@ -1765,7 +1979,7 @@ If this settings is left not-configured, no restrictions on the acceptable exten
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>21</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to specify which URLs are allowed to install extensions, apps, and themes.</string>
 			<key>pfm_description_reference</key>
@@ -1796,7 +2010,7 @@ ExtensionInstallBlacklist takes precedence over this policy. That is, an extensi
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to specify which extensions the users can NOT install. Extensions already installed will be disabled if blacklisted, without a way for the user to enable them. Once an extension disabled due to the blacklist is removed from it, it will automatically get re-enabled.</string>
 			<key>pfm_description_reference</key>
@@ -1826,7 +2040,7 @@ If this policy is left not set the user can install any extension in Google Chro
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to specify which extensions are not subject to the blacklist.</string>
 			<key>pfm_description_reference</key>
@@ -1856,7 +2070,7 @@ By default, all extensions are whitelisted, but if all extensions have been blac
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>9</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies a list of apps and extensions that are installed silently, without user interaction, and which cannot be uninstalled nor disabled by the user. All permissions requested by the apps/extensions are granted implicitly, without user interaction, including any additional permissions requested by future versions of the app/extension. Furthermore, permissions are granted for the enterprise.deviceAttributes and enterprise.platformKeys extension APIs. (These two APIs are not available to apps/extensions that are not force-installed.)</string>
 			<key>pfm_description_reference</key>
@@ -1893,7 +2107,7 @@ If this policy is left not set, no apps or extensions are installed automaticall
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>62</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Configures extension management settings for Google Chrome. A default configuration can be set for the special ID "*"</string>
 			<key>pfm_description_reference</key>
@@ -2192,7 +2406,7 @@ Starting in Google Chrome 78, this policy will be ignored and treated as disable
 		<!-- START ContentSettings/GoogleCast -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>52</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If this policy is set to true or is not set, Google Cast will be enabled, and users will be able to launch it from the app menu, page context menus, media controls on Cast-enabled websites, and (if shown) the Cast toolbar icon.</string>
 			<key>pfm_description_reference</key>
@@ -2210,7 +2424,7 @@ If this policy set to false, Google Cast will be disabled.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>58</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If this policy is set to true, the Cast toolbar icon will always be shown on the toolbar or the overflow menu, and users will not be able to remove it.</string>
 			<key>pfm_description_reference</key>
@@ -2232,7 +2446,7 @@ If the policy "EnableMediaRouter" is set to false, then this policy's value woul
 		<!-- START ContentSettings/HTTPAuthentication -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>13</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Controls whether third-party sub-content on a page is allowed to pop-up an HTTP Basic Auth dialog box.</string>
 			<key>pfm_description_reference</key>
@@ -2250,9 +2464,9 @@ Typically this is disabled as a phishing defense. If this policy is not set, thi
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>9</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Servers that Google Chrome may delegate to.</string>
+			<string>Servers that Microsoft Edge may delegate to.</string>
 			<key>pfm_description_reference</key>
 			<string>Servers that Google Chrome may delegate to.
 
@@ -2262,7 +2476,7 @@ If you leave this policy not set Google Chrome will not delegate user credential
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#authnegotiatedelegateallowlist</string>
 			<key>pfm_name</key>
-			<string>AuthNegotiateDelegateWhitelist</string>
+			<string>AuthNegotiateDelegateAllowlist</string>
 			<key>pfm_title</key>
 			<string>Kerberos delegation server whitelist</string>
 			<key>pfm_type</key>
@@ -2272,9 +2486,9 @@ If you leave this policy not set Google Chrome will not delegate user credential
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>9</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Specifies which HTTP authentication schemes are supported by Google Chrome. Possible values are 'basic', 'digest', 'ntlm' and 'negotiate'. Separate multiple values with commas.</string>
+			<string>Specifies which HTTP authentication schemes are supported by Microsoft Edge. Possible values are 'basic', 'digest', 'ntlm' and 'negotiate'. Separate multiple values with commas.</string>
 			<key>pfm_description_reference</key>
 			<string>Specifies which HTTP authentication schemes are supported by Google Chrome.
 
@@ -2294,9 +2508,9 @@ If this policy is left not set, all four schemes will be used.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>9</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Specifies which servers should be whitelisted for integrated authentication. Integrated authentication is only enabled when Google Chrome receives an authentication challenge from a proxy or from a server which is in this permitted list.</string>
+			<string>Specifies which servers should be whitelisted for integrated authentication. Integrated authentication is only enabled when Microsoft Edge receives an authentication challenge from a proxy or from a server which is in this permitted list.</string>
 			<key>pfm_description_reference</key>
 			<string>Specifies which servers should be whitelisted for integrated authentication. Integrated authentication is only enabled when Google Chrome receives an authentication challenge from a proxy or from a server which is in this permitted list.
 
@@ -2317,7 +2531,7 @@ If you leave this policy not set Google Chrome will try to detect if a server is
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>9</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies whether the generated Kerberos SPN is based on the canonical DNS name or the original name entered.</string>
 			<key>pfm_description_reference</key>
@@ -2337,7 +2551,7 @@ If you disable this setting or leave it not set, the canonical name of the serve
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>9</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies whether the generated Kerberos SPN should include a non-standard port.</string>
 			<key>pfm_description_reference</key>
@@ -2670,9 +2884,9 @@ If this policy is left not set, True will be used.</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict> -->
-		<!-- <dict>
+		<dict>
 			<key>pfm_app_min</key>
-			<string>65</string>
+			<string>79</string>
 			<key>pfm_description</key>
 			<string>Allows you to set whether ads should be blocked on sites with intrusive ads.</string>
 			<key>pfm_description_reference</key>
@@ -2685,7 +2899,7 @@ However this behavior will not trigger if SafeBrowsingEnabled policy is set to F
 If this policy is set to 1, ads will not be blocked on sites with intrusive ads.
 If this policy is left not set, 2 will be used.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://cloud.google.com/docs/chrome-enterprise/policies/?policy=AdsSettingForIntrusiveAdsSites</string>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#adssettingforintrusiveadssites</string>
 			<key>pfm_name</key>
 			<string>AdsSettingForIntrusiveAdsSites</string>
 			<key>pfm_range_list</key>
@@ -2702,12 +2916,12 @@ If this policy is left not set, 2 will be used.</string>
 			<string>Ads setting for sites with intrusive ads</string>
 			<key>pfm_type</key>
 			<string>integer</string>
-		</dict> -->
+		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>57</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Enables deleting browser history and download history in Google Chrome and prevents users from changing this setting.</string>
+			<string>Enables deleting browser history and download history in Microsoft Edge and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables deleting browser history and download history in Google Chrome and prevents users from changing this setting.
 
@@ -2745,9 +2959,9 @@ If this policy is set to False, users will not be able to play the dinosaur east
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>12</string>
+			<string>78</string>
 			<key>pfm_description</key>
-			<string>Allows access to local files on the machine by allowing Google Chrome to display file selection dialogs.</string>
+			<string>Allows access to local files on the machine by allowing Microsoft Edge to display file selection dialogs.</string>
 			<key>pfm_description_reference</key>
 			<string>Allows access to local files on the machine by allowing Google Chrome to display file selection dialogs.
 
@@ -2894,9 +3108,9 @@ Users cannot change or override this setting.</string>
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>80</string>
 			<key>pfm_description</key>
-			<string>Enables the use of alternate error pages that are built into Google Chrome (such as 'page not found') and prevents users from changing this setting.</string>
+			<string>Enables the use of alternate error pages that are built into Microsoft Edge (such as 'page not found') and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables the use of alternate error pages that are built into Google Chrome (such as 'page not found') and prevents users from changing this setting.
 
@@ -2918,9 +3132,9 @@ If this policy is left not set, this will be enabled but the user will be able t
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>55</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Disables the internal PDF viewer in Google Chrome. Instead it treats it as download and allows the user to open PDF files with the default application.</string>
+			<string>Disables the internal PDF viewer in Microsoft Edge. Instead it treats it as download and allows the user to open PDF files with the default application.</string>
 			<key>pfm_description_reference</key>
 			<string>Disables the internal PDF viewer in Google Chrome. Instead it treats it as download and allows the user to open PDF files with the default application.
 
@@ -2935,8 +3149,32 @@ If this policy is left not set or disabled the PDF plugin will be used to open P
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<string>en</string>
 			<key>pfm_app_min</key>
-			<string>25</string>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Set application locale</string>
+			<key>pfm_description_reference</key>
+			<string>Configures the application locale in Microsoft Edge and prevents users from changing the locale.
+
+If you enable this policy, Microsoft Edge uses the specified locale. If the configured locale isn't supported, 'en-US' is used instead.
+
+If you disable or don't configure this setting, Microsoft Edge uses either the user-specified preferred locale (if configured) or the fallback locale 'en-US'.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#alwaysopenpdfexternally</string>
+			<key>pfm_name</key>
+			<string>ApplicationLocaleValue</string>
+			<key>pfm_note</key>
+			<string>If you disable or don't configure this setting, Microsoft Edge uses either the user-specified preferred locale (if configured) or the fallback locale 'en-US'.</string>
+			<key>pfm_title</key>
+			<string>Application locale value</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If enabled or not configured (default), the user will be prompted for audio capture access except for URLs configured in the AudioCaptureAllowedUrls list which will be granted access without prompting.</string>
 			<key>pfm_description_reference</key>
@@ -2956,7 +3194,7 @@ This policy affects all types of audio inputs and not only the built-in micropho
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>29</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Patterns in this list will be matched against the security
 origin of the requesting URL.  If a match is found, access to audio
@@ -3045,9 +3283,9 @@ If you enable this setting or do not set a value, AutoFill will remain under the
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>69</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Enables Google Chrome's AutoFill feature and allows users to auto complete address information in web forms using previously stored information.</string>
+			<string>Enables Microsoft Edge's AutoFill feature and allows users to auto complete address information in web forms using previously stored information.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables Google Chrome's AutoFill feature and allows users to auto complete address information in web forms using previously stored information.
 
@@ -3065,9 +3303,9 @@ If this setting is enabled or has no value, the user will be able to control Aut
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>63</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Enables Google Chrome's AutoFill feature and allows users to auto complete credit card information in web forms using previously stored information.</string>
+			<string>Enables Microsoft Edge's AutoFill feature and allows users to auto complete credit card information in web forms using previously stored information.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables Google Chrome's AutoFill feature and allows users to auto complete credit card information in web forms using previously stored information.
 
@@ -3085,9 +3323,9 @@ If this setting is enabled or has no value, the user will be able to control Aut
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>12</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If you enable this setting, Google Chrome will show a bookmark bar.</string>
+			<string>If you enable this setting, Microsoft Edge will show a bookmark bar.</string>
 			<key>pfm_description_reference</key>
 			<string>If you enable this setting, Google Chrome will show a bookmark bar.
 
@@ -3108,9 +3346,9 @@ If this setting is left not set the user can decide to use this function or not.
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>39</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If this policy is set to true or not configured, Google Chrome will allow Add Person from the user manager.</string>
+			<string>Enable profile creation from the Identity flyout menu or the Settings page</string>
 			<key>pfm_description_reference</key>
 			<string>If this policy is set to true or not configured, Google Chrome will allow Add Person from the user manager.
 
@@ -3127,9 +3365,9 @@ If this policy is set to false, Google Chrome will not allow creation of new pro
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>38</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If this policy is set to true or not configured, Google Chrome will enable guest logins. Guest logins are Google Chrome profiles where all windows are in incognito mode.</string>
+			<string>Enable the option to allow the use of guest profiles in Microsoft Edge. In a guest profile, the browser doesn't import browsing data from existing profiles, and it deletes browsing data when all guest profiles are closed.</string>
 			<key>pfm_description_reference</key>
 			<string>If this policy is set to true or not configured, Google Chrome will enable guest logins. Guest logins are Google Chrome profiles where all windows are in incognito mode.
 
@@ -3163,9 +3401,9 @@ If this policy is set to disabled or not set or browser guest mode is disabled b
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>60</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Setting this policy to false stops Google Chrome from occasionally sending queries to a Google server to retrieve an accurate timestamp. These queries will be enabled if this policy is set to True or is not set.</string>
+			<string>If set to false, prevents Microsoft Edge from occasionally sending queries to a browser network time service to retrieve an accurate timestamp.</string>
 			<key>pfm_description_reference</key>
 			<string>Setting this policy to false stops Google Chrome from occasionally sending queries to a Google server to retrieve an accurate timestamp. These queries will be enabled if this policy is set to True or is not set.</string>
 			<key>pfm_documentation_url</key>
@@ -3173,15 +3411,15 @@ If this policy is set to disabled or not set or browser guest mode is disabled b
 			<key>pfm_name</key>
 			<string>BrowserNetworkTimeQueriesEnabled</string>
 			<key>pfm_title</key>
-			<string>Allow queries to a Google time service</string>
+			<string>Allow queries to a network time service</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>70</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>This policy controls the sign-in behavior of the browser. It allows you to specify if the user can sign in to Google Chrome with their account and use account related services like Chrome sync.</string>
+			<string>Specify whether a user can sign into Microsoft Edge with their account and use account-related services like sync and single sign on.</string>
 			<key>pfm_description_reference</key>
 			<string>This policy controls the sign-in behavior of the browser. It allows you to specify if the user can sign in to Google Chrome with their account and use account related services like Chrome sync.
 
@@ -3219,9 +3457,9 @@ If this policy is not set then the user can decide if they want to enable the br
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>25</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Controls whether the built-in DNS client is used in Google Chrome.</string>
+			<string>Controls whether to use the built-in DNS client.</string>
 			<key>pfm_description_reference</key>
 			<string>Controls whether the built-in DNS client is used in Google Chrome.
 
@@ -3241,7 +3479,7 @@ If this policy is left not set, the users will be able to change whether the bui
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>67</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Disables enforcing Certificate Transparency requirements for a list of subjectPublicKeyInfo hashes.</string>
 			<key>pfm_description_reference</key>
@@ -3277,7 +3515,7 @@ If this policy is not set, any certificate that is required to be disclosed via 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>67</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Disables enforcing Certificate Transparency requirements for a list of Legacy Certificate Authorities.</string>
 			<key>pfm_description_reference</key>
@@ -3310,9 +3548,9 @@ If this policy is not set, any certificate that is required to be disclosed via 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>53</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Disables enforcing Certificate Transparency requirements to the listed URLs. A URL pattern is formatted according to https://www.chromium.org/administrators/url-blacklist-filter-format.</string>
+			<string>Disables enforcing Certificate Transparency requirements to the listed URLs. Form your URL pattern according to https://go.microsoft.com/fwlink/?linkid=2095322</string>
 			<key>pfm_description_reference</key>
 			<string>Disables enforcing Certificate Transparency requirements to the listed URLs.
 
@@ -3423,9 +3661,9 @@ This policy is only available as a mandatory machine platform policy and it only
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>76</string>
+			<string>78</string>
 			<key>pfm_description</key>
-			<string>If disabled, prevents security warnings from appearing when Chrome is launched with some potentially dangerous command-line flags.</string>
+			<string>If disabled, prevents security warnings from appearing when Edge is launched with some potentially dangerous command-line flags.</string>
 			<key>pfm_description_reference</key>
 			<string>If disabled, prevents security warnings from appearing when Chrome is launched with some potentially dangerous command-line flags.
 
@@ -3445,9 +3683,9 @@ On Windows, this policy is only available on instances that are joined to a Micr
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>54</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Enables component updates for all components in Google Chrome when not set or set to True.</string>
+			<string>Enables component updates for all components in Microsoft Edge when not set or set to True.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables component updates for all components in Google Chrome when not set or set to True.
 
@@ -3458,8 +3696,10 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#componentupdatesenabled</string>
 			<key>pfm_name</key>
 			<string>ComponentUpdatesEnabled</string>
+			<key>pfm_note</key>
+			<string>Some components are exempt from this policy. This includes any component that doesn't contain executable code, that doesn't significantly alter the behavior of the browser, or that's critical for security. That is, updates that are deemed "critical for security" are still applied even if you disable this policy.</string>
 			<key>pfm_title</key>
-			<string>Enable component updates in Google Chrome</string>
+			<string>Edge component updates</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -3545,9 +3785,9 @@ If you disable this policy, DNS interception checks aren’t performed.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the default browser checks in Google Chrome and prevents users from changing them.</string>
+			<string>Configures the default browser checks in Microsoft Edge and prevents users from changing them. If set to true, Edge will always checks on startup whether it is the default browser and automatically registers itself, if possible.</string>
 			<key>pfm_description_reference</key>
 			<string>Configures the default browser checks in Google Chrome and prevents users from changing them.
 
@@ -3561,7 +3801,7 @@ If this setting is not set, Google Chrome will allow the user to control whether
 			<key>pfm_name</key>
 			<string>DefaultBrowserSettingEnabled</string>
 			<key>pfm_title</key>
-			<string>Set Google Chrome as Default Browser</string>
+			<string>Set Microsoft Edge as Default Browser</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -3593,7 +3833,7 @@ See https://www.chromium.org/administrators/policy-list-3/user-data-directory-va
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>68</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to control where Developer Tools can be used.</string>
 			<key>pfm_description_reference</key>
@@ -3628,7 +3868,7 @@ If this policy is set to 'DeveloperToolsDisallowed' (value 2), the Developer Too
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>9</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Enabling this setting prevents web pages from accessing the graphics processing unit (GPU). Specifically, web pages can not access the WebGL API and plugins can not use the Pepper 3D API.</string>
 			<key>pfm_description_reference</key>
@@ -3668,7 +3908,7 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>22</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If enabled, screenshots cannot be taken using keyboard shortcuts or extension APIs.</string>
 			<key>pfm_description_reference</key>
@@ -3797,9 +4037,9 @@ If this policy is left not set or the list is empty all schemes will be accessib
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>13</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the directory that Google Chrome will use for storing cached files on the disk. See https://www.chromium.org/administrators/policy-list-3/user-data-directory-variables for a list of variables that can be used. To avoid data loss or other unexpected errors this policy should not be set to a volume's root directory or to a directory used for other purposes, because Google Chrome manages its contents</string>
+			<string>Configures the directory that Microsoft Edge will use for storing cached files on the disk. See https://www.chromium.org/administrators/policy-list-3/user-data-directory-variables for a list of variables that can be used. To avoid data loss or other unexpected errors this policy should not be set to a volume's root directory or to a directory used for other purposes, because Edge manages its contents</string>
 			<key>pfm_description_reference</key>
 			<string>Configures the directory that Google Chrome will use for storing cached files on the disk.
 
@@ -3821,9 +4061,9 @@ If this policy is left not set the default cache directory will be used and the 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>17</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the cache size that Google Chrome will use for storing cached files on the disk. The value specified in this policy is not a hard boundary but rather a suggestion to the caching system, any value below a few megabytes is too small and will be rounded up to a sane minimum. If the value of this policy is 0, the default cache size will be used but the user will not be able to change it.</string>
+			<string>Configures the cache size that Microsoft Edge will use for storing cached files on the disk. The value specified in this policy is not a hard boundary but rather a suggestion to the caching system, any value below a few megabytes is too small and will be rounded up to a sane minimum. If the value of this policy is 0, the default cache size will be used but the user will not be able to change it.</string>
 			<key>pfm_description_reference</key>
 			<string>Configures the cache size that Google Chrome will use for storing cached files on the disk.
 
@@ -3847,11 +4087,11 @@ If this policy is not set the default size will be used and the user will be abl
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the directory that Google Chrome will use for downloading files. If you set this policy, Google Chrome will use the provided directory regardless whether the user has specified one or enabled the flag to be prompted for download location every time. If this policy is left not set the default download directory will be used and the user will be able to change it.
+			<string>Configures the directory that Microsoft Edge will use for downloading files. If you set this policy, Edge will use the provided directory regardless whether the user has specified one or enabled the flag to be prompted for download location every time. If this policy is left not set the default download directory will be used and the user will be able to change it.
 
-See https://www.chromium.org/administrators/policy-list-3/user-data-directory-variables for a list of variables that can be used.</string>
+See https://go.microsoft.com/fwlink/?linkid=2095041 for a list of variables that can be used.</string>
 			<key>pfm_description_reference</key>
 			<string>Configures the directory that Google Chrome will use for downloading files.
 
@@ -3873,9 +4113,9 @@ If this policy is left not set the default download directory will be used and t
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>61</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the type of downloads that Google Chrome will completely block, without letting users override the security decision.</string>
+			<string>Configures the type of downloads that Microsoft Edge will completely block, without letting users override the security decision.</string>
 			<key>pfm_description_reference</key>
 			<string>0 - No special restrictions
 1 - Block dangerous downloads
@@ -3939,9 +4179,9 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>12</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If you enable this setting, bookmarks can be added, removed or modified. This is the default also when this policy is not set.</string>
+			<string>If you enable this setting, favorites can be added, removed or modified. This is the default also when this policy is not set.</string>
 			<key>pfm_description_reference</key>
 			<string>If you enable this setting, bookmarks can be added, removed or modified. This is the default also when this policy is not set.
 
@@ -3952,13 +4192,13 @@ If you disable this setting, bookmarks can not be added, removed or modified. Ex
 			<key>pfm_name</key>
 			<string>EditFavoritesEnabled</string>
 			<key>pfm_title</key>
-			<string>Enable or disable bookmark editing</string>
+			<string>Enable or disable favorites editing</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>37</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>ExampleDeprecatedFeature_EffectiveUntil20080902 - Enable ExampleDeprecatedFeature API through 2008/09/02
 Specify a list of deprecated web platform features to re-enable temporarily.</string>
@@ -4015,7 +4255,7 @@ If you don't configure this policy, the list of Domain Actions will continue to 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>19</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>In light of the fact that soft-fail, online revocation checks provide no effective security benefit, they are disabled by default in Google Chrome version 19 and later. By setting this policy to true, the previous behavior is restored and online OCSP/CRL checks will be performed.</string>
 			<key>pfm_description_reference</key>
@@ -4063,7 +4303,7 @@ If this policy is left not set the user can disable any plugin installed on the 
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>71</string>
+			<string>78</string>
 			<key>pfm_description</key>
 			<string>When this policy is set to enabled, extensions installed by enterprise policy are allowed to use the Enterprise Hardware Platform API.</string>
 			<key>pfm_description_reference</key>
@@ -4082,6 +4322,52 @@ If this policy is left not set the user can disable any plugin installed on the 
 		<dict>
 			<key>pfm_app_min</key>
 			<string>77</string>
+			<key>pfm_description</key>
+			<string>Control communication with the Experimentation and Configuration Service</string>
+			<key>pfm_description_reference</key>
+			<string>In Microsoft Edge, the Experimentation and Configuration Service is used to deploy Experimentation and Configuration payload.
+
+Experimentation payload consists of a list of early in development features that Microsoft is enabling for testing and feedback.
+
+Configuration payload consists of a list of settings that Microsoft wants to deploy to Microsoft Edge to optimize user experience. For example, configuration payload may specify how often Microsoft Edge sends requests to the Experimentation and Configuration Service to retrieve the newest payload.
+
+If you set this policy to "Retrieve configurations and experiments" mode, the full payload is downloaded from the Experimentation and Configuration Service. This includes both the experimentation and configuration payloads.
+
+If you set this policy to "Retrieve configurations only" mode, only the configuration payload is delivered.
+
+If you set this policy to "Disable communication with the Experimentation and Configuration Service" mode, the communication with the Experimentation and Configuration Service is stopped completely.
+
+If you don't configure this policy, on a managed device on Stable and Beta channels the behavior is the same as the "Retrieve configurations only" mode.
+
+If you don't configure this policy, on an unmanaged device the behavior is the same as the "Retrieve configurations and experiments" mode.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#experimentationandconfigurationservicecontrol</string>
+			<key>pfm_name</key>
+			<string>ExperimentationAndConfigurationServiceControl</string>
+			<key>pfm_note</key>
+			<string>If you don't configure this policy, on a managed device on Stable and Beta channels the behavior is the same as the "Retrieve configurations only" mode.
+
+If you don't configure this policy, on an unmanaged device the behavior is the same as the "Retrieve configurations and experiments" mode.</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Retrieve configurations and experiments</string>
+				<string>Retrieve configurations only</string>
+				<string>Disable communication with the Experimentation and Configuration Service</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Control Experimentation and Configuration Service</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>79</string>
 			<key>pfm_description</key>
 			<string>If you set to True, when an external protocol confirmation prompt is shown, the user can select "Always open". The user won’t get any future confirmation prompts for this protocol.</string>
 			<key>pfm_description_reference</key>
@@ -4123,7 +4409,7 @@ If this policy is set to false or not configured, user can use the browser witho
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>32</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If set to enabled this policy forces the profile to be switched to ephemeral mode. If this policy is specified as an OS policy (e.g. GPO on Windows) it will apply to every profile on the system; if the policy is set as a Cloud policy it will apply only to a profile signed in with a managed account.</string>
 			<key>pfm_description_reference</key>
@@ -4145,7 +4431,7 @@ If the policy is set to disabled or left not set signing in leads to regular pro
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>41</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Forces queries in Google Web Search to be done with SafeSearch set to active and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
@@ -4158,14 +4444,26 @@ If you disable this setting or do not set a value, SafeSearch in Google Search i
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#forcebingsafesearch</string>
 			<key>pfm_name</key>
 			<string>ForceBingSafeSearch</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Don't configure search restrictions in Bing</string>
+				<string>Configure moderate search restrictions in Bing</string>
+				<string>Configure strict search restrictions in Bing</string>
+			</array>
 			<key>pfm_title</key>
 			<string>Force Bing SafeSearch</string>
 			<key>pfm_type</key>
-			<string>boolean</string>
+			<string>integer</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>41</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Forces queries in Google Web Search to be done with SafeSearch set to active and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
@@ -4209,7 +4507,7 @@ If you disable this setting or do not set a value, SafeSearch in Google Search a
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>55</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Enforces a minimum Restricted Mode on YouTube and prevents users from picking a less restricted mode.</string>
 			<key>pfm_description_reference</key>
@@ -4272,6 +4570,24 @@ If this setting is disabled or no value is set, Restricted Mode on YouTube is no
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Allow full screen mode</string>
+			<key>pfm_description_reference</key>
+			<string>Set the availability of full screen mode - all Microsoft Edge UI is hidden and only web content is visible.
+
+If you enable this policy or don't configure it, the user, apps, and extensions with appropriate permissions can enter full screen mode.
+
+If you disable this policy, users, apps, and extensions can't enter full screen mode.
+
+Opening Microsoft Edge in kiosk mode using the command line is unavailable when full screen mode is disabled.</string>
+			<key>pfm_name</key>
+			<string>FullscreenAllowed</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>78</string>
 			<key>pfm_description</key>
 			<string>If you enable this policy, the top auto-suggest result in the address bar suggestion list will navigate to intranet sites if the text entered in the address bar is a single word without punctuation.</string>
@@ -4321,7 +4637,7 @@ Popular, single-word search terms will require manual selection of search sugges
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>46</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If this policy is set to true or left unset, hardware acceleration will be enabled unless a certain GPU feature is blacklisted.</string>
 			<key>pfm_description_reference</key>
@@ -4399,7 +4715,7 @@ If this policy is not set, HTTP/0.9 will be disabled on non-default ports.</stri
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>39</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>This policy forces the autofill form data to be imported from the previous default browser if enabled. If enabled, this policy also affects the import dialog.</string>
 			<key>pfm_description_reference</key>
@@ -4443,7 +4759,7 @@ You can also set this policy as a recommendation. This means that Microsoft Edge
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>This policy forces bookmarks to be imported from the current default browser if enabled. If enabled, this policy also affects the import dialog.</string>
 			<key>pfm_description_reference</key>
@@ -4456,7 +4772,7 @@ If it is not set, the user may be asked whether to import, or importing may happ
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#importfavorites</string>
 			<!-- In Chrome this is ImportBookmarks -->
 			<key>pfm_name</key>
-			<string>Import Favorites</string>
+			<string>ImportFavorites</string>
 			<key>pfm_title</key>
 			<string>Import Favorites from default browser on first run</string>
 			<key>pfm_type</key>
@@ -4464,7 +4780,7 @@ If it is not set, the user may be asked whether to import, or importing may happ
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>This policy forces the browsing history to be imported from the current default browser if enabled. If enabled, this policy also affects the import dialog.</string>
 			<key>pfm_description_reference</key>
@@ -4484,7 +4800,7 @@ If it is not set, the user may be asked whether to import, or importing may happ
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>This policy forces the home page to be imported from the current default browser if enabled.</string>
 			<key>pfm_description_reference</key>
@@ -4522,7 +4838,7 @@ You can also set this policy as a recommendation. This means that Microsoft Edge
 			<key>pfm_name</key>
 			<string>ImportOpenTabs</string>
 			<key>pfm_note</key>
-			<string>This policy currently manages importing Google Chrome</string>
+			<string>This policy currently only supports importing from Google Chrome (on Windows 7, 8, and 10 and on macOS)</string>
 			<key>pfm_title</key>
 			<string>Allow importing of open tabs</string>
 			<key>pfm_type</key>
@@ -4554,7 +4870,7 @@ You can also set this policy as a recommendation. This means that Microsoft Edge
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>This policy forces the saved passwords to be imported from the previous default browser if enabled. If enabled, this policy also affects the import dialog.</string>
 			<key>pfm_description_reference</key>
@@ -4574,7 +4890,7 @@ If it is not set, the user may be asked whether to import, or importing may happ
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>This policy forces search engines to be imported from the current default browser if enabled. If enabled, this policy also affects the import dialog.</string>
 			<key>pfm_description_reference</key>
@@ -4620,9 +4936,9 @@ If this policy is left not set, this will be enabled and the user will be able t
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>14</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Specifies whether the user may open pages in Incognito mode in Google Chrome.</string>
+			<string>Specifies whether the user may open pages in Private mode in Microsoft Edge.</string>
 			<key>pfm_description_reference</key>
 			<string>0 - Incognito mode available
 1 - Incognito mode disabled
@@ -4652,15 +4968,15 @@ If 'Forced' is selected, pages may be opened ONLY in Incognito mode.</string>
 				<string>Private mode forced</string>
 			</array>
 			<key>pfm_title</key>
-			<string>Incognito mode availability</string>
+			<string>Private mode availability</string>
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>63</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If the policy is enabled, each of the named origins in a comma-separated list will run in its own process. This will also isolate origins named by subdomains; e.g. specifying https://example.com/ will also cause https://foo.example.com/ to be isolated as part of the https://example.com/ site. If the policy is disabled, no explicit Site Isolation will happen and field trials of IsolateOrigins and SitePerProcess will be disabled. Users will still be able to enable IsolateOrigins manually. If the policy is not configured, the user will be able to change this setting. On Google Chrome OS, it is recommended to also set the DeviceLoginScreenIsolateOrigins device policy to the same value. If the values specified by the two policies don't match, a delay may be incurred when entering a user session while the value specified by user policy is being applied.</string>
+			<string>Specify origins to run in isolation, in their own process. This policy also isolates origins named by subdomains - for example, specifying https://contoso.com/ will cause https://foo.contoso.com/ to be isolated as part of the https://contoso.com/ site. If the policy is enabled, each of the named origins in a comma-separated list will run in its own process. If you disable this policy, then both the 'IsolateOrigins' and 'SitePerProcess' features are disabled. Users can still enable 'IsolateOrigins' policy manually, via command line flags. If you don't configure the policy, the user can change this setting.</string>
 			<key>pfm_description_reference</key>
 			<string>If the policy is enabled, each of the named origins in a comma-separated list will run in its own process. This will also isolate origins named by subdomains; e.g. specifying https://example.com/ will also cause https://foo.example.com/ to be isolated as part of the https://example.com/ site. If the policy is disabled, no explicit Site Isolation will happen and field trials of IsolateOrigins and SitePerProcess will be disabled. Users will still be able to enable IsolateOrigins manually. If the policy is not configured, the user will be able to change this setting. On Google Chrome OS, it is recommended to also set the DeviceLoginScreenIsolateOrigins device policy to the same value. If the values specified by the two policies don't match, a delay may be incurred when entering a user session while the value specified by user policy is being applied.
 
@@ -4722,7 +5038,7 @@ If this setting is enabled or not set, web pages can use JavaScript but the user
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>37</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Configures a list of managed bookmarks.</string>
 			<key>pfm_description_reference</key>
@@ -4829,7 +5145,78 @@ Managed bookmarks are not synced to the user account and can't be modified by ex
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>14</string>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Manage Search Engines</string>
+			<key>pfm_description_reference</key>
+			<string>Lets you configure a list of list of up to 10 search engines, one of which must be marked as the default search engine. You do not need to specify the encoding, suggest_url, image_search_url, or image_search_post_params for any search engine (the image_search_post_params consists of comma-separated name/value pairs).
+
+If you enable this policy, users can't add, remove, or change any search engine in the list. Users can set their default search engine to any search engine in the list.
+
+If you disable or don't configure this policy, users can modify the search engines list as desired.
+
+If the DefaultSearchProviderSearchURL policy is set, this policy (ManagedSearchEngines) is ignored. The user must restart their browser to finish applying this policy.</string>
+			<key>pfm_name</key>
+			<string>ManagedSearchEngines</string>
+			<key>pfm_note</key>
+			<string>Microsoft's doc example XML indicate this dictionary lives within an array, so that you can include multiple which ProfileCreator cannot handle. If you use this preference in your exported file, you'll likely need to add surrounding array tags and add more managed search engine dictionaries.
+
+You can list up to 10 search engines. Not all keys in the preference dictionary are required.</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>is_default</string>
+					<key>pfm_title</key>
+					<string>Default?</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>name</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>keyword</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>search_url</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>suggest_url</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>image_search_url</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>encoding</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Managed search engines</string>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies the maximal number of simultaneous connections to the proxy server.</string>
 			<key>pfm_description_reference</key>
@@ -4883,7 +5270,7 @@ Leaving this policy not set will make Google Chrome use the default value of 500
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>67</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If this policy is set to true, Google Cast will connect to Cast devices on all IP addresses, not just RFC1918/RFC4913 private addresses.</string>
 			<key>pfm_description_reference</key>
@@ -4905,9 +5292,9 @@ If the policy "EnableMediaRouter" is set to false, then this policy's value woul
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Enables anonymous reporting of usage and crash-related data about Google Chrome to Google and prevents users from changing this setting.</string>
+			<string>Enables anonymous reporting of usage and crash-related data about Microsoft Edge to Microsoft and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables anonymous reporting of usage and crash-related data about Google Chrome to Google and prevents users from changing this setting.
 
@@ -4999,10 +5386,9 @@ If you don't configure this policy, Proactive Authentication is turned on.</stri
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>38</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>(Deprecated in 50, removed in 52. After 52, if value 1 is set, it will be treated as 0 - predict network actions on any network connection.)
-Enables network prediction in Google Chrome and prevents users from changing this setting.</string>
+			<string>Enables network prediction and prevents users from changing this setting. This controls DNS prefetching, TCP and SSL preconnection, and prerendering of web pages.</string>
 			<key>pfm_description_reference</key>
 			<string>0 - Predict network actions on any network connection
 1 - Predict network actions on any network that is not cellular.
@@ -5022,13 +5408,11 @@ If this policy is left not set, network prediction will be enabled but the user 
 			<key>pfm_range_list</key>
 			<array>
 				<integer>0</integer>
-				<integer>1</integer>
 				<integer>2</integer>
 			</array>
 			<key>pfm_range_list_titles</key>
 			<array>
 				<string>Predict network actions on any network connection</string>
-				<string>Predict network actions on any network that is not cellular.</string>
 				<string>Do not predict network actions on any network connection</string>
 			</array>
 			<key>pfm_title</key>
@@ -5036,7 +5420,7 @@ If this policy is left not set, network prediction will be enabled but the user 
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
-		<!-- <dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>69</string>
 			<key>pfm_description</key>
@@ -5052,7 +5436,7 @@ Setting a list of URLs in this policy has the same effect as setting the command
 
 For more information on secure contexts, see https://www.w3.org/TR/secure-contexts/</string>
 			<key>pfm_documentation_url</key>
-			<string>https://cloud.google.com/docs/chrome-enterprise/policies/?policy=OverrideSecurityRestrictionsOnInsecureOrigin</string>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#overridesecurityrestrictionsoninsecureorigin</string>
 			<key>pfm_name</key>
 			<string>OverrideSecurityRestrictionsOnInsecureOrigin</string>
 			<key>pfm_subkeys</key>
@@ -5063,10 +5447,10 @@ For more information on secure contexts, see https://www.w3.org/TR/secure-contex
 				</dict>
 			</array>
 			<key>pfm_title</key>
-			<string>Origins or hostname patterns to be treated as secure context.</string>
+			<string>Origins or hostname patterns to be treated as secure context</string>
 			<key>pfm_type</key>
 			<string>array</string>
-		</dict> -->
+		</dict>
 		<!-- <dict>
 			<key>pfm_app_min</key>
 			<string>76</string>
@@ -5153,9 +5537,9 @@ If a policy is not in the list, in case there is any conflict between sources, s
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>69</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Allows you to control the presentation of full-tab promotional and/or educational content in Google Chrome.</string>
+			<string>Allows you to control the presentation of full-tab promotional and/or educational content in Microsoft Edge.</string>
 			<key>pfm_description_reference</key>
 			<string>Allows you to control the presentation of full-tab promotional and/or educational content in Google Chrome.
 
@@ -5175,7 +5559,7 @@ This setting controls the presentation of the welcome pages that help users sign
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>64</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If the policy is enabled, the user will be asked where to save each file before downloading.
 If the policy is disabled, downloads will start immediately, and the user will not be asked where to save the file.
@@ -5237,76 +5621,67 @@ If you choose the value 'pac_script' as 'ProxyMode', the 'ProxyPacUrl' and 'Prox
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
-					<key>pfm_description</key>
-					<string></string>
+					<!-- <key>pfm_description_reference</key>
+					<string>The ProxyMode field allows you to specify the proxy server used by Google Chrome and prevents users from changing proxy settings.</string> -->
 					<key>pfm_name</key>
-					<string>ProxySetting</string>
+					<string>ProxyMode</string>
+					<key>pfm_range_list</key>
+					<array>
+						<string>direct</string>
+						<string>system</string>
+						<string>auto_detect</string>
+						<string>fixed_server</string>
+						<string>pac_script</string>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>Never use proxy (ignores other fields)</string>
+						<string>System (ignores other fields)</string>
+						<string>Auto Detect (ignores other fields)</string>
+						<string>Fixed (Uses ProxyServer &amp; ProxyBypassList)</string>
+						<string>Pac Script (Uses ProxyPacUrl &amp; ProxyBypassList)</string>
+					</array>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<!-- <key>pfm_description_reference</key>
+					<string>The ProxyPacUrl field is a URL to a proxy .pac file.</string> -->
+					<key>pfm_format</key>
+					<string>^https?://.*.pac$</string>
+					<key>pfm_name</key>
+					<string>ProxyPacUrl</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>https://internal.site/example.pac</string>
+				</dict>
+				<dict>
+					<!-- <key>pfm_description_reference</key>
+					<string>The ProxyServer field is a URL of the proxy server.</string> -->
+					<key>pfm_name</key>
+					<string>ProxyServer</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>123.123.123.123:8080</string>
+				</dict>
+				<dict>
+					<!-- <key>pfm_description_reference</key>
+					<string>The ProxyBypassList field is a list of proxy hosts that Google Chrome will bypass.</string> -->
+					<key>pfm_name</key>
+					<string>ProxyBypassList</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
-							<!-- <key>pfm_description_reference</key>
-							<string>The ProxyMode field allows you to specify the proxy server used by Google Chrome and prevents users from changing proxy settings.</string> -->
-							<key>pfm_name</key>
-							<string>ProxyMode</string>
-							<key>pfm_range_list</key>
-							<array>
-								<string>direct</string>
-								<string>system</string>
-								<string>auto_detect</string>
-								<string>fixed_server</string>
-								<string>pac_script</string>
-							</array>
-							<key>pfm_range_list_titles</key>
-							<array>
-								<string>Never use proxy (ignores other fields)</string>
-								<string>System (ignores other fields)</string>
-								<string>Auto Detect (ignores other fields)</string>
-								<string>Fixed (Uses ProxyServer &amp; ProxyBypassList)</string>
-								<string>Pac Script (Uses ProxyPacUrl &amp; ProxyBypassList)</string>
-							</array>
-							<key>pfm_type</key>
-							<string>string</string>
-						</dict>
-						<dict>
-							<!-- <key>pfm_description_reference</key>
-							<string>The ProxyPacUrl field is a URL to a proxy .pac file.</string> -->
 							<key>pfm_format</key>
-							<string>^https?://.*.pac$</string>
-							<key>pfm_name</key>
-							<string>ProxyPacUrl</string>
+							<string>^https?://.*</string>
 							<key>pfm_type</key>
 							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>https://internal.site/example.pac</string>
-						</dict>
-						<dict>
-							<!-- <key>pfm_description_reference</key>
-							<string>The ProxyServer field is a URL of the proxy server.</string> -->
-							<key>pfm_name</key>
-							<string>ProxyServer</string>
-							<key>pfm_type</key>
-							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>123.123.123.123:8080</string>
-						</dict>
-						<dict>
-							<!-- <key>pfm_description_reference</key>
-							<string>The ProxyBypassList field is a list of proxy hosts that Google Chrome will bypass.</string> -->
-							<key>pfm_name</key>
-							<string>ProxyBypassList</string>
-							<key>pfm_subkeys</key>
-							<array>
-								<dict>
-									<key>pfm_format</key>
-									<string>^https?://.*</string>
-									<key>pfm_type</key>
-									<string>string</string>
-								</dict>
-							</array>
-							<key>pfm_type</key>
-							<string>array</string>
 						</dict>
 					</array>
+					<key>pfm_type</key>
+					<string>array</string>
 				</dict>
 			</array>
 			<key>pfm_title</key>
@@ -5316,10 +5691,9 @@ If you choose the value 'pac_script' as 'ProxyMode', the 'ProxyPacUrl' and 'Prox
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>43</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If this policy is set to true or not set usage of QUIC protocol in Google Chrome is allowed.
-If this policy is set to false usage of QUIC protocol is disallowed.</string>
+			<string>QUIC is a transport layer network protocol that can improve performance of web applications that currently use TCP.</string>
 			<key>pfm_description_reference</key>
 			<string>If this policy is set to true or not set usage of QUIC protocol in Google Chrome is allowed.
 If this policy is set to false usage of QUIC protocol is disallowed.</string>
@@ -5334,9 +5708,9 @@ If this policy is set to false usage of QUIC protocol is disallowed.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>66</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Notify users that Google Chrome must be relaunched to apply a pending update.</string>
+			<string>Notify users that Microsoft Edge must be relaunched to apply a pending update.</string>
 			<key>pfm_description_reference</key>
 			<string>1 - Show a recurring prompt to the user indicating that a relaunch is recommended
 2 - Show a recurring prompt to the user indicating that a relaunch is required
@@ -5366,9 +5740,9 @@ The user's session is restored following the relaunch.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>67</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Allows you to set the time period, in milliseconds, over which users are notified that Google Chrome must be relaunched or that a Google Chrome OS device must be restarted to apply a pending update.</string>
+			<string>Allows you to set the time period, in milliseconds, over which users are notified that Microsoft Edge must be relaunched or that a Microsoft Edge OS device must be restarted to apply a pending update.</string>
 			<key>pfm_description_reference</key>
 			<string>Allows you to set the time period, in milliseconds, over which users are notified that Google Chrome must be relaunched or that a Google Chrome OS device must be restarted to apply a pending update.
 
@@ -5408,9 +5782,9 @@ If you don't configure this policy, Microsoft Edge respects the user preference 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>21</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Contains a regular expression which is used to determine which users can sign in to Google Chrome.</string>
+			<string>Determines which accounts can be set as browser primary accounts in Microsoft Edge (the account that is chosen during the Sync opt-in flow)</string>
 			<key>pfm_description_reference</key>
 			<string>Contains a regular expression which is used to determine which users can sign in to Google Chrome.
 
@@ -5430,7 +5804,7 @@ If this policy is left not set or blank, then any user can sign in to Google Chr
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>63</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If you enable this setting, all Flash content embedded on websites that have been set to allow Flash in content settings -- either by the user or by enterprise policy -- will be run, including content from other origins or small content.</string>
 			<key>pfm_description_reference</key>
@@ -5450,9 +5824,9 @@ If this setting is disabled or not set, Flash content from other origins or smal
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>44</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Chrome shows a warning page when users navigate to sites that have SSL errors. By default or when this policy is set to true, users are allowed to click through these warning pages.
+			<string>Edge shows a warning page when users navigate to sites that have SSL errors. By default or when this policy is set to true, users are allowed to click through these warning pages.
 Setting this policy to false disallows users to click through any warning page.</string>
 			<key>pfm_description_reference</key>
 			<string>Chrome shows a warning page when users navigate to sites that have SSL errors. By default or when this policy is set to true, users are allowed to click through these warning pages.
@@ -5468,9 +5842,9 @@ Setting this policy to false disallows users to click through any warning page.<
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>66</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If this policy is not configured then Google Chrome uses a default minimum version which is TLS 1.0.</string>
+			<string>If this policy is not configured then Microsoft Edge uses a default minimum version which is TLS 1.0.</string>
 			<key>pfm_description_reference</key>
 			<string>tls1 - TLS 1.0
 tls1.1 - TLS 1.1
@@ -5535,9 +5909,9 @@ When this policy is set to "Filter top level sites for adult content", sites cla
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Disables saving browser history in Google Chrome and prevents users from changing this setting.</string>
+			<string>Disables saving browser history in Microsft Edge and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
 			<string>Disables saving browser history in Google Chrome and prevents users from changing this setting.
 
@@ -5555,9 +5929,9 @@ If this setting is disabled or not set, browsing history is saved.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Enables search suggestions in Google Chrome's omnibox and prevents users from changing this setting.</string>
+			<string>Enables search suggestions in Microsoft Edge's omnibox and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables search suggestions in Google Chrome's omnibox and prevents users from changing this setting.
 
@@ -5579,7 +5953,7 @@ If this policy is left not set, this will be enabled but the user will be able t
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>65</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Specifies URLs and domains for which no prompt will be shown when attestation certificates from Security Keys are requested. Additionally, a signal will be sent to the Security Key indicating that individual attestation may be used. Without this, users will be prompted in Chrome 65+ when sites request attestation of Security Keys.</string>
 			<key>pfm_description_reference</key>
@@ -5660,7 +6034,7 @@ If this policy is configured then the user can't change it, and the apps shortcu
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>75</string>
+			<string>78</string>
 			<key>pfm_description</key>
 			<string>Enable support for Signed HTTP Exchange (SXG).</string>
 			<key>pfm_description_reference</key>
@@ -5704,7 +6078,7 @@ If you set this policy, you can configure whether a user is allowed to sign in t
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>63</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>You might want to look at the IsolateOrigins policy setting to get the best of both worlds, isolation and limited impact for users, by using IsolateOrigins with a list of the sites you want to isolate. This setting, SitePerProcess, isolates all sites. If the policy is enabled, each site will run in its own process. If the policy is disabled, no explicit Site Isolation will happen and field trials of IsolateOrigins and SitePerProcess will be disabled. Users will still be able to enable SitePerProcess manually. If the policy is not configured, the user will be able to change this setting. On Google Chrome OS, it is recommended to also set the DeviceLoginScreenSitePerProcess device policy to the same value. If the values specified by the two policies don't match, a delay may be incurred when entering a user session while the value specified by user policy is being applied.</string>
 			<key>pfm_description_reference</key>
@@ -5722,7 +6096,7 @@ NOTE: This policy does not apply on Android. To enable SitePerProcess on Android
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>65</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If this policy is not set or enabled, the user is allowed to use spellcheck.</string>
 			<key>pfm_description_reference</key>
@@ -5740,9 +6114,9 @@ If this policy is disabled, the user is not allowed to use spellcheck. The Spell
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>49</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Suppresses the warning that appears when Google Chrome is running on a computer or operating system that is no longer supported.</string>
+			<string>Suppresses the warning that appears when Microsoft Edge is running on a computer or operating system that is no longer supported.</string>
 			<key>pfm_description_reference</key>
 			<string>Suppresses the warning that appears when Google Chrome is running on a computer or operating system that is no longer supported.</string>
 			<key>pfm_documentation_url</key>
@@ -5756,7 +6130,7 @@ If this policy is disabled, the user is not allowed to use spellcheck. The Spell
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Disables data synchronization in Google Chrome using Google-hosted synchronization services and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
@@ -5800,7 +6174,7 @@ If you disable this policy, no tabs will be frozen.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>52</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If set to false, the 'End process' button is disabled in the Task Manager.</string>
 			<key>pfm_description_reference</key>
@@ -5840,9 +6214,45 @@ If you don't set this policy, the browser will only attempt to save memory when 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>12</string>
+			<string>78</string>
 			<key>pfm_description</key>
-			<string>Enables the integrated Google Translate service on Google Chrome.</string>
+			<string>Block tracking of users' web-browsing activity</string>
+			<key>pfm_description_reference</key>
+			<string>Lets you decide whether to block websites from tracking users' web-browsing activity.
+
+If you enable this policy, you have the following options for setting the level of tracking prevention:
+
+0 = Off (no tracking prevention) 1 = Basic (blocks harmful trackers, content and ads will be personalized) 2 = Balanced (blocks harmful trackers and trackers from sites user has not visited; content and ads will be less personalized) 3 = Strict (blocks harmful trackers and majority of trackers from all sites; content and ads will have minimal personalization. Some parts of sites might not work)
+
+If you disable this policy or don't configure it, users can set their own level of tracking prevention.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#trackingprevention</string>
+			<key>pfm_name</key>
+			<string>TrackingPrevention</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Off (no tracking prevention)</string>
+				<string>Basic (blocks harmful trackers, content and ads will be personalized)</string>
+				<string>Balanced (blocks harmful trackers and trackers from sites user has not visited; content and ads will be less personalized)</string>
+				<string>Strict (blocks harmful trackers and majority of trackers from all sites; content and ads will have minimal personalization. Some parts of sites might not work)</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Tracking Prevention</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Enables the integrated Microsoft translation service on Microsoft Edge.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables the integrated Google Translate service on Google Chrome.
 
@@ -5864,9 +6274,9 @@ If this setting is left not set the user can decide to use this function or not.
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>This policy prevents the user from loading web pages from blacklisted URLs. The blacklist provides a list of URL patterns that specify which URLs will be blacklisted. A URL pattern is formatted according to https://www.chromium.org/administrators/url-blacklist-filter-format.</string>
+			<string>Define a list of sites, based on URL patterns, that are blocked (your users can't load them). Format the URL pattern according to https://go.microsoft.com/fwlink/?linkid=2095322.</string>
 			<key>pfm_description_reference</key>
 			<string>This policy prevents the user from loading web pages from blacklisted URLs. The blacklist provides a list of URL patterns that specify which URLs will be blacklisted.
 
@@ -5898,9 +6308,9 @@ If this policy is not set no URL will be blacklisted in the browser.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>15</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Allows access to the listed URLs, as exceptions to the URL blacklist. A URL pattern is formatted according to https://www.chromium.org/administrators/url-blacklist-filter-format.</string>
+			<string>Allow access to the listed URLs, as exceptions to the URL block list. Format the URL pattern according to https://go.microsoft.com/fwlink/?linkid=2095322.</string>
 			<key>pfm_description_reference</key>
 			<string>Allows access to the listed URLs, as exceptions to the URL blacklist.
 
@@ -5999,7 +6409,7 @@ If this policy is left not set, URL-keyed anonymized data collection will be ena
 			<key>pfm_app_min</key>
 			<string>77</string>
 			<key>pfm_description</key>
-			<string>Allow user feedback. If the policy is set to false, users can not send feedback to Google.</string>
+			<string>Allow user feedback. If the policy is set to false, users can not send feedback to Microsoft.</string>
 			<key>pfm_description_reference</key>
 			<string>Allow user feedback. If the policy is set to false, users can not send feedback to Google.
 
@@ -6015,9 +6425,9 @@ If the policy is unset or set to true, users can send feedback to Google via Men
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>11</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the directory that Google Chrome will use for storing user data. See https://www.chromium.org/administrators/policy-list-3/user-data-directory-variables for a list of variables that can be used.</string>
+			<string>Configures the directory that Microsoft Edge will use for storing user data. See https://go.microsoft.com/fwlink/?linkid=2095041 for a list of variables that can be used.</string>
 			<key>pfm_description_reference</key>
 			<string>Configures the directory that Google Chrome will use for storing user data.
 
@@ -6035,15 +6445,14 @@ If this policy is left not set the default profile path will be used and the use
 			<key>pfm_type</key>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
-			<string>${users}/${user_name}/Chrome</string>
+			<string>${users}/${user_name}/Edge</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>25</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If enabled or not configured (default), the user will be prompted for
-video capture access except for URLs configured in the
-VideoCaptureAllowedUrls list which will be granted access without prompting.</string>
+video capture access except for URLs configured in the VideoCaptureAllowedUrls list which will be granted access without prompting.</string>
 			<key>pfm_description_reference</key>
 			<string>If enabled or not configured (default), the user will be prompted for
 video capture access except for URLs configured in the
@@ -6064,7 +6473,7 @@ This policy affects all types of video inputs and not only the built-in camera.<
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>29</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Patterns in this list will be matched against the security
 origin of the requesting URL.  If a match is found, access to audio
@@ -6095,9 +6504,9 @@ NOTE: Until version 45, this policy was only supported in Kiosk mode.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>35</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Allows to turn off WPAD (Web Proxy Auto-Discovery) optimization in Google Chrome.</string>
+			<string>Allows you to turn off WPAD (Web Proxy Auto-Discovery) optimization in Microsoft Edge</string>
 			<key>pfm_description_reference</key>
 			<string>Allows to turn off WPAD (Web Proxy Auto-Discovery) optimization in Google Chrome.
 
@@ -6115,7 +6524,7 @@ Independent of whether or how this policy is set, the WPAD optimization setting 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>75</string>
+			<string>80</string>
 			<key>pfm_description</key>
 			<string>Specifies a list of websites that are installed silently, without user interaction, and which cannot be uninstalled nor disabled by the user.</string>
 			<key>pfm_description_reference</key>
@@ -6176,10 +6585,12 @@ Each list item of the policy is an object with a mandatory member: "url" and two
 			<string>array</string>
 		</dict>
 		<dict>
+			<key>pfm_app_deprecated</key>
+			<string></string>
 			<key>pfm_app_min</key>
-			<string>65</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>This policy allows users of the WebDriver feature to override policies which can interfere with its operation.</string>
+			<string>This policy allows users of the WebDriver feature to override policies which can interfere with its operation. This policy is deprecated. It is currently supported but will become obsolete in a future release.</string>
 			<key>pfm_description_reference</key>
 			<string>This policy allows users of the WebDriver feature to override policies which can interfere with its operation.
 
@@ -6225,7 +6636,74 @@ Google may associate these logs, by means of a session ID, with other logs colle
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>54</string>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Manage exposure of local IP addressess by WebRTC</string>
+			<key>pfm_description_reference</key>
+			<string>Specifies a list of origins (URLs) or hostname patterns (like "contoso.com") for which local IP address should be exposed by WebRTC.
+
+If you enable this policy and set a list of origins (URLs) or hostname patterns, when edge://flags/#enable-webrtc-hide-local-ips-with-mdns is Enabled, WebRTC will expose the local IP address for cases that match patterns in the list.
+
+If you disable or don't configure this policy, and edge://flags/#enable-webrtc-hide-local-ips-with-mdns is Enabled, WebRTC will not expose local IP addresses. The local IP address is concealed with an mDNS hostname.
+
+If you enable, disable, or don't configure this policy, and edge://flags/#enable-webrtc-hide-local-ips-with-mdns is Disabled, WebRTC will expose local IP addresses.
+
+Please note that this policy weakens the protection of local IP addresses that might be needed by administrators.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#webrtclocalipsallowedurls</string>
+			<key>pfm_name</key>
+			<string>WebRtcLocalIpsAllowedUrls</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_title</key>
+					<string>URLs</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Manage exposure of local IP addressess by WebRTC</string>
+			<key>pfm_description_reference</key>
+			<string>Specifies a list of origins (URLs) or hostname patterns (like "contoso.com") for which local IP address should be exposed by WebRTC.
+
+If you enable this policy and set a list of origins (URLs) or hostname patterns, when edge://flags/#enable-webrtc-hide-local-ips-with-mdns is Enabled, WebRTC will expose the local IP address for cases that match patterns in the list.
+
+If you disable or don't configure this policy, and edge://flags/#enable-webrtc-hide-local-ips-with-mdns is Enabled, WebRTC will not expose local IP addresses. The local IP address is concealed with an mDNS hostname.
+
+If you enable, disable, or don't configure this policy, and edge://flags/#enable-webrtc-hide-local-ips-with-mdns is Disabled, WebRTC will expose local IP addresses.
+
+Please note that this policy weakens the protection of local IP addresses that might be needed by administrators.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#webrtclocalhostiphandling</string>
+			<key>pfm_name</key>
+			<string>WebRtcLocalhostIpHandling</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>default</string>
+				<string>default_public_and_private_interfaces</string>
+				<string>default_public_interface_only</string>
+				<string>disable_non_proxied_udp</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Allow all interfaces</string>
+				<string>Allow public and private interfaces over http default route</string>
+				<string>Allow public interface over http default route, but don't expose local IP</string>
+				<string>Use TCP unless proxy server supports UDP and don't expose local IP</string>
+			</array>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If the policy is set, the UDP port range used by WebRTC is restricted to the specified port interval (endpoints included).</string>
 			<key>pfm_description_reference</key>
@@ -6247,7 +6725,7 @@ If the policy is not set, or if it is set to the empty string or an invalid port
 		<!-- START NativeMessaging -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>34</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to specify which native messaging hosts that should not be loaded. A blacklist value of '*' means all native messaging hosts are blacklisted unless they are explicitly listed in the whitelist.</string>
 			<key>pfm_description_reference</key>
@@ -6277,7 +6755,7 @@ If this policy is left not set Google Chrome will load all installed native mess
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>34</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Enables user-level installation of Native Messaging hosts.</string>
 			<key>pfm_description_reference</key>
@@ -6299,7 +6777,7 @@ If this setting is left not set Google Chrome will allow usage of user-level Nat
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>34</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to specify which native messaging hosts are not subject to the blacklist. A blacklist value of * means all native messaging hosts are blacklisted and only native messaging hosts listed in the whitelist will be loaded.</string>
 			<key>pfm_description_reference</key>
@@ -6331,9 +6809,9 @@ By default, all native messaging hosts are whitelisted, but if all native messag
 		<!-- START PasswordManager -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>If this setting is enabled, users can have Google Chrome memorize passwords and provide them automatically the next time they log in to a site.</string>
+			<string>If this setting is enabled, users can have Microsoft Edge memorize passwords and provide them automatically the next time they log in to a site.</string>
 			<key>pfm_description_reference</key>
 			<string>If this setting is enabled, users can have Google Chrome memorize passwords and provide them automatically the next time they log in to a site.
 
@@ -6394,9 +6872,9 @@ If this setting is disabled, users cannot print to Google Cloud Print from the G
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>48</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Overrides Google Chrome default printer selection rules.</string>
+			<string>Overrides Microsoft Edge default printer selection rules.</string>
 			<key>pfm_description_reference</key>
 			<string>Overrides Google Chrome default printer selection rules.
 
@@ -6460,7 +6938,7 @@ If this policy is not set or is set to false, print commands trigger the print p
 		</dict> -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>70</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Force 'headers and footers' to be on or off in the printing dialog.</string>
 			<key>pfm_description_reference</key>
@@ -6482,9 +6960,9 @@ If the policy is set to true, 'Headers and footers' is selected in the print pre
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Enables printing in Google Chrome and prevents users from changing this setting.</string>
+			<string>Enables printing in Microsoft Edge and prevents users from changing this setting.</string>
 			<key>pfm_description_reference</key>
 			<string>Enables printing in Google Chrome and prevents users from changing this setting.
 
@@ -6518,9 +6996,9 @@ If this setting is disabled, users cannot print from Google Chrome. Printing is 
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>61</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Causes Google Chrome to use the system default printer as the default choice in Print Preview instead of the most recently used printer.</string>
+			<string>Causes Microsoft Edge to use the system default printer as the default choice in Print Preview instead of the most recently used printer.</string>
 			<key>pfm_description_reference</key>
 			<string>Causes Google Chrome to use the system default printer as the default choice in Print Preview instead of the most recently used printer.
 
@@ -6540,9 +7018,9 @@ If you enable this setting, Print Preview will use the OS system default printer
 		<!-- START ProxyServer -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Google Chrome will bypass any proxy for the list of hosts given here.</string>
+			<string>Microsoft Edge will bypass any proxy for the list of hosts given here.</string>
 			<key>pfm_description_reference</key>
 			<string>Google Chrome will bypass any proxy for the list of hosts given here.
 
@@ -6565,9 +7043,9 @@ https://www.chromium.org/developers/design-documents/network-settings#TOC-Comman
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Allows you to specify the proxy server used by Google Chrome and prevents users from changing proxy settings.</string>
+			<string>Allows you to specify the proxy server used by Microsoft Edge and prevents users from changing proxy settings.</string>
 			<key>pfm_description_reference</key>
 			<string>direct - Never use a proxy
 auto_detect - Auto detect proxy settings
@@ -6619,7 +7097,7 @@ Leaving this policy not set will allow the users to choose the proxy settings on
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>You can specify a URL to a proxy .pac file here.</string>
 			<key>pfm_description_reference</key>
@@ -6643,6 +7121,8 @@ https://www.chromium.org/developers/design-documents/network-settings#TOC-Comman
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>You can specify the URL of the proxy server here.</string>
 			<key>pfm_description_reference</key>
@@ -6664,38 +7144,38 @@ https://www.chromium.org/developers/design-documents/network-settings#TOC-Comman
 			<string>string</string>
 		</dict>
 		<dict>
-			<!-- Documentation does not have an explicit version listed for deprecation -->
-			<key>pfm_app_deprecated</key>
-			<string>10</string>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>This policy is deprecated, use ProxyMode instead.
-
-Allows you to specify the proxy server used by Google Chrome and prevents users from changing proxy settings.</string>
+			<string>Configures the proxy settings for Microsoft Edge.</string>
 			<key>pfm_description_reference</key>
-			<string>This policy is deprecated, use ProxyMode instead.
+			<string>Configures the proxy settings for Microsoft Edge.
 
-Allows you to specify the proxy server used by Google Chrome and prevents users from changing proxy settings.
+If you enable this policy, Microsoft Edge ignores all proxy-related options specified from the command line.
 
-This policy only takes effect if the ProxySettings policy has not been specified.
+If you don't configure this policy, users can choose their own proxy settings.
 
-If you choose to never use a proxy server and always connect directly, all other options are ignored.
+This policy overrides the following individual policies:
 
-If you choose to use system proxy settings or auto detect the proxy server, all other options are ignored.
+ProxyMode ProxyPacUrl ProxyServer ProxyBypassList
 
-If you choose manual proxy settings, you can specify further options in 'Address or URL of proxy server', 'URL to a proxy .pac file' and 'Comma-separated list of proxy bypass rules'. Only the HTTP proxy server with the highest priority is available for ARC-apps.
+The ProxyMode field lets you specify the proxy server used by Microsoft Edge and prevents users from changing proxy settings.
 
-For detailed examples, visit: https://www.chromium.org/developers/design-documents/network-settings#TOC-Command-line-options-for-proxy-sett.
+The ProxyPacUrl field is a URL to a proxy .pac file.
 
-If you enable this setting, Google Chrome ignores all proxy-related options specified from the command line.
+The ProxyServer field is a URL for the proxy server.
 
-Leaving this policy not set will allow the users to choose the proxy settings on their own.
+The ProxyBypassList field is a list of proxy hosts that Microsoft Edge bypasses.
 
-0 = Never use a proxy
-1 = Auto detect proxy settings
-2 = Manually specify proxy settings
-3 = Use system proxy settings</string>
+If you choose the 'direct' value as 'ProxyMode', a proxy is never used and all other fields are ignored.
+
+If you choose the 'system' value as 'ProxyMode', the systems's proxy is used and all other fields are ignored.
+
+If you choose the 'auto_detect' value as 'ProxyMode', all other fields are ignored.
+
+If you choose the 'fixed_server' value as 'ProxyMode', the 'ProxyServer' and 'ProxyBypassList' fields are used.
+
+If you choose the 'pac_script' value as 'ProxyMode', the 'ProxyPacUrl' and 'ProxyBypassList' fields are used.</string>
 			<key>pfm_name</key>
 			<string>ProxyServerMode</string>
 			<key>pfm_range_list</key>
@@ -6716,6 +7196,151 @@ Leaving this policy not set will allow the users to choose the proxy settings on
 			<string>Proxy server settings</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Configure Microsoft Defender SmartScreen</string>
+			<key>pfm_description_reference</key>
+			<string>This policy setting lets you configure whether to turn on Microsoft Defender SmartScreen. Microsoft Defender SmartScreen provides warning messages to help protect your users from potential phishing scams and malicious software. By default, Microsoft Defender SmartScreen is turned on.
+
+If you enable this setting, Microsoft Defender SmartScreen is turned on.
+
+If you disable this setting, Microsoft Defender SmartScreen is turned off.
+
+If you don't configure this setting, users can choose whether to use Microsoft Defender SmartScreen.
+
+This policy is available only on Windows instances that are joined to a Microsoft Active Directory domain; or on Windows 10 Pro or Enterprise instances that are enrolled for device management.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#smartscreenenabled</string>
+			<key>pfm_name</key>
+			<string>SmartScreenEnabled</string>
+			<key>pfm_title</key>
+			<string>SmartScreen Enabled</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Lets you decide whether users can override the Microsoft Defender SmartScreen warnings about potentially malicious websites.</string>
+			<key>pfm_description_reference</key>
+			<string>This policy setting lets you decide whether users can override the Microsoft Defender SmartScreen warnings about potentially malicious websites.
+
+If you enable this setting, users can't ignore Microsoft Defender SmartScreen warnings and they are blocked from continuing to the site.
+
+If you disable or don't configure this setting, users can ignore Microsoft Defender SmartScreen warnings and continue to the site.
+
+This policy is available only on Windows instances that are joined to a Microsoft Active Directory domain; or on Windows 10 Pro or Enterprise instances that are enrolled for device management.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#preventsmartscreenpromptoverride</string>
+			<key>pfm_name</key>
+			<string>PreventSmartScreenPromptOverride</string>
+			<key>pfm_title</key>
+			<string>Prevent SmartScreen prompt override</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Lets you determine whether users can override Microsoft Defender SmartScreen warnings about unverified downloads.</string>
+			<key>pfm_description_reference</key>
+			<string>This policy lets you determine whether users can override Microsoft Defender SmartScreen warnings about unverified downloads.
+
+If you enable this policy, users in your organization can't ignore Microsoft Defender SmartScreen warnings, and they're prevented from completing the unverified downloads.
+
+If you disable or don't configure this policy, users can ignore Microsoft Defender SmartScreen warnings and complete unverified downloads.
+
+This policy is available only on Windows instances that are joined to a Microsoft Active Directory domain; or on Windows 10 Pro or Enterprise instances that are enrolled for device management.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#preventsmartscreenpromptoverrideforfiles</string>
+			<key>pfm_name</key>
+			<string>PreventSmartScreenPromptOverrideForFiles</string>
+			<key>pfm_title</key>
+			<string>Prevent SmartScreen prompt override for files</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Configure the list of domains for which Microsoft Defender SmartScreen won't trigger warnings.</string>
+			<key>pfm_description_reference</key>
+			<string>Configure the list of Microsoft Defender SmartScreen trusted domains. This means: Microsoft Defender SmartScreen won't check for potentially malicious resources like phishing software and other malware if the source URLs match these domains. The Microsoft Defender SmartScreen download protection service won't check downloads hosted on these domains.
+
+If you enable this policy, Microsoft Defender SmartScreen trusts these domains. If you disable or don't set this policy, default Microsoft Defender SmartScreen protection is applied to all resources.
+
+This policy is available only on Windows instances that are joined to a Microsoft Active Directory domain; or on Windows 10 Pro or Enterprise instances that are enrolled for device management. Also note that this policy does not apply if your organization has enabled Microsoft Defender Advanced Threat Protection. You must configure your allow and block lists in Microsoft Defender Security Center instead.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#smartscreenallowlistdomains</string>
+			<key>pfm_name</key>
+			<string>SmartScreenAllowListDomains</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_title</key>
+					<string>Allowed Domains</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>mydomain.com</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Prevent SmartScreen prompt override for files</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
+			<key>pfm_description</key>
+			<string>Force Microsoft Defender SmartScreen checks on downloads from trusted sources</string>
+			<key>pfm_description_reference</key>
+			<string>This policy setting lets you configure whether Microsoft Defender SmartScreen checks download reputation from a trusted source.
+
+If you enable or don't configure this setting, Microsoft Defender SmartScreen checks the download’s reputation regardless of source.
+
+If you disable this setting, Microsoft Defender SmartScreen doesn’t check the download’s reputation when downloading from a trusted source.
+
+This policy is available only on Windows instances that are joined to a Microsoft Active Directory domain; or on Windows 10 Pro or Enterprise instances that are enrolled for device management.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#smartscreenfortrusteddownloadsenabled</string>
+			<key>pfm_name</key>
+			<string>SmartScreenForTrustedDownloadsEnabled</string>
+			<key>pfm_title</key>
+			<string>Enable SmartScreen Trusted Downloads</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Configure Microsoft Defender SmartScreen to block potentially unwanted apps</string>
+			<key>pfm_description_reference</key>
+			<string>This policy setting lets you configure whether to turn on blocking for potentially unwanted apps in Microsoft Defender SmartScreen. Potentially unwanted app blocking in Microsoft Defender SmartScreen provides warning messages to help protect users from adware, coin miners, bundleware, and other low-reputation apps that are hosted by websites. Potentially unwanted app blocking in Microsoft Defender SmartScreen is turned off by default.
+
+If you enable this setting, potentially unwanted app blocking in Microsoft Defender SmartScreen is turned on.
+
+If you disable this setting, potentially unwanted app blocking in Microsoft Defender SmartScreen is turned off.
+
+If you don't configure this setting, users can choose whether to use potentially unwanted app blocking in Microsoft Defender SmartScreen.
+
+This policy is available only on Windows instances that are joined to a Microsoft Active Directory domain; or on Windows 10 Pro or Enterprise instances that are enrolled for device management.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#smartscreenfortrusteddownloadsenabled</string>
+			<key>pfm_name</key>
+			<string>SmartScreenPuaEnabled</string>
+			<key>pfm_title</key>
+			<string>Enable SmartScreen potentially unwanted apps</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<!-- END ProxyServer -->
 		<!-- START RemoteAccess -->
@@ -7068,10 +7693,9 @@ If this policy is left not set, or if it is set to an empty string, the remote a
 		<!-- Documentation does not have an explicit version listed for deprecation -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>69</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configure the change password URL (HTTP and HTTPS schemes only). Password protection service will send users to this URL to change their password after seeing a warning in the browser.
-In order for Google Chrome to correctly capture the new password fingerprint on this change password page, please make sure your change password page follows the guidelines on https://www.chromium.org/developers/design-documents/create-amazing-password-forms.</string>
+			<string>Configure the change password URL (HTTP and HTTPS schemes only). Password protection service will send users to this URL to change their password after seeing a warning in the browser.</string>
 			<key>pfm_description_reference</key>
 			<string>Configure the change password URL (HTTP and HTTPS schemes only). Password protection service will send users to this URL to change their password after seeing a warning in the browser.
 In order for Google Chrome to correctly capture the new password fingerprint on this change password page, please make sure your change password page follows the guidelines on https://www.chromium.org/developers/design-documents/create-amazing-password-forms.
@@ -7081,10 +7705,12 @@ If this setting is disabled or not set, then password protection service will se
 This policy is not available on Windows instances that are not joined to a Microsoft® Active Directory® domain.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#passwordprotectionchangepasswordurl</string>
+			<key>pfm_format</key>
+			<string>^https?://.*</string>
 			<key>pfm_name</key>
 			<string>PasswordProtectionChangePasswordURL</string>
 			<key>pfm_title</key>
-			<string>Configure the change password URL.</string>
+			<string>Change password URL</string>
 			<key>pfm_type</key>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
@@ -7092,10 +7718,9 @@ This policy is not available on Windows instances that are not joined to a Micro
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>69</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configure the list of enterprise login URLs (HTTP and HTTPS schemes only). Fingerprint of password will be captured on these URLs and used for password reuse detection.
-In order for Google Chrome to correctly capture password fingerprints, please make sure your login pages follow the guidelines on https://www.chromium.org/developers/design-documents/create-amazing-password-forms.</string>
+			<string>Configure the list of enterprise login URLs (HTTP and HTTPS schemes only). Fingerprint of password will be captured on these URLs and used for password reuse detection.</string>
 			<key>pfm_description_reference</key>
 			<string>Configure the list of enterprise login URLs (HTTP and HTTPS schemes only). Fingerprint of password will be captured on these URLs and used for password reuse detection.
 In order for Google Chrome to correctly capture password fingerprints, please make sure your login pages follow the guidelines on https://www.chromium.org/developers/design-documents/create-amazing-password-forms.
@@ -7105,6 +7730,8 @@ If this setting is disabled or not set, then password protection service will on
 This policy is not available on Windows instances that are not joined to a Microsoft® Active Directory® domain.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#passwordprotectionloginurls</string>
+			<key>pfm_format</key>
+			<string>^https?://.*</string>
 			<key>pfm_name</key>
 			<string>PasswordProtectionLoginURLs</string>
 			<key>pfm_subkeys</key>
@@ -7117,13 +7744,13 @@ This policy is not available on Windows instances that are not joined to a Micro
 				</dict>
 			</array>
 			<key>pfm_title</key>
-			<string>Configure the list of enterprise login URLs where password protection service should capture fingerprint of password.</string>
+			<string>Enterprise login URLs</string>
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>69</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to control the triggering of passwore protection warning. Password protection alerts users when they reuse their protected password on potentially suspicious sites.</string>
 			<key>pfm_description_reference</key>
@@ -7276,9 +7903,9 @@ See https://developers.google.com/safe-browsing for more info on Safe Browsing.<
 		<!-- START StartupHomepageNewTabPage -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the type of the default home page in Google Chrome and prevents users from changing home page preferences. The home page can either be set to a URL you specify or set to the New Tab Page.</string>
+			<string>Configures the type of the default home page in Microsoft Edge and prevents users from changing home page preferences. The home page can either be set to a URL you specify or set to the New Tab Page.</string>
 			<key>pfm_description_reference</key>
 			<string>Configures the type of the default home page in Google Chrome and prevents users from changing home page preferences. The home page can either be set to a URL you specify or set to the New Tab Page.
 
@@ -7303,9 +7930,9 @@ to a Microsoft® Active Directory® domain.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
-			<string>Configures the default home page URL in Google Chrome and prevents users from changing it.</string>
+			<string>Configures the default home page URL in Microsoft Edge and prevents users from changing it.</string>
 			<key>pfm_description_reference</key>
 			<string>Configures the default home page URL in Google Chrome and prevents users from changing it.
 
@@ -7330,6 +7957,89 @@ to a Microsoft® Active Directory® domain.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>Set new tab page company logo. The logo must be in PNG or SVG format, and its file size must not exceed 16 MB. For help with determining the SHA-256 hash, see https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash.</string>
+			<key>pfm_description_reference</key>
+			<string>Specifies the company logo to use on the new tab page in Microsoft Edge.
+
+The policy should be configured as a string that expresses the logo(s) in JSON format. For example: { "default_logo": { "url": "https://www.contoso.com/logo.png", "hash": "cd0aa9856147b6c5b4ff2b7dfee5da20aa38253099ef1b4a64aced233c9afe29" }, "light_logo": { "url": "https://www.contoso.com/light_logo.png", "hash": "517d286edb416bb2625ccfcba9de78296e90da8e32330d4c9c8275c4c1c33737" } }
+
+You configure this policy by specifying the URL from which Microsoft Edge can download the logo and its cryptographic hash (SHA-256), which is used to verify the integrity of the download. The logo must be in PNG or SVG format, and its file size must not exceed 16 MB. The logo is downloaded and cached, and it will be redownloaded whenever the URL or the hash changes. The URL must be accessible without any authentication.
+
+The 'default_logo' is required and will be used when there's no background image. If 'light_logo' is provided, it will be used when the user's new tab page has a background image. We recommend a horizontal logo with a transparent background that is left-aligned and vertically centered. The logo should have a minimum height of 32 pixels and an aspect ratio from 1:1 to 4:1. The 'default_logo' should have proper contrast against a white/black background while the 'light_logo' should have proper contrast against a background image.
+
+If you enable this policy, Microsoft Edge downloads and shows the specified logo(s) on the new tab page. Users can't override or hide the logo(s).
+
+If you disable or don't configure this policy, Microsoft Edge will show no company logo or a Microsoft logo on the new tab page.
+
+For help with determining the SHA-256 hash, see https://docs.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#newtabpagecompanylogo</string>
+			<key>pfm_name</key>
+			<string>NewTabPageCompanyLogo</string>
+			<key>pfm_note</key>
+			<string>The 'default_logo' is required and will be used when there's no background image. If 'light_logo' is provided, it will be used when the user's new tab page has a background image. We recommend a horizontal logo with a transparent background that is left-aligned and vertically centered. The logo should have a minimum height of 32 pixels and an aspect ratio from 1:1 to 4:1.</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>default_logo</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_name</key>
+							<string>hash</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_format</key>
+							<string>^.*\.[png|svg]</string>
+							<key>pfm_name</key>
+							<string>url</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Default Logo</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>light_logo</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_name</key>
+							<string>hash</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_format</key>
+							<string>^.*\.[png|svg]</string>
+							<key>pfm_name</key>
+							<string>url</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Light Logo</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>New Tab Page Company Logo</string>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>77</string>
 			<key>pfm_description</key>
 			<string>Hides the default top sites from the new tab page in Microsoft Edge.</string>
@@ -7348,7 +8058,7 @@ If you set this policy to false or don't configure it, the default top site tile
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>58</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Configures the default New Tab page URL and prevents users from changing it.</string>
 			<key>pfm_description_reference</key>
@@ -7372,7 +8082,62 @@ This policy is not available on Windows instances that are not joined to a Micro
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>Set new tab page managed quick links</string>
+			<key>pfm_description_reference</key>
+			<string>By default, Microsoft Edge displays quick links on the new tab page from user-added shortcuts and top sites based on browsing history. With this policy, you can configure up to three quick link tiles on the new tab page, expressed as a JSON object:
+
+[ { "url": "https://www.contoso.com", "title": "Contoso Portal", "pinned": true/false }, ... ]
+
+The 'url' field is required; 'title' and 'pinned' are optional. If 'title' is not provided, the URL is used as the default title. If 'pinned' is not provided, the default value is false.
+
+Microsoft Edge presents these in the order listed, from left to right, with all pinned tiles displayed ahead of non-pinned tiles.
+
+If the policy is set as mandatory, the 'pinned' field will be ignored and all tiles will be pinned. The tiles can't be deleted by the user and will always appear at the front of the quick links list.
+
+If the policy is set as recommended, pinned tiles will remain in the list but the user has the ability to edit and delete them. Quick link tiles that aren't pinned behave like default top sites and are pushed off the list if other websites are visited more frequently. When applying non-pinned links via this policy to an existing browser profile, the links may not appear at all, depending on how they rank compared to the user's browsing history.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#newtabpagemanagedquicklinks</string>
+			<key>pfm_name</key>
+			<string>NewTabPageManagedQuickLinks</string>
+			<key>pfm_note</key>
+			<string>Microsoft's doc example XML indicate this dictionary lives within an array, so that you can include multiple which ProfileCreator cannot handle. If you use this preference in your exported file, you'll likely need to add surrounding array tags and add more quick link dictionaries.</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>url</string>
+					<key>pfm_title</key>
+					<string>URL</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>title</string>
+					<key>pfm_title</key>
+					<string>Title</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>pinned</string>
+					<key>pfm_title</key>
+					<string>Pinned</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>New Tab page managed quick links</string>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to specify the behavior on startup.</string>
 			<key>pfm_description_reference</key>
@@ -7417,7 +8182,7 @@ to a Microsoft® Active Directory® domain.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>If 'Open a list of URLs' is selected as the startup action, this allows you to specify the list of URLs that are opened. If left not set no URL will be opened on start up.</string>
 			<key>pfm_description_reference</key>
@@ -7447,7 +8212,7 @@ to a Microsoft® Active Directory® domain.</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>8</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Shows the Home button on Microsoft Edge's toolbar.</string>
 			<key>pfm_description_reference</key>
@@ -7472,7 +8237,7 @@ Leaving this policy not set will allow the user to choose whether to show the ho
 		<!-- END StartupHomepageNewTabPage -->
 		<dict>
 			<key>pfm_app_min</key>
-			<string>68</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are allowed to ask the user to grant them access to a USB device.</string>
 			<key>pfm_description_reference</key>
@@ -7499,7 +8264,7 @@ URL patterns in this policy should not clash with ones configured via WebUsbBloc
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>68</string>
+			<string>77</string>
 			<key>pfm_description</key>
 			<string>Allows you to set a list of url patterns that specify sites which are prevented from asking the user to grant them access to a USB device.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -476,6 +476,7 @@
 					<string>NewTabPageHideDefaultTopSites</string>
 					<string>NewTabPageLocation</string>
 					<string>NewTabPageManagedQuickLinks</string>
+					<string>NewTabPageSetFeedType</string>
 					<string>RestoreOnStartup</string>
 					<string>RestoreOnStartupURLs</string>
 					<string>ShowHomeButton</string>
@@ -8134,6 +8135,50 @@ If the policy is set as recommended, pinned tiles will remain in the list but th
 			<string>New Tab page managed quick links</string>
 			<key>pfm_type</key>
 			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>79</string>
+			<key>pfm_description</key>
+			<string>Configure the Microsoft Edge new tab page experience</string>
+			<key>pfm_description_reference</key>
+			<string>Lets you choose either the Microsoft News or Office 365 feed experience for the new tab page.
+
+When you set this policy to Microsoft News feed experience (0), users will see the Microsoft News feed experience on the new tab page.
+
+When you set this policy to Office 365 feed experience (1), users with an Azure Active Directory browser sign-in will see the Office 365 feed experience on the new tab page.
+
+If you disable or don't configure this policy:
+
+Users with an Azure Active Directory browser sign-in are offered the Office 365 new tab page feed experience, as well as the standard new tab page feed experience.
+
+Users without an Azure Active Directory browser sign-in will see the standard new tab page experience.
+
+If you configure this policy and the NewTabPageLocation policy, NewTabPageLocation has precedence.
+
+Default setting: Disabled or not configured.
+
+0 = Microsoft News feed experience
+
+1 = Office 365 feed experience</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#newtabpagesetfeedtype</string>
+			<key>pfm_name</key>
+			<string>NewTabPageSetFeedType</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Microsoft News feed experience</string>
+				<string>Office 365 feed experience</string>
+			</array>
+			<key>pfm_title</key>
+			<string>New Tab Page Feed Type</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-01-17T14:55:00Z</date>
+	<date>2020-01-20T14:03:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -8326,6 +8326,6 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Fix typo in one instance of com.microsoft.Edge where an extra 'e' was added.  Thanks @andre_db90
- Add Edge-specific keys which differ from Chrome. Thanks to @andre_db90
- Hide Chrome prefs that don't appear in Edge docs at the current time
- Add SmartScreen menu and related prefs
- Add more Edge-specific prefs
- Fix incorrect pref key names in menus referring to Black/Whitelist which should be Block/Allowlist instead
- Fix incorrect BookmarkBarEnabled to FavoritesBarEnabled in menu and others that were missing and therefore showing up on all menus.
- Update pfm_app_min for prefs to reflect Edge, rather than Chrome
- Update applicable pref descriptions, replacing Chrome with Edge
- Bump pfm_version and update modified date

Need to determine what the integers for DefaultInsecureContentSetting refer to settings-wise: https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#defaultinsecurecontentsetting

Problematic for a couple preferences is the fact that there are arrays which contain a dictionary.  ProfileCreator can't currently handle this.  For example, the `ManagedSearchEngines` key.  As a result, can't 100% achieve the desired result and so include pfm_notes to indicate this.

Not critical, but should update pfm_description_references to match Microsoft docs, rather than Google's.