### PR TITLE
DigiDNA Jan 2021 tweaks

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
@@ -457,7 +457,7 @@ If set to false, the user must validate with their existing IdP password, which 
 				<string>OIDCAdmin</string>
 				<key>pfm_description_reference</key>
 				<string>Determines which roles become an admin at the loginwindow. Users assigned a specified role become an admin at the loginwindow. You can also specify an array of strings to list multiple users</string>
-				<key>pfm_description_reference</key>
+				<key>pfm_description</key>
 				<string>Determines which roles become an admin at the loginwindow. Users assigned a specified role become an admin at the loginwindow.</string>
 				<key>pfm_type</key>
 				<string>array</string>
@@ -482,7 +482,7 @@ If set to false, the user must validate with their existing IdP password, which 
 			<dict>
 				<key>pfm_name</key>
 				<string>OIDCClientSecret</string>
-				<key>pfm_description</key>
+				<key>pfm_description_reference</key>
 				<string>The client secret used by Jamf Connect Login and your IdP.
 Important: If using Google ID or OneLogin as your IdP, this key must be specified.</string>
 				<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
@@ -1359,7 +1359,7 @@ Note: If the the user has a password in the keychain, the sign in window will no
 			<key>pfm_description_reference</key>
 			<string>Specifies the path to image file used as a logo.
 Note: A 342 x 90 pixel image is recommended.</string>
-			<key>pfm_description_reference</key>
+			<key>pfm_description</key>
 			<string>Specifies the path to image file used as a logo.</string>
 			<key>pfm_name</key>
 			<string>SignInLogo</string>

--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -605,7 +605,7 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<string>boolean</string>
 						</dict>
 					</array>
-					<key>pfm_name</key>
+					<key>pfm_title</key>
 					<string>Allow Non-FQDN</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>

--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -642,7 +642,7 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 							<string>boolean</string>
 						</dict>
 					</array>
-					<key>pfm_name</key>
+					<key>pfm_title</key>
 					<string>Allow Proxies</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>
@@ -4597,9 +4597,8 @@ In Firefox 65, you can specify a fully qualified path.</string>
 			<key>pfm_note</key>
 			<string>Certificates can be located in the following locations:
 /Library/Application Support/Mozilla/Certificates
-~/Library/Application Support/Mozilla/Certificates</string>
-			<key>pfm_note</key>
-			<string>See https://support.mozilla.org/kb/setting-certificate-authorities-firefox for more detail.</string>
+~/Library/Application Support/Mozilla/Certificates
+See https://support.mozilla.org/kb/setting-certificate-authorities-firefox for more detail.</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
@@ -33,8 +33,6 @@ This payload allows controls the authentication UI during mobile account creatio
 	<string>Mobile Accounts</string>
 	<key>pfm_unique</key>
 	<true/>
-	<key>pfm_version</key>
-	<integer>1</integer>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -683,8 +683,6 @@ The payload organization for a payload need not match the payload organization i
 			<integer>1</integer>
 			<key>pfm_title</key>
 			<string>Deferred Software Updates Delay</string>
-			<key>pfm_tvos_min</key>
-			<string>12.2</string>
 			<key>pfm_type</key>
 			<string>integer</string>
 			<key>pfm_value_unit</key>


### PR DESCRIPTION
The following commits all address keys that occurred twice in the same dictionary. Flat-out duplicates having the same value were removed, while those with different values were either combined under one key or replaced with the presumably intended PFM key.