### PR TITLE
Updated version check in index scripts to pass on Big Sur

### DIFF
--- a/updateIndexIcons
+++ b/updateIndexIcons
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if (($( sw_vers -productVersion | awk -F. '{ print $2 }' ) < 14)); then
+if [[ $( printf "%s\n" "10.14" "$( sw_vers -productVersion )" | sort -V | head -n1 ) != "10.14" ]]; then
 	printf "%s\n" "This script requires macOS 10.14 or higher to create correct hashes for the icons..."
 	exit 1
 fi

--- a/updateIndexManifests
+++ b/updateIndexManifests
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if (($( sw_vers -productVersion | awk -F. '{ print $2 }' ) < 14)); then
+if [[ $( printf "%s\n" "10.14" "$( sw_vers -productVersion )" | sort -V | head -n1 ) != "10.14" ]]; then
 	printf "%s\n" "This script requires macOS 10.14 or higher to create correct hashes for the manifests..."
 	exit 1
 fi


### PR DESCRIPTION
The index-update scripts stopped working on Big Sur because their version checks fail due to the versioning convention change on the OS (major version number no longer fixed at 10). This commit resolves the issue.