### PR TITLE
Fix Compressor Manifest

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.apple.Compressor.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.Compressor.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-09T19:00:00Z</date>
+	<date>2020-04-11T16:59:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.apple.Compressor.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.Compressor.plist
@@ -117,6 +117,18 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
+			<string>Suppresses the popup to upgrade Compressor on first run.</string>
+			<key>pfm_hidden</key>
+			<string>all</string>
+			<key>pfm_name</key>
+			<string>FFCheckedUpgrade</string>
+			<key>pfm_title</key>
+			<string>Upgrade Checked</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
 			<string>Suppress the Whats New screen on the selected versions of Compressor.</string>
 			<key>pfm_description_reference</key>
 			<string>Correct value is the whole version number, i.e 4.4.1. Can specify multiple versions if required.</string>


### PR DESCRIPTION
With just a dictionary with `{{name}}` and `{{value}}`, nothing appears in the GUI for the payload.

With at least one concrete preference added, it displays correctly.  Preference copied from Motion manifest.  Since it is unclear as to whether this preference actually applies to Compressor, hide it from the GUI with `pfm_hidden`.  Confirmed that this does not add it to the GUI or XML, but that original dictionary and contained prefs appear now.

![Screen Shot 2020-04-11 at 1 00 11 PM 1](https://user-images.githubusercontent.com/11789931/79049911-70078880-7bf4-11ea-8995-0a58c08b8a9f.png)