### PR TITLE
DigiDNA Passcode tweaks

### DIFF
--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -227,7 +227,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Requires users to change their passcode at the specified interval. It can be set to "none," or from 1 to 730 days.</string>
+			<string>Requires users to change their passcode at the specified interval. It can be set to between 1 and 730 days, or turned off with a value of 0.</string>
 			<key>pfm_description_reference</key>
 			<string>The number of days for which the passcode can remain unchanged. After this number of days, the user is forced to change the passcode before the device is unlocked.</string>
 			<key>pfm_name</key>
@@ -245,7 +245,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If the device isn’t used for the period of time you specify, it automatically locks. It can be set to "none," or set to lock after 1 to 15 minutes. In macOS, this inactivity value is translated to screen-saver settings.</string>
+			<string>If the device isn’t used for the period of time you specify, it automatically locks. It can be set to lock after 1 to 15 minutes, or turned off with a value of 0. In macOS, this inactivity value is translated to screen-saver settings.</string>
 			<key>pfm_description_reference</key>
 			<string>The maximum number of minutes for which the device can be idle, without being unlocked by the user, before it gets locked by the system. When this limit is reached, the device is locked and the passcode must be entered. The user can edit this setting, but the value cannot exceed the maxInactivity value. In macOS, this inactivity value is translated to screen-saver settings.</string>
 			<key>pfm_exclude</key>
@@ -277,7 +277,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The device refuses a new passcode if it matches a previously used passcode. You can specify how many previous passcodes are remembered and compared. It can be set to "none," or from 1 to 50 passcodes.</string>
+			<string>The device refuses a new passcode if it matches a previously used passcode. You can specify how many previous passcodes are remembered and compared. It can be set to between 1 and 50 passcodes, or turned off with a value of 0.</string>
 			<key>pfm_name</key>
 			<string>pinHistory</string>
 			<key>pfm_range_max</key>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-12-06T20:38:51Z</date>
+	<date>2020-02-24T09:44:57Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -392,6 +392,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -115,7 +115,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enforce the use of a passcode before using the device.</string>
 			<key>pfm_description_reference</key>


### PR DESCRIPTION
Two changes on the Passcode configuration domain:
1. Corrected the default value for the `forcePIN` property.
2. The use of the word _none_ for a possible value on an integer property was confusing for us so we clarified the affected description texts.