### PR TITLE
Update Firefox manifest

### DIFF
--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -20,7 +20,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-06T20:25:11Z</date>
+	<date>2020-04-13T18:47:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -158,6 +158,7 @@
 				<key>General</key>
 				<array>
 					<string>General_SegmentedControl</string>
+					<string>AppAutoUpdate</string>
 					<string>AppUpdateURL</string>
 					<string>Authentication</string>
 					<string>BlockAboutConfig</string>
@@ -241,6 +242,7 @@
 					<string>Certificates</string>
 					<string>DisableSecurityBypass</string>
 					<string>SecurityDevices</string>
+					<string>UserMessaging</string>
 					<string>WebsiteFilter</string>
 				</array>
 			</dict>
@@ -278,6 +280,7 @@
 				</array>
 				<key>General</key>
 				<array>
+					<string>AppAutoUpdate</string>
 					<string>AppUpdateURL</string>
 					<string>Authentication</string>
 					<string>BlockAboutConfig</string>
@@ -387,11 +390,39 @@
 					<string>CaptivePortal</string>
 					<string>DisableSecurityBypass</string>
 					<string>SecurityDevices</string>
+					<string>UserMessaging</string>
 					<string>WebsiteFilter</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>75</string>
+			<key>pfm_description</key>
+			<string>Enable or disable automatic application update.</string>
+			<key>pfm_description_reference</key>
+			<string>Enable or disable automatic application update.
+
+If set to true, application updates are installed without user approval.
+
+If set to false, application updates are downloaded but the user can choose when to install the update.
+
+If you have disabled updates via DisableAppUpdate, this policy has no effect.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mozilla/policy-templates/blob/master/README.md#appautoupdate</string>
+			<key>pfm_name</key>
+			<string>AppAutoUpdate</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Check for updates, user chooses when to install</string>
+				<string>Auto install updates</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Firefox Auto Update</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -431,28 +462,26 @@ For more information on setting up your own update server: https://developer.moz
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>60</string>
 					<key>pfm_description</key>
 					<string>If this preference is enabled, the specified websites are permitted to engage in SPNEGO authentication with the browser. Entries in the list are formatted as mydomain.com or https://myotherdomain.com.
 
 If this preference is disabled or not configured, no websites are permitted to engage in SPNEGO authentication with the browser.
 
-For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.
-						</string>
+For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.</string>
 					<key>pfm_description_reference</key>
 					<string>Optional. If this preference is enabled, the specified websites are permitted to engage in SPNEGO authentication with the browser. Entries in the list are formatted as mydomain.com or https://myotherdomain.com.
 
 If this preference is disabled or not configured, no websites are permitted to engage in SPNEGO authentication with the browser.
 
-For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.
-						</string>
+For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.</string>
 					<key>pfm_name</key>
 					<string>SPNEGO</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
 							<key>pfm_name</key>
-							<string>Domain</string>
-							<key>pfm_title</key>
 							<string>Domain</string>
 							<key>pfm_type</key>
 							<string>string</string>
@@ -466,29 +495,26 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<string>array</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>60</string>
 					<key>pfm_description</key>
 					<string>If this preference is enabled, the browser may delegate user authorization to the server for the specified websites. Entries in the list are formatted as mydomain.com or https://myotherdomain.com.
 
 If this preference is disabled or not configured, the browser will not delegate user authorization to the server for any websites.
 
-For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication
-						</string>
+For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication</string>
 					<key>pfm_description_reference</key>
-					<string>
-							Optional. If this preference is enabled, the browser may delegate user authorization to the server for the specified websites. Entries in the list are formatted as mydomain.com or https://myotherdomain.com.
+					<string>Optional. If this preference is enabled, the browser may delegate user authorization to the server for the specified websites. Entries in the list are formatted as mydomain.com or https://myotherdomain.com.
 
-							If this preference is disabled or not configured, the browser will not delegate user authorization to the server for any websites.
+If this preference is disabled or not configured, the browser will not delegate user authorization to the server for any websites.
 
