### PR TITLE
DigiDNA Range Corrections

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
+++ b/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
@@ -1415,8 +1415,6 @@
 
 Line one
 Line two</string>
-			<key>pfm_range_max</key>
-			<integer>2</integer>
 			<key>pfm_title</key>
 			<string>Password Change Policy Message</string>
 			<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
+++ b/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-03-24T21:30:50Z</date>
+	<date>2020-05-14T11:47:11Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -12,12 +12,12 @@
 	<string>menu.nomad.login.ad</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
+	<key>pfm_last_modified</key>
+	<date>2020-05-14T11:47:11Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
 	</array>
-	<key>pfm_last_modified</key>
-	<date>2020-04-13T20:48:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -625,8 +625,6 @@
 			<string>Text to present in the EULA window.</string>
 			<key>pfm_name</key>
 			<string>EULAText</string>
-			<key>pfm_range_max</key>
-			<integer>2</integer>
 			<key>pfm_title</key>
 			<string>End User License Agreement Text</string>
 			<key>pfm_type</key>
@@ -826,8 +824,6 @@
 			<string>User Input Text</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_range_max</key>
-			<integer>4</integer>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -14,7 +14,7 @@ window payloads may be installed together.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2020-05-14T11:47:11Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -224,8 +224,6 @@ The payload organization for a payload need not match the payload organization i
 			<string>Optional. Text to display in the login window.</string>
 			<key>pfm_name</key>
 			<string>LoginwindowText</string>
-			<key>pfm_range_max</key>
-			<integer>2</integer>
 			<key>pfm_title</key>
 			<string>Banner</string>
 			<key>pfm_type</key>


### PR DESCRIPTION
Fixed a few incorrect range_max attributes that slipped into string keys in the com.trusourcelabs.NoMAD, menu.nomad.login.ad, and com.apple.loginwindow domains.