### PR TITLE
v.4 macOS & iOS Preference Additions

### DIFF
--- a/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
@@ -226,6 +226,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>Requires you to allow sharing the computer's Internet connection and cached content with iOS devices connected using USB.</string>
 			<key>pfm_macos_min</key>
 			<string>10.15.4</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-04-10T20:33:00Z</date>
+	<date>2020-04-15T21:05:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.4</string>
 	<key>pfm_platforms</key>
@@ -222,6 +222,16 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<string>AllowSharedCaching</string>
 			<key>pfm_title</key>
 			<string>Allow non-iCloud Data Caching</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_macos_min</key>
+			<string>10.15.4</string>
+			<key>pfm_name</key>
+			<string>AutoEnableTetheredCaching</string>
+			<key>pfm_title</key>
+			<string>Automatically activate Internet connection sharing</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -1616,6 +1626,6 @@ Availability: Available in macOS 10.13.4 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-04-13T17:11:00Z</date>
+	<date>2020-04-15T21:05:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -167,6 +167,7 @@ The payload organization for a payload need not match the payload organization i
 					<string>allowContinuousPathKeyboard</string>
 					<string>allowBluetoothModification</string>
 					<string>allowCellularPlanModification</string>
+					<string>allowDeprecatedWebKitTLS</string>
 					<string>allowDeviceNameModification</string>
 					<string>allowDiagnosticSubmission</string>
 					<string>allowDiagnosticSubmissionModification</string>
@@ -197,6 +198,7 @@ The payload organization for a payload need not match the payload organization i
 					<string>allowProximitySetupToNewDevice</string>
 					<string>allowRemoteScreenObservation</string>
 					<string>allowScreenshot</string>
+					<string>allowSharedDeviceTemporarySession</string>
 					<string>allowSpellCheck</string>
 					<string>allowUIConfigurationProfileInstallation</string>
 					<string>allowUSBRestrictedMode</string>
@@ -638,6 +640,18 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 			<key>pfm_supervised</key>
 			<true/>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Allow websites that use TLS 1.0 and TLS 1.1 to be accessed using Safari.</string>
+			<key>pfm_ios_min</key>
+			<string>13.4</string>
+			<key>pfm_name</key>
+			<string>allowDeprecatedWebKitTLS</string>
+			<key>pfm_title</key>
+			<string>Allow accessing websites using TLS 1.0 and 1.1</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -1830,6 +1844,18 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>Enable temporary sessions for iPads that have been enabled as Shared iPad.</string>
+			<key>pfm_ios_min</key>
+			<string>13.4</string>
+			<key>pfm_name</key>
+			<string>allowSharedDeviceTemporarySession</string>
+			<key>pfm_title</key>
+			<string>Allow Shared iPad temporary session</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
@@ -2640,6 +2666,6 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2020-04-13T17:11:00Z</date>
+		<date>2020-04-15T21:05:00Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>
@@ -157,6 +157,7 @@ A profile can consist of payloads with different version numbers. For example, c
 						<string>allowCamera</string>
 						<string>allowContentCaching</string>
 						<string>allowDefinitionLookup</string>
+						<string>allowDeprecatedWebKitTLS</string>
 						<string>allowFindMyDevice</string>
 						<string>allowFindMyFriends</string>
 						<string>allowiTunesFileSharing</string>
@@ -560,6 +561,18 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>boolean</string>
 			</dict>
 			<dict>
+				<key>pfm_description</key>
+				<string>Allow websites that use TLS 1.0 and TLS 1.1 to be accessed using Safari.</string>
+				<key>pfm_macos_min</key>
+				<string>10.15.4</string>
+				<key>pfm_name</key>
+				<string>allowDeprecatedWebKitTLS</string>
+				<key>pfm_title</key>
+				<string>Allow accessing websites using TLS 1.0 and 1.1</string>
+				<key>pfm_type</key>
+				<string>boolean</string>
+			</dict>
+			<dict>
 				<key>pfm_default</key>
 				<true/>
 				<key>pfm_description</key>
@@ -866,6 +879,6 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		<key>pfm_unique</key>
 		<true/>
 		<key>pfm_version</key>
-		<integer>4</integer>
+		<integer>5</integer>
 	</dict>
 </plist>


### PR DESCRIPTION
While Apple does not yet have updated documentation for these, Jamf has them listed here: https://docs.jamf.com/10.20.0/jamf-pro/release-notes/What%27s_New.html

com.apple.AssetCache.managed
- Add `AutoEnableTetheredCaching`

com.apple.applicationaccess
- Add `allowDeprecatedWebKitTLS` for macOS & iOS
- Add `allowSharedDeviceTemporarySession` for iOS