### PR TITLE
Update com.google.Keystone.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-04-10T15:54:26Z</date>
+	<date>2020-04-16T20:11:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -131,13 +131,13 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description</key>
-			<string></string>
 			<key>pfm_name</key>
 			<string>updatePolicies</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_description</key>
+					<string>Configure Global Google update settings</string>
 					<key>pfm_name</key>
 					<string>global</string>
 					<key>pfm_subkeys</key>
@@ -260,6 +260,8 @@ Updates never applied = Never update Google apps</string>
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>Configure Chrome update settings</string>
 					<key>pfm_name</key>
 					<string>com.google.Chrome</string>
 					<key>pfm_subkeys</key>
@@ -298,6 +300,8 @@ Updates never applied = Never update Chrome</string>
 						<dict>
 							<key>pfm_description</key>
 							<string>Pin an application to a single version. This stops your devices from updating to versions of the app beyond the number you specify. This should be done only temporarily, such as while testing a new version.</string>
+							<key>pfm_format</key>
+							<string>^[\d]+\.$</string>
 							<key>pfm_name</key>
 							<string>TargetVersionPrefix</string>
 							<key>pfm_title</key>
@@ -316,6 +320,8 @@ Updates never applied = Never update Chrome</string>
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>Configure Drive File Stream update settings</string>
 					<key>pfm_name</key>
 					<string>com.google.drivefs</string>
 					<key>pfm_subkeys</key>
@@ -347,17 +353,19 @@ Updates never applied = Never update FileStream</string>
 								<string>Updates never applied</string>
 							</array>
 							<key>pfm_title</key>
-							<string>FileStream Update</string>
+							<string>Drive File Stream Update</string>
 							<key>pfm_type</key>
 							<string>integer</string>
 						</dict>
 						<dict>
 							<key>pfm_description</key>
 							<string>Pin an application to a single version. This stops your devices from updating to versions of the app beyond the number you specify. This should be done only temporarily, such as while testing a new version.</string>
+							<key>pfm_format</key>
+							<string>^[\d]+\.$</string>
 							<key>pfm_name</key>
 							<string>TargetVersionPrefix</string>
 							<key>pfm_title</key>
-							<string>FileStream Update Version Pin</string>
+							<string>Drive File Stream Update Version Pin</string>
 							<key>pfm_type</key>
 							<string>string</string>
 							<key>pfm_value_placeholder</key>
@@ -367,11 +375,13 @@ Updates never applied = Never update FileStream</string>
 						</dict>
 					</array>
 					<key>pfm_title</key>
-					<string>FileStream Update settings</string>
+					<string>Drive File Stream Update settings</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>Configure Chat update settings</string>
 					<key>pfm_name</key>
 					<string>com.google.chat</string>
 					<key>pfm_subkeys</key>
@@ -380,10 +390,10 @@ Updates never applied = Never update FileStream</string>
 							<key>pfm_default</key>
 							<integer>0</integer>
 							<key>pfm_description</key>
-							<string>Enable auto-updates &amp; installs = Turns on auto-updates. Hangouts Chat updates are always applied when detected by Google Software Update.
+							<string>Enable auto-updates &amp; installs = Turns on auto-updates. Chat updates are always applied when detected by Google Software Update.
 Install updates at scheduled update checks = Manual update checks will not install updates.
-Turn off updates = Stops Google Software Update automatically updating all users to the latest stable version of Hangouts Chat. Updates are only applied when the user manually checks for updates.
-Updates never applied = Never update Hangouts Chat</string>
+Turn off updates = Stops Google Software Update automatically updating all users to the latest stable version of Chat. Updates are only applied when the user manually checks for updates.
+Updates never applied = Never update Chat</string>
 							<key>pfm_documentation_url</key>
 							<string>https://support.google.com/chrome/a/answer/7591084?hl=en#updatepolicysettings</string>
 							<key>pfm_name</key>
@@ -403,17 +413,19 @@ Updates never applied = Never update Hangouts Chat</string>
 								<string>Updates never applied</string>
 							</array>
 							<key>pfm_title</key>
-							<string>Hangouts Chat Update</string>
+							<string>Chat Update</string>
 							<key>pfm_type</key>
 							<string>integer</string>
 						</dict>
 						<dict>
 							<key>pfm_description</key>
 							<string>Pin an application to a single version. This stops your devices from updating to versions of the app beyond the number you specify. This should be done only temporarily, such as while testing a new version.</string>
+							<key>pfm_format</key>
+							<string>^[\d]+\.$</string>
 							<key>pfm_name</key>
 							<string>TargetVersionPrefix</string>
 							<key>pfm_title</key>
-							<string>Hangouts Chat Update Version Pin</string>
+							<string>Chat Update Version Pin</string>
 							<key>pfm_type</key>
 							<string>string</string>
 							<key>pfm_value_placeholder</key>
@@ -423,11 +435,13 @@ Updates never applied = Never update Hangouts Chat</string>
 						</dict>
 					</array>
 					<key>pfm_title</key>
-					<string>Hangouts Chat Update settings</string>
+					<string>Chat Update settings</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>Configure Backup &amp; Sync update settings</string>
 					<key>pfm_name</key>
 					<string>com.google.GoogleDrive</string>
 					<key>pfm_subkeys</key>
@@ -466,6 +480,8 @@ Updates never applied = Never update Backup &amp; Sync</string>
 						<dict>
 							<key>pfm_description</key>
 							<string>Pin an application to a single version. This stops your devices from updating to versions of the app beyond the number you specify. This should be done only temporarily, such as while testing a new version.</string>
+							<key>pfm_format</key>
+							<string>^[\d]+\.$</string>
 							<key>pfm_name</key>
 							<string>TargetVersionPrefix</string>
 							<key>pfm_title</key>


### PR DESCRIPTION
- Add `pfm_description` to preference dictionaries
- Add `pfm_format` for all version pinning preferences to ensure the supplied value ends with `.`
- Change 'Hangouts Chat' to 'Chat' given Google branding changes
- Change 'FileStream' to 'Google File Stream' to match Google branding.
- Update last_modified date