-							For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication
-						</string>
+For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication</string>
 					<key>pfm_name</key>
 					<string>Delegated</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
 							<key>pfm_name</key>
-							<string>Domain</string>
-							<key>pfm_title</key>
 							<string>Domain</string>
 							<key>pfm_type</key>
 							<string>string</string>
@@ -502,28 +528,26 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<string>array</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>60</string>
 					<key>pfm_description</key>
 					<string>If this preference is enabled, the specified websites are trusted to use NTLM authentification. Entries in the list are formatted as mydomain.com or https://myotherdomain.com.
 
 If this policy is disabled or not configured, no websites are trusted to use NTLM authentification.
 
-For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.
-						</string>
+For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.</string>
 					<key>pfm_description_reference</key>
 					<string>Optional. If this preference is enabled, the specified websites are trusted to use NTLM authentification. Entries in the list are formatted as mydomain.com or https://myotherdomain.com.
 
-							If this policy is disabled or not configured, no websites are trusted to use NTLM authentification.
+If this policy is disabled or not configured, no websites are trusted to use NTLM authentification.
 
-							For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.
-						</string>
+For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integrated_authentication.</string>
 					<key>pfm_name</key>
 					<string>NTLM</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
 							<key>pfm_name</key>
-							<string>Domain</string>
-							<key>pfm_title</key>
 							<string>Domain</string>
 							<key>pfm_type</key>
 							<string>string</string>
@@ -532,11 +556,13 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 						</dict>
 					</array>
 					<key>pfm_title</key>
-					<string>NTLM</string>
+					<string>Microsoft Challenge/Response (NTLM)</string>
 					<key>pfm_type</key>
 					<string>array</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>62</string>
 					<key>pfm_description</key>
 					<string>If this preference is enabled, you can always allow SPNEGO or NTLM on non FQDNs (fully qualified domain names). If this preference is disabled or not configured, NTLM and SPNEGO are not enabled on non FQDNs.</string>
 					<key>pfm_description_reference</key>
@@ -566,8 +592,57 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<string>boolean</string>
 						</dict>
 					</array>
+					<key>pfm_name</key>
+					<string>Allow Non-FQDN</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>62</string>
+					<key>pfm_description</key>
+					<string>If this preference is enabled, you can always allow SPNEGO or NTLM on non FQDNs (fully qualified domain names). If this preference is disabled or not configured, NTLM and SPNEGO are not enabled on non FQDNs.</string>
+					<key>pfm_description_reference</key>
+					<string>If this preference is enabled, you can always allow SPNEGO or NTLM on non FQDNs (fully qualified domain names). If this preference is disabled or not configured, NTLM and SPNEGO are not enabled on non FQDNs.</string>
+					<key>pfm_name</key>
+					<string>AllowProxies</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_name</key>
+							<string>NTLM</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_name</key>
+							<string>SPNEGO</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+					</array>
+					<key>pfm_name</key>
+					<string>Allow Proxies</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>71</string>
+					<key>pfm_name</key>
+					<string>Locked</string>
+					<key>pfm_title</key>
+					<string>Locked (Authentication)</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
 				</dict>
 			</array>
 			<key>pfm_type</key>
@@ -1910,85 +1985,103 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 			<string>https://github.com/mozilla/policy-templates/blob/master/README.md#sanitizeonshutdown-selective</string>
 			<key>pfm_name</key>
 			<string>SanitizeOnShutdown</string>
+			<key>pfm_note</key>
+			<string>Previously, these values were always locked. Starting with Firefox 74 and Firefox ESR 68.6, you can use the 'Locked' option to either keep the values unlocked (set it to false), or lock only the values you set (set it to true). If you want the old behavior of locking everything, do not set Locked at all.</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
 					<string>Cache</string>
-					<key>pfm_title</key>
-					<string>Cache</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
-					<string>Cookies</string>
-					<key>pfm_title</key>
 					<string>Cookies</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
-					<string>Downloads</string>
-					<key>pfm_title</key>
 					<string>Downloads</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
 					<string>FormData</string>
 					<key>pfm_title</key>
