### PR TITLE
DigiDNA Ethernet tweak

### DIFF
--- a/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-25T18:52:00Z</date>
+	<date>2020-04-16T12:05:03Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
@@ -795,7 +795,7 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: First Active</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
 	<integer>1</integer>
 </dict>

--- a/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
@@ -795,7 +795,7 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: First</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
 	<integer>1</integer>
 </dict>

--- a/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-25T18:52:00Z</date>
+	<date>2020-04-16T12:05:03Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-25T18:52:00Z</date>
+	<date>2020-04-16T12:05:03Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
@@ -795,7 +795,7 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: Global</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
 	<integer>1</integer>
 </dict>

--- a/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-25T18:52:00Z</date>
+	<date>2020-04-16T12:05:03Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
@@ -795,7 +795,7 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: Second Active</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
 	<integer>1</integer>
 </dict>

--- a/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-25T18:52:00Z</date>
+	<date>2020-04-16T12:05:03Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
@@ -795,7 +795,7 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: Second</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
 	<integer>1</integer>
 </dict>

--- a/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
@@ -795,7 +795,7 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: Third Active</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
 	<integer>1</integer>
 </dict>

--- a/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-25T18:52:00Z</date>
+	<date>2020-04-16T12:05:03Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-25T18:52:00Z</date>
+	<date>2020-04-16T12:05:03Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
@@ -795,7 +795,7 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: Third</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
 	<integer>1</integer>
 </dict>


### PR DESCRIPTION
I noticed that the Ethernet manifests were set to allow multiple payloads so here's a correction of that.