### PR TITLE
Update Microsoft Update manifest

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2020-05-19T16:57:16Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -433,8 +433,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>MSau04</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -457,8 +455,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<integer>1033</integer>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>LCID</string>
 							<key>pfm_range_list</key>
@@ -920,8 +916,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>MSRD10</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -987,8 +981,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>TEAM01</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -1125,8 +1117,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>IMCP01</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -1192,8 +1182,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>ONDR18</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -1320,16 +1308,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_type</key>
 			<string>dictionary</string>
 		</dict>
-
-
-
-
-
-
-
-
-
-
 		<dict>
 			<key>pfm_app_min</key>
 			<string>4.13</string>
@@ -1357,8 +1335,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>MSau04</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -1802,8 +1778,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>MSRD10</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -1863,8 +1837,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>TEAM01</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -1989,8 +1961,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>IMCP01</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
@@ -2050,8 +2020,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 						<dict>
 							<key>pfm_default</key>
 							<string>ONDR18</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>


### PR DESCRIPTION
Remove pfm_hidden for apps with 1 app ID.  Want to make this more visible to admins.  Per https://macadmins.slack.com/archives/C2N7MED7G/p1589901144125800

Also remove some whitespace and bump the last_modified date