### PR TITLE
Update com.apple.touristd.plist

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
@@ -4,12 +4,14 @@
 <dict>
 	<key>pfm_description</key>
 	<string>"New to Mac" notification settings</string>
+	<key>pfm_documentation_url</key>
+	<string>https://help.apple.com/macOS/config.json</string>
 	<key>pfm_domain</key>
 	<string>com.apple.touristd</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-01-07T09:25:03Z</date>
+	<date>2020-05-21T15:40:03Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -171,6 +173,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				<array>
 					<string>seed-viewed-SkI/dLAkQu6k/qpzSOG6Iw</string>
 					<string>seed-viewed-Tu81gKhDTvmNkjyqcPBfKA</string>
+					<string>seed-viewed-catalina_early-2020_macbook-air</string>
 					<string>seed-viewed-catalina_macbook-air</string>
 				</array>
 				<key>MacBook Pro</key>
@@ -184,6 +187,7 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>seed-viewed-GZAJdmpdSqmfH2PkCr8ebw</string>
 					<string>seed-viewed-JTecrrXDSVut2tSfltty9Q</string>
 					<string>seed-viewed-MM3ne3nTR9eXFyVwZ5gN7Q</string>
+					<string>seed-viewed-catalina_early-2020_macbook-pro-13</string>
 					<string>seed-viewed-catalina_late-2019_macbook-pro</string>
 					<string>seed-viewed-catalina_macbook-pro</string>
 					<string>seed-viewed-catalina_macbook-pro-13</string>
@@ -208,7 +212,7 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>seed-viewed-LR2P9+rnQ2q9xSUy1ZgWOw</string>
 					<string>seed-viewed-bydF6fX5Sp6aBYdEXD0VwQ</string>
 					<string>seed-viewed-catalina_mac-basics</string>
-					<string>seed-viewed-catalina_whats-new</string>
+					<string>seed-viewed-catalina_whats_new</string>
 					<string>seed-viewed-f/Pn3F4RScOh+GUBKO9sRA</string>
 					<string>seed-viewed-lQlm1yrMS0GPVyAL44id+A</string>
 				</array>
@@ -798,9 +802,33 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>https://help.apple.com/macos/catalina/whats-new</string>
 			<key>pfm_name</key>
-			<string>seed-viewed-catalina_whats-new</string>
+			<string>seed-viewed-catalina_whats_new</string>
 			<key>pfm_title</key>
 			<string>What's New: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/early-2020/macbook-air</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_early-2020_macbook-air</string>
+			<key>pfm_title</key>
+			<string>MacBook Air Early 2020: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/catalina/early-2020/macbook-pro-13</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-catalina_early-2020_macbook-pro-13</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13 Early 2020: 10.15</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -815,6 +843,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Add pfm_documentation_url to point to the latest Apple touristd config file for reference.
- Fix typo in pfm_name for what's new with Catalina
- Add early 2020 MacBook Air and MacBook Pro for Catalina
- Bump pfm_version and update modified_date