### PR TITLE
Update DefaultInsecureContentSetting preference

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-01-29T15:23:36Z</date>
+	<date>2020-02-10T10:08:36Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -678,15 +678,13 @@ If this policy isn't set, users will be allowed to add exceptions to allow block
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#defaultinsecurecontentsetting</string>
 			<key>pfm_range_list</key>
 			<array>
-				<integer>0</integer>
-				<integer>1</integer>
 				<integer>2</integer>
+				<integer>3</integer>
 			</array>
 			<key>pfm_range_list_titles</key>
 			<array>
-				<string>0</string>
-				<string>1</string>
-				<string>2</string>
+				<string>Do not allow any site to load blockable mixed content</string>
+				<string>Allow users to add exceptions to allow blockable mixed content</string>
 			</array>
 			<key>pfm_name</key>
 			<string>DefaultInsecureContentSetting</string>


### PR DESCRIPTION
Per https://github.com/MicrosoftDocs/EdgeEnterprise/issues/56 resolution indicating available integer values & meanings where documentation originally did not have these listed