-					<string>FormData</string>
+					<string>Form Data</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
 					<string>History</string>
-					<key>pfm_title</key>
-					<string>History</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
 					<string>Sessions</string>
-					<key>pfm_title</key>
-					<string>Sessions</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
 					<string>SiteSettings</string>
 					<key>pfm_title</key>
-					<string>SiteSettings</string>
+					<string>Site Settings</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_name</key>
 					<string>OfflineApps</string>
 					<key>pfm_title</key>
-					<string>OfflineApps</string>
+					<string>Offline Apps</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>74</string>
+					<key>pfm_default</key>
+					<false/>
+					<key>pfm_name</key>
+					<string>Locked</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
@@ -2215,6 +2308,8 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>63</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
@@ -2229,6 +2324,8 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>63</string>
 					<key>pfm_description</key>
 					<string>URL to an alternative DNS over HTTPS provider.</string>
 					<key>pfm_description_reference</key>
@@ -2236,13 +2333,15 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<key>pfm_name</key>
 					<string>ProviderURL</string>
 					<key>pfm_title</key>
-					<string>ProviderURL</string>
+					<string>Provider URL</string>
 					<key>pfm_type</key>
 					<string>string</string>
 					<key>pfm_value_placeholder</key>
 					<string>https://mozilla.cloudflare-dns.com/dns-query</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>63</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
@@ -2253,6 +2352,29 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<string>Locked</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>75</string>
+					<key>pfm_description</key>
+					<string>List of excluded domains from DNS over HTTPS.</string>
+					<key>pfm_name</key>
+					<string>ExcludedDomains</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_title</key>
+							<string>Excluded Domains</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>example.com</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Excluded Domains</string>
+					<key>pfm_type</key>
+					<string>array</string>
 				</dict>
 			</array>
 			<key>pfm_title</key>
@@ -3197,9 +3319,9 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 			<key>pfm_app_min</key>
 			<string>62</string>
 			<key>pfm_description</key>
-			<string>Set permissions associated with camera, microphone, location, and notifications.</string>
+			<string>Set permissions associated with camera, microphone, location, notifications, and autoplay.</string>
 			<key>pfm_description_reference</key>
-			<string>This preference allows you to change the permissions associated with camera, microphone, location, and notifications.</string>
+			<string>This preference allows you to change the permissions associated with camera, microphone, location, notifications, and autoplay.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://github.com/mozilla/policy-templates/blob/master/README.md#permissions</string>
 			<key>pfm_hidden</key>
@@ -3209,6 +3331,8 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>62</string>
 					<key>pfm_description</key>
 					<string>This preference allows you to change the camera permissions.</string>
 					<key>pfm_name</key>
@@ -3233,8 +3357,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Allow</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3256,8 +3378,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Block</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3271,7 +3391,7 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<key>pfm_name</key>
 							<string>BlockNewRequests</string>
 							<key>pfm_title</key>
-							<string>BlockNewRequests</string>
+							<string>Block New Requests</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>
@@ -3284,8 +3404,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<string>Optional. If this preference is enabled, camera preferences cannot be changed by the user. If this preference is disabled or not configured, the user can change their camera preferences.</string>
 							<key>pfm_name</key>
 							<string>Locked</string>
-							<key>pfm_title</key>
-							<string>Locked</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>
@@ -3296,6 +3414,8 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>62</string>
 					<key>pfm_description</key>
 					<string>This preference allows you to change the microphone permissions.</string>
 					<key>pfm_name</key>
@@ -3320,8 +3440,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Allow</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3343,8 +3461,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Block</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3358,7 +3474,7 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<key>pfm_name</key>
 							<string>BlockNewRequests</string>
 							<key>pfm_title</key>
-							<string>BlockNewRequests</string>
+							<string>Block New Requests</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>
@@ -3371,8 +3487,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<string>Optional. If this preference is enabled, microphone preferences cannot be changed by the user. If this preference is disabled or not configured, the user can change their microphone preferences.</string>
 							<key>pfm_name</key>
 							<string>Locked</string>
