### PR TITLE
Removal of erroneous RecentWhatsNewPanelVersion key

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
@@ -11,7 +11,7 @@
 		<key>pfm_format_version</key>
 		<integer>1</integer>
 		<key>pfm_last_modified</key>
-		<date>2019-09-05T19:00:00Z</date>
+		<date>2020-08-05T19:00:00Z</date>
 		<key>pfm_platforms</key>
 		<array>
 			<string>macOS</string>
@@ -185,16 +185,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			</dict>
 			<dict>
 				<key>pfm_description</key>
-				<string>Suppresses the What's New window on launch. Correct value for Logic Pro 10.4.3 is 7.</string>
-				<key>pfm_name</key>
-				<string>RecentWhatsNewPanelVersion</string>
-				<key>pfm_title</key>
-				<string>Recent Whats New Panel Version</string>
-				<key>pfm_type</key>
-				<string>integer</string>
-			</dict>
-			<dict>
-				<key>pfm_description</key>
 				<string>Configures whether Show Advanced Tools is enabled.</string>
 				<key>pfm_name</key>
 				<string>userLevel</string>
@@ -287,6 +277,6 @@ A profile can consist of payloads with different version numbers. For example, c
 		<key>pfm_unique</key>
 		<false/>
 		<key>pfm_version</key>
-		<integer>4</integer>
+		<integer>5</integer>
 	</dict>
 </plist>


### PR DESCRIPTION
The current version of this manifest has two `RecentWhatsNewPanelVersion` keys. I've removed the dodgy one.