### PR TITLE
DigiDNA com.apple.print.add update

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
@@ -141,7 +141,7 @@
 						<string>com.apple.print.add.search</string>
 					</array>
 					<key>pfm_description</key>
-					<string>The items to include in the toolbar and order. The only items that can be added more than once are the Flexible Space and Space. Warning: misconfiguration may lead to no UI showing, and settings may persist after removal of profile.</string>
+					<string>The items to include in the toolbar and their order. The only items that can be added more than once are the Flexible Space and Space. Warning: configuring this property with no actual buttons (Default, IP, Windows, or Advanced) may lead to the display of no UI, and this condition may persist after removal of profile.</string>
 					<key>pfm_name</key>
 					<string>TB Item Identifiers</string>
 					<key>pfm_subkeys</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-08-15T14:32:48Z</date>
+	<date>2021-02-01T09:50:53Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Add Printer Settings</string>
+	<string>Use this section to configure the toolbar of the Add Printer window under Printers and Scanners in System Preferences. The primary use case for this manifest is for prepopulating the toolbar with the 'Advanced' button.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.print.add</string>
 	<key>pfm_format_version</key>
@@ -20,7 +20,7 @@
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Configures Add Printer settings</string>
+			<string>Configures the toolbar of the Add Printer window under Printers and Scanners in System Preferences</string>
 			<key>pfm_description</key>
 			<string>Description of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -34,7 +34,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>Add Printer</string>
+			<string>Printing: Toolbar of Add Printer Window</string>
 			<key>pfm_description</key>
 			<string>Name of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -141,7 +141,7 @@
 						<string>com.apple.print.add.search</string>
 					</array>
 					<key>pfm_description</key>
-					<string>The items to include in the toolbar and order. The only items that can be added more than once are the Flexible Space and Space.</string>
+					<string>The items to include in the toolbar and order. The only items that can be added more than once are the Flexible Space and Space. Warning: misconfiguration may lead to no UI showing, and settings may persist after removal of profile.</string>
 					<key>pfm_name</key>
 					<string>TB Item Identifiers</string>
 					<key>pfm_subkeys</key>
@@ -259,7 +259,7 @@
 		<string>user</string>
 	</array>
 	<key>pfm_title</key>
-	<string>Add Printer</string>
+	<string>Printing: Toolbar of Add Printer Window</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>


### PR DESCRIPTION
This PR updates some of the texts of the `com.apple.print.add` manifest to better represent its role.

A note was also added to the Toolbar Items property, to warn admins about potential unwanted UI behavior that was reported by iMazing Profile Editor users and was successfully reproduced on our machines. This behavior persists after removal of the installing profile, although we did manage to restore to original state by either deleting the com.apple.print.add.plist file from the user preferences or by manually resetting the toolbar through the UI.