### PR TITLE
Update com.apple.touristd.plist for M1 Macs

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-11-15T17:33:41Z</date>
+	<date>2021-02-01T04:20:52Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -177,6 +177,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				<array>
 					<string>seed-viewed-SkI/dLAkQu6k/qpzSOG6Iw</string>
 					<string>seed-viewed-Tu81gKhDTvmNkjyqcPBfKA</string>
+					<string>seed-viewed-bigsur_late-2020_macbook-air</string>
 					<string>seed-viewed-catalina_early-2020_macbook-air</string>
 					<string>seed-viewed-catalina_macbook-air</string>
 				</array>
@@ -191,6 +192,7 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>seed-viewed-GZAJdmpdSqmfH2PkCr8ebw</string>
 					<string>seed-viewed-JTecrrXDSVut2tSfltty9Q</string>
 					<string>seed-viewed-MM3ne3nTR9eXFyVwZ5gN7Q</string>
+					<string>seed-viewed-bigsur_late-2020_macbook-pro-13</string>
 					<string>seed-viewed-bigsur_macbook-pro</string>
 					<string>seed-viewed-bigsur_macbook-pro-13</string>
 					<string>seed-viewed-catalina_early-2020_macbook-pro-13</string>
@@ -212,6 +214,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				<key>Mac mini</key>
 				<array>
 					<string>seed-viewed-baXokbqsQ/2KLkzIZrR6ng</string>
+					<string>seed-viewed-bigsur_late-2020_mac-mini</string>
 					<string>seed-viewed-bigsur_mac-mini</string>
 					<string>seed-viewed-catalina_mac-mini</string>
 				</array>
@@ -490,6 +493,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>seed-viewed-catalina_early-2020_macbook-air</string>
 			<key>pfm_title</key>
 			<string>MacBook Air Early 2020: 10.15</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/big-sur/macbook-air</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-bigsur_late-2020_macbook-air</string>
+			<key>pfm_title</key>
+			<string>MacBook Air Late 2020: 11.0</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -837,7 +852,19 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>seed-viewed-bigsur_macbook-pro-13</string>
 			<key>pfm_title</key>
-			<string>MacBook Pro: 11.0</string>
+			<string>MacBook Pro 13: 11.0</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/big-sur/late-2020/macbook-pro-13</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-bigsur_late-2020_macbook-pro-13</string>
+			<key>pfm_title</key>
+			<string>MacBook Pro 13 Late 2020: 11.0</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -886,6 +913,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>seed-viewed-bigsur_mac-mini</string>
 			<key>pfm_title</key>
 			<string>Mac mini: 11.0</string>
+			<key>pfm_type</key>
+			<string>date</string>
+		</dict>
+		<dict>
+			<key>pfm_date_allow_past</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>https://help.apple.com/macos/big-sur/late-2020/mac-mini</string>
+			<key>pfm_name</key>
+			<string>seed-viewed-bigsur_late-2020_mac-mini</string>
+			<key>pfm_title</key>
+			<string>Mac mini Late 2020: 11.0</string>
 			<key>pfm_type</key>
 			<string>date</string>
 		</dict>
@@ -960,6 +999,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #407 

- Add late 2020 Mac models
- Update previously added MacBook Pro 13in. pfm_title to separate from other Big Sur MBP
- Bump pfm_version and last modified date