### PR TITLE
Fix typo in Catalina Mac Basics key name

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-05-21T15:40:03Z</date>
+	<date>2020-05-29T20:25:02Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -211,7 +211,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				<array>
 					<string>seed-viewed-LR2P9+rnQ2q9xSUy1ZgWOw</string>
 					<string>seed-viewed-bydF6fX5Sp6aBYdEXD0VwQ</string>
-					<string>seed-viewed-catalina_mac-basics</string>
+					<string>seed-viewed-catalina_mac_basics</string>
 					<string>seed-viewed-catalina_whats_new</string>
 					<string>seed-viewed-f/Pn3F4RScOh+GUBKO9sRA</string>
 					<string>seed-viewed-lQlm1yrMS0GPVyAL44id+A</string>
@@ -754,7 +754,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>https://help.apple.com/macos/catalina/mac-basics</string>
 			<key>pfm_name</key>
-			<string>seed-viewed-catalina_mac-basics</string>
+			<string>seed-viewed-catalina_mac_basics</string>
 			<key>pfm_title</key>
 			<string>New to Mac: 10.15</string>
 			<key>pfm_type</key>


### PR DESCRIPTION
Hyphen should have been an underscore.  This change was made to catalina_whats_new in a previous commit.