### PR TITLE
Update Microsoft ATP

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.wdav.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.wdav.plist
@@ -200,7 +200,7 @@
 											<key>pfm_target_conditions</key>
 											<array>
 												<dict>
-													<key>pfm_contains_any</key>
+													<key>pfm_range_list</key>
 													<array>
 														<string>excludedFileExtension</string>
 														<string>excludedFileName</string>
@@ -231,7 +231,7 @@
 											<key>pfm_target_conditions</key>
 											<array>
 												<dict>
-													<key>pfm_n_contains_any</key>
+													<key>pfm_n_range_list</key>
 													<array>
 														<string>excludedPath</string>
 													</array>
@@ -259,7 +259,7 @@
 											<key>pfm_target_conditions</key>
 											<array>
 												<dict>
-													<key>pfm_n_contains_any</key>
+													<key>pfm_n_range_list</key>
 													<array>
 														<string>excludedFileExtension</string>
 													</array>
@@ -287,7 +287,7 @@
 											<key>pfm_target_conditions</key>
 											<array>
 												<dict>
-													<key>pfm_n_contains_any</key>
+													<key>pfm_n_range_list</key>
 													<array>
 														<string>excludedFileName</string>
 													</array>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.wdav.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.wdav.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-03-24T18:10:00Z</date>
+	<date>2020-03-26T22:45:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>


### PR DESCRIPTION
Change contains_any to range_list for pfm_exclude

For whatever reason, the exclude rule messages below the preference don't appear with contain_any ...