### PR TITLE
Update PPPC Manifest

### DIFF
--- a/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
@@ -126,6 +126,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Specifies the policies for the app via the Accessibility subsystem.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>Accessibility</string>
 					<key>pfm_subkeys</key>
@@ -202,6 +204,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -236,6 +248,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Specifies the policies for the app sending restricted AppleEvents to another process.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>AppleEvents</string>
 					<key>pfm_subkeys</key>
@@ -312,6 +326,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -392,6 +416,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Specifies the policies for calendar information managed by the Calendar.app.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>Calendar</string>
 					<key>pfm_subkeys</key>
@@ -468,6 +494,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -502,6 +538,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>A system camera. Access to the camera cannot be given in a profile; it can only be denied.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>Camera</string>
 					<key>pfm_subkeys</key>
@@ -578,6 +616,14 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -612,6 +658,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Specifies the policies for contact information managed by the Contacts.app.</string>
+					<key>pfm_macos_min</key>
+					<string>10.15</string>
 					<key>pfm_name</key>
 					<string>AddressBook</string>
 					<key>pfm_subkeys</key>
@@ -688,6 +736,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -800,6 +858,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -910,6 +978,14 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1020,6 +1096,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1052,6 +1138,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>A system microphone. Access to the microphone cannot be given in a profile; it can only be denied.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>Microphone</string>
 					<key>pfm_subkeys</key>
@@ -1128,6 +1216,14 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1162,6 +1258,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Pictures managed by Photos.app in ~/Pictures/.photoslibrary.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>Photos</string>
 					<key>pfm_subkeys</key>
@@ -1238,6 +1336,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1272,6 +1380,8 @@
 				<dict>
 					<key>pfm_description</key>
 					<string>Specifies the policies for the application to use CoreGraphics APIs to send CGEvents to the system event stream.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>PostEvent</string>
 					<key>pfm_subkeys</key>
@@ -1348,6 +1458,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1382,6 +1502,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Specifies the policies for reminders information managed by the Reminders app.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>Reminders</string>
 					<key>pfm_subkeys</key>
@@ -1458,6 +1580,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1492,6 +1624,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Allows the application access to all protected files.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>SystemPolicyAllFiles</string>
 					<key>pfm_subkeys</key>
@@ -1568,6 +1702,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1680,6 +1824,14 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1790,6 +1942,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1822,6 +1984,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Allows the application to access files in the user's Desktop folder.</string>
+					<key>pfm_macos_min</key>
+					<string>10.15</string>
 					<key>pfm_name</key>
 					<string>SystemPolicyDesktopFolder</string>
 					<key>pfm_subkeys</key>
@@ -1898,6 +2062,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -1926,12 +2100,12 @@
 					<string>array</string>
 					<key>pfm_value_import_processor</key>
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
-					<key>pfm_macos_min</key>
-					<string>10.15</string>
 				</dict>
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Allows the application to access files in the user's Documents folder.</string>
+					<key>pfm_macos_min</key>
+					<string>10.15</string>
 					<key>pfm_name</key>
 					<string>SystemPolicyDocumentsFolder</string>
 					<key>pfm_subkeys</key>
@@ -2008,6 +2182,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -2036,8 +2220,6 @@
 					<string>array</string>
 					<key>pfm_value_import_processor</key>
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
-					<key>pfm_macos_min</key>
-					<string>10.15</string>
 				</dict>
 				<dict>
 					<key>pfm_description_reference</key>
@@ -2120,6 +2302,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -2230,6 +2422,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -2340,6 +2542,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -2372,6 +2584,8 @@
 				<dict>
 					<key>pfm_description_reference</key>
 					<string>Allows the application access to some files used in system administration.</string>
+					<key>pfm_macos_min</key>
+					<string>10.14</string>
 					<key>pfm_name</key>
 					<string>SystemPolicySysAdminFiles</string>
 					<key>pfm_subkeys</key>
@@ -2448,6 +2662,16 @@
 									<string>If set to true, access is granted. Otherwise the process does not have access. The user is not prompted and cannot change this value.</string>
 									<key>pfm_name</key>
 									<string>Allowed</string>
+									<key>pfm_range_list</key>
+									<array>
+										<false/>
+										<true/>
+									</array>
+									<key>pfm_range_list_titles</key>
+									<array>
+										<string>Deny</string>
+										<string>Allow</string>
+									</array>
 									<key>pfm_title</key>
 									<string>Allowed</string>
 									<key>pfm_type</key>
@@ -2498,6 +2722,6 @@
 	<key>pfm_user_approved</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>


### PR DESCRIPTION
- Add pfm_macos_min values for 10.14 PPPC prefs to be explicit.  These had already been added for 10.15 prefs.
- Make `Allowed` preference a dropdown menu instead of a checkbox.  This makes the option more explicit and has the added benefit of allowing us to force admins to only be able to deny access for the applicable prefs - Camera, Microphone, ListenEvent, ScreenCapture
- Bump pfm_version