### PR TITLE
Add com.apple.AdLib manifest

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.AdLib.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.AdLib.plist
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>pfm_description</key>
+		<string>Ad Tracking settings</string>
+		<key>pfm_domain</key>
+		<string>com.apple.AdLib</string>
+		<key>pfm_format_version</key>
+		<integer>1</integer>
+		<key>pfm_last_modified</key>
+		<date>2020-04-21T18:58:47Z</date>
+		<key>pfm_platforms</key>
+		<array>
+			<string>macOS</string>
+		</array>
+		<key>pfm_subkeys</key>
+		<array>
+			<dict>
+				<key>pfm_default</key>
+				<string>Configures Ad Tracking settings</string>
+				<key>pfm_description</key>
+				<string>Description of the payload.</string>
+				<key>pfm_description_reference</key>
+				<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+				<key>pfm_name</key>
+				<string>PayloadDescription</string>
+				<key>pfm_title</key>
+				<string>Payload Description</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>Ad Tracking</string>
+				<key>pfm_description</key>
+				<string>Name of the payload.</string>
+				<key>pfm_description_reference</key>
+				<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+				<key>pfm_name</key>
+				<string>PayloadDisplayName</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Display Name</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>com.apple.AdLib</string>
+				<key>pfm_description</key>
+				<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+				<key>pfm_description_reference</key>
+				<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+				<key>pfm_name</key>
+				<string>PayloadIdentifier</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Identifier</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string>com.apple.AdLib</string>
+				<key>pfm_description</key>
+				<string>The type of the payload, a reverse dns string.</string>
+				<key>pfm_description_reference</key>
+				<string>The payload type.</string>
+				<key>pfm_name</key>
+				<string>PayloadType</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Type</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<string/>
+				<key>pfm_description</key>
+				<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+				<key>pfm_description_reference</key>
+				<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+				<key>pfm_format</key>
+				<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+				<key>pfm_name</key>
+				<string>PayloadUUID</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload UUID</string>
+				<key>pfm_type</key>
+				<string>string</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<integer>1</integer>
+				<key>pfm_description</key>
+				<string>The version of the whole configuration profile.</string>
+				<key>pfm_description_reference</key>
+				<string>The version number of the individual payload.
+A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+				<key>pfm_name</key>
+				<string>PayloadVersion</string>
+				<key>pfm_require</key>
+				<string>always</string>
+				<key>pfm_title</key>
+				<string>Payload Version</string>
+				<key>pfm_type</key>
+				<string>integer</string>
+			</dict>
+			<dict>
+				<key>pfm_description</key>
+				<string>Enabling this opts out of receiving ads targeted to interests in Apple Apps and macOS devices. May still receive the same number of ads, but the ads may be less relevant.</string>
+				<key>pfm_name</key>
+				<string>forceLimitAdTracking</string>
+				<key>pfm_note</key>
+				<string>This preference lives in the Restrictions payload, but is only officially supported for iOS. This payload and preference permits the management of this setting on macOS.</string>
+				<key>pfm_title</key>
+				<string>Force Limiting Ad Tracking</string>
+				<key>pfm_type</key>
+				<string>boolean</string>
+			</dict>
+		</array>
+		<key>pfm_targets</key>
+		<array>
+			<string>system</string>
+			<string>user</string>
+		</array>
+		<key>pfm_title</key>
+		<string>Ad Tracking</string>
+		<key>pfm_unique</key>
+		<true/>
+		<key>pfm_version</key>
+		<integer>1</integer>
+	</dict>
+</plist>


### PR DESCRIPTION
`forceLimitAdTracking` is a part of the Restrictions payload, but the preference is only supported on iOS.  This manifest allows this preference to be managed on macOS. Included a pfm_note to indicate this.

Tested and confirmed desired behavior is enforced.