### PR TITLE
Update Edge to indicate deprecated policies

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -321,6 +321,7 @@
 					<string>ForceBrowserSignin</string>
 					<string>ForceEphemeralProfiles</string>
 					<string>ForceGoogleSafeSearch</string>
+					<string>ForceLegacyDefaultReferrerPolicy</string>
 					<string>ForceYouTubeRestrict</string>
 					<string>ForceYouTubeSafetyMode</string>
 					<string>FullscreenAllowed</string>
@@ -396,6 +397,7 @@
 					<string>VideoCaptureAllowedUrls</string>
 					<string>WPADQuickCheckEnabled</string>
 					<string>WebAppInstallForceList</string>
+					<string>WebComponentsV0Enabled</string>
 					<string>WebDriverOverridesIncompatiblePolicies</string>
 					<string>WebRtcEventLogCollectionAllowed</string>
 					<string>WebRtcLocalIpsAllowedUrls</string>
@@ -4478,6 +4480,32 @@ If you disable this setting or do not set a value, SafeSearch in Google Search i
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_app_deprecated</key>
+			<string>82</string>
+			<key>pfm_app_min</key>
+			<string>81</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Use a default referrer policy of no-referrer-when-downgrade.</string>
+			<key>pfm_description_reference</key>
+			<string>This enterprise policy is for short-term adaptation and will be removed in M82.
+
+Microsoft Edge's default referrer policy is being strengthened from its current value of no-referrer-when-downgrade to the more secure strict-origin-when-cross-origin through a gradual rollout targeting M80 stable.
+
+Before the rollout, this enterprise policy will have no effect. After the rollout, when this enterprise policy is enabled, Microsoft Edge's default referrer policy will be set to its pre-M80 value of no-referrer-when-downgrade.
+
+This enterprise policy is disabled by default.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#forcelegacydefaultreferrerpolicy</string>
+			<key>pfm_name</key>
+			<string>ForceLegacyDefaultReferrerPolicy</string>
+			<key>pfm_title</key>
+			<string>Force Legacy Default Referrer Policy</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 		<!-- <dict>
 			<key>pfm_app_deprecated</key>
 			<string>30</string>
@@ -6590,13 +6618,31 @@ Each list item of the policy is an object with a mandatory member: "url" and two
 		</dict>
 		<dict>
 			<key>pfm_app_deprecated</key>
-			<string></string>
+			<string>84</string>
+			<key>pfm_app_min</key>
+			<string>80</string>
+			<key>pfm_description</key>
+			<string>Re-enable Web Components v0 API until M84.</string>
+			<key>pfm_description_reference</key>
+			<string>The Web Components v0 APIs (Shadow DOM v0, Custom Elements v0, and HTML Imports) were deprecated in 2018, and have been disabled by default starting in M80. This policy allows these features to be selectively re-enabled until M84.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#webcomponentsv0enabled</string>
+			<key>pfm_name</key>
+			<string>WebComponentsV0Enabled</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_deprecated</key>
+			<string>83</string>
 			<key>pfm_app_min</key>
 			<string>77</string>
 			<key>pfm_description</key>
 			<string>This policy allows users of the WebDriver feature to override policies which can interfere with its operation. This policy is deprecated. It is currently supported but will become obsolete in a future release.</string>
 			<key>pfm_description_reference</key>
-			<string>This policy allows users of the WebDriver feature to override policies which can interfere with its operation.
+			<string>This policy was removed in M83, because it is not necessary anymore as WebDriver is now compatible with all existing policies.
+
+This policy allows users of the WebDriver feature to override policies which can interfere with its operation.
 
 Currently this policy disables SitePerProcess and IsolateOrigins policies.
 
@@ -7960,6 +8006,8 @@ to a Microsoft® Active Directory® domain.</string>
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_deprecated</key>
+			<string></string>
 			<key>pfm_app_min</key>
 			<string>79</string>
 			<key>pfm_description</key>
@@ -7983,7 +8031,9 @@ For help with determining the SHA-256 hash, see https://docs.microsoft.com/power
 			<key>pfm_name</key>
 			<string>NewTabPageCompanyLogo</string>
 			<key>pfm_note</key>
-			<string>The 'default_logo' is required and will be used when there's no background image. If 'light_logo' is provided, it will be used when the user's new tab page has a background image. We recommend a horizontal logo with a transparent background that is left-aligned and vertically centered. The logo should have a minimum height of 32 pixels and an aspect ratio from 1:1 to 4:1.</string>
+			<string>Per Microsoft Docs, this policy doesn't work as expected and is recommended to not be used.
+
+The 'default_logo' is required and will be used when there's no background image. If 'light_logo' is provided, it will be used when the user's new tab page has a background image. We recommend a horizontal logo with a transparent background that is left-aligned and vertically centered. The logo should have a minimum height of 32 pixels and an aspect ratio from 1:1 to 4:1.</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-10T10:08:36Z</date>
+	<date>2020-03-24T19:10:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -8440,6 +8440,6 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Add two missing preferences which are to be deprecated: `ForceLegacyDefaultReferrerPolicy` & `WebComponentsV0Enabled`

NewTabPageCompanyLogo docs do not indicate when this will be officially deprecated.

Per #232 