### PR TITLE
Add GUIDTool to RunScript

### DIFF
--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-05-14T11:47:11Z</date>
+	<date>2020-10-13T23:55:35Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -1645,6 +1645,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>12</integer>
+	<integer>13</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -234,6 +234,7 @@
 					<string>ScriptPath</string>
 					<string>ScriptArgs</string>
 					<string>UIDTool</string>
+					<string>GUIDTool</string>
 				</array>
 				<key>Notify</key>
 				<array>
@@ -1454,6 +1455,18 @@
 			<string>UIDTool</string>
 			<key>pfm_title</key>
 			<string>UID Tool</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.4</string>
+			<key>pfm_description</key>
+			<string>String to determine the path of an executable that is run when a new user is created. It is expected to return the GUID that the user should be created with. It passes in the new users username as the first argument, default is to use the built in functionality</string>
+			<key>pfm_name</key>
+			<string>GUIDTool</string>
+			<key>pfm_title</key>
+			<string>GUID Tool</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>


### PR DESCRIPTION
There's a function for both UID and GUID because some of use are oddly interested in such things ... i.e. I've had the same UID/GUID's for more than a decade and would like to keep them consistent. I asked and said feature was delivered.