### PR TITLE
Adding missing key and update another to Google Chrome 

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-12-10T17:48:00Z</date>
+	<date>2020-02-06T08:12:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -250,6 +250,7 @@
 					<string>AllowFileSelectionDialogs</string>
 					<string>AllowOutdatedPlugins</string>
 					<string>AllowPopupsDuringPageUnload</string>
+					<string>AllowSyncXHRInPageDismissal</string>
 					<string>AllowedDomainsForApps</string>
 					<string>AlternateErrorPagesEnabled</string>
 					<string>AlwaysOpenPdfExternally</string>
@@ -2720,7 +2721,7 @@ If this setting is not set, users will be asked for permission to run outdated p
 		</dict>
 		<dict>
 			<key>pfm_deprecated</key>
-			<string>82</string>
+			<string>88</string>
 			<key>pfm_app_min</key>
 			<string>74</string>
 			<key>pfm_description</key>
@@ -2732,13 +2733,39 @@ When the policy is set to enabled, pages are allowed to show popups while they a
 
 When the policy is set to disabled or not set, pages are not allowed to show popups while they are being unloaded, as per the spec (https://html.spec.whatwg.org/#apis-for-creating-and-navigating-browsing-contexts-by-name).
 
-This policy will be removed in Chrome 82.</string>
+This policy will be removed in Chrome 88.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://cloud.google.com/docs/chrome-enterprise/policies/?policy=AllowPopupsDuringPageUnload</string>
 			<key>pfm_name</key>
 			<string>AllowPopupsDuringPageUnload</string>
 			<key>pfm_title</key>
 			<string>Allow a page to show popups during its unloading</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_deprecated</key>
+			<string>88</string>
+			<key>pfm_app_min</key>
+			<string>78</string>
+			<key>pfm_description</key>
+			<string>This policy allows an admin to specify that a page may send synchronous XHR requests during page dismissal.</string>
+			<key>pfm_description_reference</key>
+			<string>This policy allows an admin to specify that a page may send synchronous XHR requests during page dismissal.
+
+When the policy is set to enabled, pages are allowed to send synchronous XHR requests during page dismissal.
+
+When the policy is set to disabled or not set, pages are not allowed to send synchronous XHR requests during page dismissal.
+
+This policy will be removed in Chrome 88.
+
+See https://www.chromestatus.com/feature/4664843055398912 .</string>
+			<key>pfm_documentation_url</key>
+			<string>https://cloud.google.com/docs/chrome-enterprise/policies/?policy=AllowSyncXHRInPageDismissal</string>
+			<key>pfm_name</key>
+			<string>AllowSyncXHRInPageDismissal</string>
+			<key>pfm_title</key>
+			<string>Allows a page to perform synchronous XHR requests during page dismissal.</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>

--- a/Manifests/index
+++ b/Manifests/index
@@ -417,9 +417,9 @@
 		<key>com.google.Chrome</key>
 		<dict>
 			<key>hash</key>
-			<string>2f81fbff731512d57d8845c4690b6283</string>
+			<string>7240e3026430ae8bfac6d6513033522c</string>
 			<key>modified</key>
-			<date>2019-12-10T17:48:00Z</date>
+			<date>2020-02-06T08:12:00Z</date>
 			<key>path</key>
 			<string>Manifests/ManagedPreferencesApplications/com.google.Chrome.plist</string>
 			<key>version</key>
@@ -1973,6 +1973,6 @@
 		</dict>
 	</dict>
 	<key>date</key>
-	<date>2020-02-05T02:44:24Z</date>
+	<date>2020-02-06T08:12:52Z</date>
 </dict>
 </plist>

--- a/Manifests/index
+++ b/Manifests/index
@@ -417,13 +417,13 @@
 		<key>com.google.Chrome</key>
 		<dict>
 			<key>hash</key>
-			<string>8ce5074135a705a73964a5efd18e7699</string>
+			<string>70131f490a73691a0fc765bc10303346</string>
 			<key>modified</key>
-			<date>2020-02-06T10:00:00Z</date>
+			<date>2020-02-05T18:52:00Z</date>
 			<key>path</key>
 			<string>Manifests/ManagedPreferencesApplications/com.google.Chrome.plist</string>
 			<key>version</key>
-			<integer>5</integer>
+			<integer>4</integer>
 		</dict>
 		<key>com.google.Keystone</key>
 		<dict>
@@ -1973,6 +1973,6 @@
 		</dict>
 	</dict>
 	<key>date</key>
-	<date>2020-02-06T10:01:51Z</date>
+	<date>2020-02-05T23:59:38Z</date>
 </dict>
 </plist>


### PR DESCRIPTION
I needed AllowSyncXHRInPageDismissal in my Google Chrome Profile so I added it. Also I saw that for AllowPopupsDuringPageUnload the deprecation version changed. 