-							<key>pfm_title</key>
-							<string>Locked</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>
@@ -3383,6 +3497,8 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>62</string>
 					<key>pfm_description</key>
 					<string>This preference allows you to change the location permissions.</string>
 					<key>pfm_name</key>
@@ -3407,8 +3523,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Allow</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3430,8 +3544,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Block</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3445,7 +3557,7 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<key>pfm_name</key>
 							<string>BlockNewRequests</string>
 							<key>pfm_title</key>
-							<string>BlockNewRequests</string>
+							<string>Block New Requests</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>
@@ -3458,8 +3570,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<string>Optional. If this preference is enabled, location preferences cannot be changed by the user. If this preference is disabled or not configured, the user can change their location preferences.</string>
 							<key>pfm_name</key>
 							<string>Locked</string>
-							<key>pfm_title</key>
-							<string>Locked</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>
@@ -3470,6 +3580,8 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>62</string>
 					<key>pfm_description</key>
 					<string>This preference allows you to change the notifications permissions.</string>
 					<key>pfm_name</key>
@@ -3494,8 +3606,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Allow</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3517,8 +3627,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 									<string>https://www.example.com</string>
 								</dict>
 							</array>
-							<key>pfm_title</key>
-							<string>Block</string>
 							<key>pfm_type</key>
 							<string>array</string>
 						</dict>
@@ -3532,7 +3640,7 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<key>pfm_name</key>
 							<string>BlockNewRequests</string>
 							<key>pfm_title</key>
-							<string>BlockNewRequests</string>
+							<string>Block New Requests</string>
 							<key>pfm_type</key>
 							<string>boolean</string>
 						</dict>
@@ -3545,6 +3653,89 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<string>Optional. If this preference is enabled, location preferences cannot be changed by the user. If this preference is disabled or not configured, the user can change their location preferences.</string>
 							<key>pfm_name</key>
 							<string>Locked</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Notifications Permissions</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>74</string>
+					<key>pfm_description</key>
+					<string>This preference allows you to change the autoplay permissions.</string>
+					<key>pfm_name</key>
+					<string>Autoplay</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>If this preference is enabled, autoplay can always be enabled for the domains indicated. If this preference is disabled or not configured, the default autoplay preference is followed.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. If this preference is enabled, autoplay can always be enabled for the domains indicated. If this preference is disabled or not configured, the default autoplay preference is followed.</string>
+							<key>pfm_name</key>
+							<string>Allow</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>Allowed Domains</string>
+									<key>pfm_type</key>
+									<string>string</string>
+									<key>pfm_value_placeholder</key>
+									<string>https://www.example.com</string>
+								</dict>
+							</array>
+							<key>pfm_type</key>
+							<string>array</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>If this preference is enabled, autoplay are always blocked for the domains indicated. If this preference is disabled or not configured, autoplay is not blocked by default.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. If this preference is enabled, autoplay are always blocked for the domains indicated. If this preference is disabled or not configured, autoplay is not blocked by default.</string>
+							<key>pfm_name</key>
+							<string>Block</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>Blocked Domains</string>
+									<key>pfm_type</key>
+									<string>string</string>
+									<key>pfm_value_placeholder</key>
+									<string>https://www.example.com</string>
+								</dict>
+							</array>
+							<key>pfm_type</key>
+							<string>array</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<true/>
+							<key>pfm_description</key>
+							<string>If this preference is enabled, sites that are not in the Allow preference will not be allowed to ask permission to autoplay. If this preference is disabled or not configured, any site that is not in the Block preference can ask permission to autoplay.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. If this preference is enabled, sites that are not in the Allow preference will not be allowed to ask permission to autoplay. If this preference is disabled or not configured, any site that is not in the Block preference can ask permission to autoplay.</string>
+							<key>pfm_name</key>
+							<string>BlockNewRequests</string>
+							<key>pfm_title</key>
+							<string>Block New Requests</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<false/>
+							<key>pfm_description</key>
+							<string>If this preference is enabled, autoplay preferences cannot be changed by the user. If this preference is disabled or not configured, the user can change their autoplay preferences.</string>
+							<key>pfm_description_reference</key>
+							<string>Optional. If this preference is enabled, autoplay preferences cannot be changed by the user. If this preference is disabled or not configured, the user can change their autoplay preferences.</string>
+							<key>pfm_name</key>
+							<string>Locked</string>
 							<key>pfm_title</key>
 							<string>Locked</string>
 							<key>pfm_type</key>
