### PR TITLE
Update edu.psu.macoslaps.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
+++ b/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
@@ -238,6 +238,18 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description_reference</key>
+			<string>The method to use with macOSLAPS. Default is AD for Active Directory. The other option is Local which will allow local rotation and no need to talk to Active Directory.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/joshua-d-miller/macOSLAPS#requirements</string>
+			<key>pfm_name</key>
+			<string>Method</string>
+			<key>pfm_title</key>
+			<string>Active Directory Method or local Method</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description_reference</key>
 			<string>Set your preferred Domain Controller to connect to (Useful when you have RODCs).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://github.com/joshua-d-miller/macOSLAPS#requirements</string>

--- a/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
+++ b/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-02-10T13:42:31Z</date>
+	<date>2021-07-22T03:43:44Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -237,14 +237,19 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>array</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<string>AD</string>
 			<key>pfm_description_reference</key>
 			<string>The method to use with macOSLAPS. Default is AD for Active Directory. The other option is Local which will allow local rotation and no need to talk to Active Directory.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://github.com/joshua-d-miller/macOSLAPS#requirements</string>
 			<key>pfm_name</key>
 			<string>Method</string>
-			<key>pfm_title</key>
-			<string>Active Directory Method or local Method</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>AD</string>
+				<string>Local</string>
+			</array>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
@@ -287,6 +292,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Hey i added the new Key Method

Method - The method to use with macOSLAPS. Default is AD for Active Directory. The other option is Local which will allow local rotation and no need to talk to Active Directory.

Best Regards