### PR TITLE
Update several aspects of the Wi-Fi payload

### DIFF
--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-01-17T11:58:00Z</date>
+	<date>2020-02-26T15:48:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -217,13 +217,6 @@
 							<key>pfm_target</key>
 							<string>PFC_InterfaceSelector</string>
 						</dict>
-					</array>
-				</dict>
-				<dict>
-					<key>pfm_require</key>
-					<string>always</string>
-					<key>pfm_target_conditions</key>
-					<array>
 						<dict>
 							<key>pfm_target</key>
 							<string>DomainName</string>
@@ -1010,8 +1003,12 @@
 				<dict>
 					<key>pfm_description</key>
 					<string>The EAP types accepted.</string>
+					<key>pfm_description_reference</key>
+					<string>For EAP-TLS authentication without a network payload, install the necessary identity certificates and have your users select EAP-TLS mode in the 802.1X credentials dialog that appears when they connect to the network. For other EAP types, a network payload is necessary and must specify the correct settings for the network.</string>
 					<key>pfm_name</key>
 					<string>AcceptEAPTypes</string>
+					<key>pfm_note</key>
+					<string>For EAP-TLS authentication without a network payload, install the necessary identity certificates and have your users select EAP-TLS mode in the 802.1X credentials dialog that appears when they connect to the network.</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
@@ -1125,6 +1122,8 @@
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>17</integer>
@@ -1210,6 +1209,18 @@
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_default</key>
+					<false/>
+					<key>pfm_description_reference</key>
+					<string>If true, allows for two-factor authentication for EAP-TTLS, PEAP, or EAP-FAST. If false, allows for zero-factor authentication for EAP-TLS.</string>
+					<key>pfm_name</key>
+					<string>TLSCertificateIsRequired</string>
+					<key>pfm_title</key>
+					<string>TLS Certificate is Required</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
 					<key>pfm_conditionals</key>
 					<array>
 						<dict>
@@ -1238,6 +1249,8 @@
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>21</integer>
@@ -1272,6 +1285,8 @@
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>21</integer>
@@ -1292,14 +1307,18 @@
 					<string>string</string>
 				</dict>
 				<dict>
-					<key>pfm_description</key>
-					<string></string>
+					<key>pfm_default</key>
+					<string>1.0</string>
+					<key>pfm_description_reference</key>
+					<string>The minimum TLS version to be used with EAP authentication.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>21</integer>
@@ -1330,14 +1349,18 @@
 					<string>string</string>
 				</dict>
 				<dict>
-					<key>pfm_description</key>
-					<string></string>
+					<key>pfm_default</key>
+					<string>1.2</string>
+					<key>pfm_description_reference</key>
+					<string>The maximum TLS version to be used with EAP authentication.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>21</integer>
@@ -1370,14 +1393,16 @@
 				<dict>
 					<key>pfm_default</key>
 					<false/>
-					<key>pfm_description</key>
-					<string>If set, the device will use an existing PAC if it's present. Otherwise the server must present its identity using a certificate.</string>
+					<key>pfm_description_reference</key>
+					<string>If true, the device will use an existing PAC if it's present. Otherwise, the server must present its identity using a certificate.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>43</integer>
@@ -1399,13 +1424,19 @@
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If set, allows PAC provisioning.</string>
+					<string>If set, allows PAC provisioning. This value must be set to true for EAP-FAST PAC usage to succeed, because there is no other way to provision a PAC</string>
+					<key>pfm_description_reference</key>
+					<string>If set to true, allows PAC provisioning.
+
+Used only if EAPFASTUsePAC is true. This value must be set to true for EAP-FAST PAC usage to succeed, because there is no other way to provision a PAC.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>43</integer>
@@ -1413,12 +1444,9 @@
 									<key>pfm_target</key>
 									<string>EAPClientConfiguration.AcceptEAPTypes</string>
 								</dict>
-							</array>
-						</dict>
-						<dict>
-							<key>pfm_target_conditions</key>
-							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_range_list</key>
 									<array>
 										<true/>
@@ -1439,14 +1467,16 @@
 				<dict>
 					<key>pfm_default</key>
 					<false/>
-					<key>pfm_description</key>
-					<string>If set, provisions the device anonymously. Note that there are known man-in-the-middle attacks for anonymous provisioning.</string>
+					<key>pfm_description_reference</key>
+					<string>If true, provisions the device anonymously. Note that there are known man-in-the-middle attacks for anonymous provisioning. </string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>43</integer>
@@ -1454,12 +1484,9 @@
 									<key>pfm_target</key>
 									<string>EAPClientConfiguration.AcceptEAPTypes</string>
 								</dict>
-							</array>
-						</dict>
-						<dict>
-							<key>pfm_target_conditions</key>
-							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_range_list</key>
 									<array>
 										<true/>