@@ -3552,7 +3743,7 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 						</dict>
 					</array>
 					<key>pfm_title</key>
-					<string>Notifications Permissions</string>
+					<string>Autoplay Permissions</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>
 				</dict>
@@ -3792,6 +3983,73 @@ Starting in Firefox 65, you can specify a fully qualified path (e.g. /Library/Co
 					<string>PATH_TO_LIBRARY_FOR_DEVICE</string>
 				</dict>
 			</array>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>75</string>
+			<key>pfm_description</key>
+			<string>Prevent installing search engines from webpages.</string>
+			<key>pfm_description_reference</key>
+			<string>Prevent installing search engines from webpages.
+
+WhatsNew Remove the "What's New" icon and menuitem. (Firefox 75 only)
+
+ExtensionRecommendations Don't recommend extensions.
+
+FeatureRecommendations Don't recommend browser features.
+
+UrlbarInterventions Don't offer Firefox specific suggestions in the URL bar. (Firefox 75 only)</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mozilla/policy-templates/blob/master/README.md#usermessaging</string>
+			<key>pfm_name</key>
+			<string>UserMessaging</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>If enabled, remove the "What's New" icon and menuitem.</string>
+					<key>pfm_name</key>
+					<string>WhatsNew</string>
+					<key>pfm_title</key>
+					<string>What's New</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>If enabled, don't recommend extensions.</string>
+					<key>pfm_name</key>
+					<string>ExtensionRecommendations</string>
+					<key>pfm_title</key>
+					<string>Extension Recomendations</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>If enabled, don't recommend browser features.</string>
+					<key>pfm_name</key>
+					<string>FeatureRecommendations</string>
+					<key>pfm_title</key>
+					<string>Feature Recommendations</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>If enabled, don't offer Firefox specific suggestions in the URL bar.</string>
+					<key>pfm_name</key>
+					<string>UrlbarInterventions</string>
+					<key>pfm_title</key>
+					<string>URL Bar Interventions</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Search Engine Installs from Websites</string>
 			<key>pfm_type</key>
 			<string>dictionary</string>
 		</dict>
@@ -4622,10 +4880,10 @@ Starting in Firefox 65, you can specify a fully qualified path (e.g. /Library/Co
 	</array>
 	<key>pfm_supervised</key>
 	<false/>
-	<key>pfm_target</key>
+	<key>pfm_targets</key>
 	<array>
-		<string>User</string>
-		<string>System</string>
+		<string>user</string>
+		<string>system</string>
 	</array>
 	<key>pfm_title</key>
 	<string>Firefox</string>
@@ -4634,6 +4892,6 @@ Starting in Firefox 65, you can specify a fully qualified path (e.g. /Library/Co
 	<key>pfm_user_approved</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Per #252 

- Update last_modified_date & bump pfm_version
- Add `Locked` option within `SanitizeOnShutdown`.  Also added pfm_note to indicate the use of `Locked`
- Add `Autoplay` to configure autoplay permissions
- Add `AppAutoUpdate`
- Add `UserMessaging`
- Fix manifest pfm_targets - was listed as `pfm_target` incorrectly and options were capitalized
- Add `pfm_app_min` to dictionary prefs
- Remove unneeded pfm_title keys when pfm_name is sufficient
- Fix spacing in several descriptions and reference descriptions
- Add missing `AllowProxies` and `Locked` preferences in the `Authentication` pref dictionary, along with `pfm_app_min`