### PR TITLE
Add ShareKit manifest

### DIFF
--- a/Manifests/ManifestsApple/com.apple.ShareKitHelper.plist
+++ b/Manifests/ManifestsApple/com.apple.ShareKitHelper.plist
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_description</key>
+	<string>Configures available Share menu options</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/sharekit</string>
+	<key>pfm_domain</key>
+	<string>com.apple.ShareKitHelper</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_interaction</key>
+	<string>exclusive</string>
+	<key>pfm_last_modified</key>
+	<date>2020-07-28T13:46:40Z</date>
+	<key>pfm_macos_deprecated</key>
+	<string>10.12</string>
+	<key>pfm_macos_min</key>
+	<string>10.9</string>
+	<key>pfm_platforms</key>
+	<array>
+		<string>macOS</string>
+	</array>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures Share menu options</string>
+			<key>pfm_description</key>
+			<string>Description of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>ShareKit</string>
+			<key>pfm_description</key>
+			<string>Name of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.apple.ShareKitHelper</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<key>pfm_description_reference</key>
+			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.apple.ShareKitHelper</string>
+			<key>pfm_description</key>
+			<string>The type of the payload, a reverse dns string.</string>
+			<key>pfm_description_reference</key>
+			<string>The payload type.</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
+			<key>pfm_description_reference</key>
+			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_description_reference</key>
+			<string>The version number of the individual payload.
+A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<key>pfm_description_reference</key>
+			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
+The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description_reference</key>
+			<string>The list of plugin IDs that show up in the user's Share menu. If this array exists, only these items are permitted.</string>
+			<key>pfm_name</key>
+			<string>SHKAllowedShareServices</string>
+			<key>pfm_note</key>
+			<string>To most efficiently disable all Share menu options, add this preference to your profile but include no options.</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_range_list</key>
+					<array>
+						<string>com.apple.share.AirDrop</string>
+						<string>com.apple.share.Facebook</string>
+						<string>com.apple.share.LinkedIn.post</string>
+						<string>com.apple.share.Twitter</string>
+						<string>com.apple.share.Mail</string>
+						<string>com.apple.share.Messages</string>
+						<string>com.apple.Notes.SharingExtension</string>
+						<string>com.apple.reminders.RemindersShareExtension</string>
+						<string>com.apple.share.Video</string>
+						<string>com.apple.share.addtoiphoto</string>
+						<string>com.apple.share.addtoaperture</string>
+						<string>com.apple.share.readlater</string>
+						<string>com.apple.share.SinaWeibo</string>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>AirDrop</string>
+						<string>Facebook</string>
+						<string>LinkedIn</string>
+						<string>Twitter</string>
+						<string>Mail</string>
+						<string>Messages</string>
+						<string>Notes</string>
+						<string>Reminders</string>
+						<string>Video Services - Flickr, Vimeo, Tuduo, and Youku</string>
+						<string>Add to iPhoto</string>
+						<string>Add to Aperture</string>
+						<string>Add to Reading List</string>
+						<string>Sina Weibo</string>
+					</array>
+					<key>pfm_title</key>
+					<string>Allowed Services</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_unique</key>
+					<true/>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Allowed Share Services</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description_reference</key>
+			<string>The list of plugin IDs that won't show up in the user's Share menu. This key is used only if there is no SHKAllowedShareServices key.</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<true/>
+							<key>pfm_target</key>
+							<string>SHKAllowedShareServices</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+			<key>pfm_name</key>
+			<string>SHKDeniedShareServices</string>
+			<key>pfm_note</key>
+			<string>This preference can only be used if SHKAllowedShareServices is not used.</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_range_list</key>
+					<array>
+						<string>com.apple.share.AirDrop</string>
+						<string>com.apple.share.Facebook</string>
+						<string>com.apple.share.LinkedIn.post</string>
+						<string>com.apple.share.Twitter</string>
+						<string>com.apple.share.Mail</string>
+						<string>com.apple.share.Messages</string>
+						<string>com.apple.Notes.SharingExtension</string>
+						<string>com.apple.reminders.RemindersShareExtension</string>
+						<string>com.apple.share.Video</string>
+						<string>com.apple.share.addtoiphoto</string>
+						<string>com.apple.share.addtoaperture</string>
+						<string>com.apple.share.readlater</string>
+						<string>com.apple.share.SinaWeibo</string>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>AirDrop</string>
+						<string>Facebook</string>
+						<string>LinkedIn</string>
+						<string>Twitter</string>
+						<string>Mail</string>
+						<string>Messages</string>
+						<string>Notes</string>
+						<string>Reminders</string>
+						<string>Video Services - Flickr, Vimeo, Tuduo, and Youku</string>
+						<string>Add to iPhoto</string>
+						<string>Add to Aperture</string>
+						<string>Add to Reading List</string>
+						<string>Sina Weibo</string>
+					</array>
+					<key>pfm_title</key>
+					<string>Denied Services</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_unique</key>
+					<true/>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Denied Share Services</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+	</array>
+	<key>pfm_targets</key>
+	<array>
+		<string>system</string>
+		<string>user</string>
+	</array>
+	<key>pfm_title</key>
+	<string>ShareKit</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/Manifests/ManifestsApple/com.apple.ShareKitHelper.plist
+++ b/Manifests/ManifestsApple/com.apple.ShareKitHelper.plist
@@ -137,6 +137,10 @@ The payload organization for a payload need not match the payload organization i
 		<dict>
 			<key>pfm_description_reference</key>
 			<string>The list of plugin IDs that show up in the user's Share menu. If this array exists, only these items are permitted.</string>
+			<key>pfm_macos_deprecated</key>
+			<string>10.12</string>
+			<key>pfm_macos_min</key>
+			<string>10.9</string>
 			<key>pfm_name</key>
 			<string>SHKAllowedShareServices</string>
 			<key>pfm_note</key>
@@ -206,6 +210,10 @@ The payload organization for a payload need not match the payload organization i
 					</array>
 				</dict>
 			</array>
+			<key>pfm_macos_deprecated</key>
+			<string>10.12</string>
+			<key>pfm_macos_min</key>
+			<string>10.9</string>
 			<key>pfm_name</key>
 			<string>SHKDeniedShareServices</string>
 			<key>pfm_note</key>


### PR DESCRIPTION
Per discussion in #profilecreator Slack channel (https://macadmins.slack.com/archives/C2N7MED7G/p1595515885293400) adds the long-deprecated ShareKit manifest.  Unsure if this is actually respected in later OSs (10.13+), but payload is still included in Jamf's profiles (albeit it's been broken for a while, video: https://macadmins.slack.com/archives/C2N7MED7G/p1595516156295000).  At the very least, want to give admins the opportunity to suppress these share options if we're able to.