### PR TITLE
DigiDNA Firefox tweak

### DIFF
--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -1230,15 +1230,22 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 			<key>pfm_app_min</key>
 			<string>68</string>
 			<key>pfm_description</key>
-			<string>Enable linking to local files by origin.</string>
+			<string>Enable linking to local files by origin</string>
 			<key>pfm_description_reference</key>
 			<string>Enable linking to local files by origin.</string>
 			<key>pfm_name</key>
 			<string>LinkLocalFiles</string>
 			<key>pfm_title</key>
-			<string>Link Local files</string>
+			<string>Link Local Files</string>
 			<key>pfm_type</key>
 			<string>array</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>

--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -22,7 +22,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T09:37:17Z</date>
+	<date>2020-01-29T15:30:11Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>


### PR DESCRIPTION
Subkey types established for the `LinkLocalFiles` property on the Firefox domain, along with two small textual tweaks.