### PR TITLE
Deprecate Allowed Media - com.apple.systemuiserver.plist

### DIFF
--- a/Manifests/ManifestsApple/com.apple.systemuiserver.plist
+++ b/Manifests/ManifestsApple/com.apple.systemuiserver.plist
@@ -4,14 +4,22 @@
 <dict>
 	<key>pfm_description</key>
 	<string>Allowed Media settings</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/mediamanagementallowedmedia</string>
 	<key>pfm_domain</key>
 	<string>com.apple.systemuiserver</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
+	<key>pfm_macos_deprecated</key>
+	<string>11.0</string>
+	<key>pfm_macos_max</key>
+	<string>10.15.7</string>
+	<key>pfm_macos_min</key>
+	<string>10.7</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-30T14:24:53Z</date>
+	<date>2021-04-03T19:08:31Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -144,6 +152,12 @@
 		<dict>
 			<key>pfm_description</key>
 			<string>Media type dictionary to control volume mounting.</string>
+			<key>pfm_macos_deprecated</key>
+			<string>11.0</string>
+			<key>pfm_macos_max</key>
+			<string>10.15.7</string>
+			<key>pfm_macos_min</key>
+			<string>10.7</string>
 			<key>pfm_name</key>
 			<string>mount-controls</string>
 			<key>pfm_subkeys</key>
@@ -608,6 +622,12 @@
 		<dict>
 			<key>pfm_description</key>
 			<string>Media type dictionary to control volume unmounting.</string>
+			<key>pfm_macos_deprecated</key>
+			<string>11.0</string>
+			<key>pfm_macos_max</key>
+			<string>10.15.7</string>
+			<key>pfm_macos_min</key>
+			<string>10.7</string>
 			<key>pfm_name</key>
 			<string>unmount-controls</string>
 			<key>pfm_subkeys</key>
@@ -1072,6 +1092,12 @@
 		<dict>
 			<key>pfm_description</key>
 			<string>Volumes to eject when the user logs out.</string>
+			<key>pfm_macos_deprecated</key>
+			<string>11.0</string>
+			<key>pfm_macos_max</key>
+			<string>10.15.7</string>
+			<key>pfm_macos_min</key>
+			<string>10.7</string>
 			<key>pfm_name</key>
 			<string>logout-eject</string>
 			<key>pfm_subkeys</key>
@@ -1544,6 +1570,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #425 

- Deprecate for Big Sur, add supported OS versions
- Add documentation url
- Bump pfm version and last modified date