### PR TITLE
Add S3 Endpoint for S3-Auth Plugin

### DIFF
--- a/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
+++ b/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-05-29T04:30:32Z</date>
+	<date>2020-07-23T01:39:36Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -865,6 +865,6 @@ S3 Endpoint for bucket.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>7</integer>
+	<integer>8</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
+++ b/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
@@ -204,6 +204,7 @@
 					<string>AccessKey</string>
 					<string>Region</string>
 					<string>SecretKey</string>
+					<string>S3Endpoint</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
@@ -762,6 +763,7 @@
 					<string>AccessKey</string>
 					<string>SecretKey</string>
 					<string>Region</string>
+					<string>S3Endpoint</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
@@ -818,6 +820,24 @@ SecretKey for S3 bucket.</string>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
 			<string>ex. z5MFJCcEyYBmh2BxbrlZBWNJ4izEXAMPLE</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>2.7.0</string>
+			<key>pfm_description</key>
+			<string>Munki has a feature which enables Mac administrators to use middleware to change munki's HTTP request. S3-Auth uses this feature to create the HTTP headers necessary to authenticate to S3.
+
+S3 Endpoint for bucket.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/waderobson/s3-auth</string>
+			<key>pfm_name</key>
+			<string>S3Endpoint</string>
+			<key>pfm_title</key>
+			<string>S3 Endpoint</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>ex. s3.us-west-1.wasabisys.com</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>


### PR DESCRIPTION
Wasabi (and I'm assuming other S3 compatible hosts) needs to have the S3Endpoint key defined to function. Without the key S3-Auth defaults to s3.amazonaws.com.

`S3_ENDPOINT = pref('S3Endpoint') or 's3.amazonaws.com`