### PR TITLE
DigiDNA Exchange tweak

### DIFF
--- a/Manifests/ManifestsApple/com.apple.eas.account.plist
+++ b/Manifests/ManifestsApple/com.apple.eas.account.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-08-18T17:28:30Z</date>
+	<date>2021-04-12T12:22:27Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -211,13 +211,15 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Send all communication through Secure Socket Layer.</string>
 			<key>pfm_description_reference</key>
 			<string>Optional. Default YES. Specifies whether the Exchange server uses SSL for authentication.</string>
 			<key>pfm_name</key>
 			<string>SSL</string>
+			<key>pfm_note</key>
+			<string>The official documentation as of writing shows the value of this property to be 'true', however in user reports and in further testing it was found to be the opposite case.</string>
 			<key>pfm_title</key>
 			<string>Use SSL for Internal Exchange Host</string>
 			<key>pfm_type</key>


### PR DESCRIPTION
Users of iMazing Profile Editor have reported that in contrast to the official documentation, the default value of the `SSL` property in `com.apple.eas.account` is in fact `false`.

Further testing that we've performed by installing a profile without the `SSL` key on a device have confirmed this to be true, with the _Use SSL_ switch in preferences defaulting to the off position as can be seen in the attached screenshot.

In this PR I've modified the manifest to match practice and to prevent admins from configuring accounts that will inadvertently not use SSL.

Feedback also submitted to Apple (FB9077169).

![Use SSL set to off](https://user-images.githubusercontent.com/883919/114400616-6d8e9480-9ba2-11eb-8133-0c573bcf4087.png)