@@ -1488,6 +1515,8 @@
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_present</key>
+									<false/>
 									<key>pfm_n_contains_any</key>
 									<array>
 										<integer>18</integer>
@@ -1511,13 +1540,37 @@
 					<string>integer</string>
 				</dict>
 				<dict>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_present</key>
+									<true/>
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.SystemModeUseOpenDirectoryCredentials</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
 					<key>pfm_description</key>
 					<string>Use an alternate set of credentials when in System mode (AKA not a loginwindow profile). This can be used to tell EAPOLClient to use the computer password in a bound active directory scenario for authentication.</string>
+					<key>pfm_description_reference</key>
+					<string>Set this string to ActiveDirectory to use the AD machine name and password credentials.
+
+Only one of the SystemModeCredentialsSource or SystemModeUseOpenDirectoryCredentials keys should exist in the dictionary.</string>
 					<key>pfm_name</key>
 					<string>SystemModeCredentialsSource</string>
+					<key>pfm_note</key>
+					<string>Only SystemModeCredentialsSource or SystemModeUseOpenDirectoryCredentials keys should exist in the profile. Not both.</string>
 					<key>pfm_range_list</key>
 					<array>
 						<string>ActiveDirectory</string>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>Active Directory</string>
 					</array>
 					<key>pfm_title</key>
 					<string>System Profile Credentials Source</string>
@@ -1525,10 +1578,30 @@
 					<string>string</string>
 				</dict>
 				<dict>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_present</key>
+									<true/>
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.SystemModeCredentialsSource</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
 					<key>pfm_description</key>
 					<string>This indicates if the connection should try to use the OpenDirectory machine credentials.</string>
+					<key>pfm_description_reference</key>
+					<string>If true, the System mode connection should try to use the OpenDirectory machine credentials.
+
+Only one of the SystemModeCredentialsSource or SystemModeUseOpenDirectoryCredentials keys should exist in the dictionary.</string>
 					<key>pfm_name</key>
 					<string>SystemModeUseOpenDirectoryCredentials</string>
+					<key>pfm_note</key>
+					<string>Only SystemModeCredentialsSource or SystemModeUseOpenDirectoryCredentials keys should exist in the profile. Not both.</string>
 					<key>pfm_title</key>
 					<string>Use OpenDirectory System Profile Credentials</string>
 					<key>pfm_type</key>
@@ -1640,6 +1713,8 @@
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
+							<key>pfm_present</key>
+							<false/>
 							<key>pfm_n_contains_any</key>
 							<array>
 								<integer>13</integer>
@@ -1676,36 +1751,6 @@
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
-		<dict>
-			<key>pfm_name</key>
-			<string>Interface</string>
-			<key>pfm_title</key>
-			<string>Interface</string>
-			<key>pfm_description</key>
-			<string>The wireless interface to use</string>
-			<key>pfm_type</key>
-			<string>string</string>
-			<key>pfm_range_list</key>
-			<array>
-				<string>AnyEthernet</string>
-				<string>FirstEthernet</string>
-				<string>FirstActiveEthernet</string>
-				<string>SecondEthernet</string>
-				<string>SecondActiveEthernet</string>
-				<string>ThirdEthernet</string>
-				<string>ThirdActiveEthernet</string>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Any Ethernet</string>
-				<string>First Ethernet</string>
-				<string>First Active Ethernet</string>
-				<string>Second Ethernet</string>
-				<string>Second Active Ethernet</string>
-				<string>Third Ethernet</string>
-				<string>Third Active Ethernet</string>
-			</array>
-		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -1717,6 +1762,6 @@
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>7</integer>
+	<integer>8</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Add pfm_description_reference & pfm_note for AcceptEAPTypes
- Add missing TLSCertificateIsRequired preference
- Add pfm_default and pfm_description_reference for TLSMaximumVersion and TLSMinimumVersion, remove blank pfm_description
- Remove instances of 2 pfm_target_conditions dictionaries within pfm_conditionals, when multiple options should be listed under 1.
- Add pfm_exclude for SystemModeUseOpenDirectoryCredentials & SystemModeCredentialsSource, as docs indicate only 1 is supposed to be used. Use pfm_note to reinforce the fact that only one of these keys are to be used in a profile. Also add pfm_description_reference.
- Add pfm_range_list_titles array for SystemModeCredentialsSource to have the more friendly 'Active Directory' option listed
- Remove Interface preference since the options are only related to ethernet connections, as these are being broken out into separate manifests (upcoming PR)
- Add pfm_present key with `false` value for pfm_exclude dictionaries when the pfm_target is EAPClientConfiguration.AcceptEAPTypes
- Bump pfm_version and modified date