### PR TITLE
DigiDNA Web Content Filter tweak

### DIFF
--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-09-16T02:20:42Z</date>
+	<date>2021-05-03T08:32:57Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -171,7 +171,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description_reference</key>
 			<string>If true, automatic filtering is enabled. This function evaluates each web page as it is loaded and attempts to identify and block content not suitable for children. The search algorithm is complex and may vary from release to release, but it is basically looking for adult language.</string>
 			<key>pfm_exclude</key>
@@ -192,12 +192,14 @@
 			</array>
 			<key>pfm_name</key>
 			<string>AutoFilterEnabled</string>
+			<key>pfm_note</key>
+			<string>The official documentation as of writing shows the default value of this property to be 'true', however in user reports and in further testing it was found to be the opposite case.</string>
 			<key>pfm_title</key>
 			<string>Limit adult content automatically</string>
 			<key>pfm_description</key>
 			<string>Optional. If true, automatic filtering is enabled. This function evaluates each web page as it is loaded and attempts to identify and block content not suitable for children.
 
-The search algorithm is complex and may vary from release to release, but it is basically looking for adult language, i.e. swearing and sexually explicit language. The default value is true.</string>
+The search algorithm is complex and may vary from release to release, but it is basically looking for adult language, i.e. swearing and sexually explicit language. The default value is false.</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>


### PR DESCRIPTION
Similarly to #433, this PR addresses an incorrectly documented default value.

Users of iMazing Profile Editor have reported that in contrast to the official documentation, the default value of the `AutoFilterEnabled` property in `com.apple.webcontent-filter` is in fact `false`.

Further testing that we've performed by installing a profile without the `AutoFilterEnabled` key on a device have confirmed this to be the case, with filter-free internet browsing. Installing a profile one with the key forced to its documented default of `true` on the other hand lead to filtered browsing.

In this PR I've modified the manifest to match practice and to prevent admins from configuring web content filters that will inadvertently not be filtered.

Note that this PR doesn't include changes introduced on this same manifest in #428. When a conflict occurs on line 16 this PR should prevail.