### PR TITLE
Update pfm_segments for BBEdit

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.barebones.bbedit.plist
+++ b/Manifests/ManagedPreferencesApplications/com.barebones.bbedit.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-07-22T00:00:00Z</date>
+	<date>2021-07-22T12:58:59Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.barebones.bbedit.plist
+++ b/Manifests/ManagedPreferencesApplications/com.barebones.bbedit.plist
@@ -240,6 +240,8 @@
 					<string>BBEditSerialNumber:12.0</string>
 					<string>BBEditRegisteredOwner:13.0</string>
 					<string>BBEditSerialNumber:13.0</string>
+					<string>BBEditRegisteredOwner:14.0</string>
+					<string>BBEditSerialNumber:14.0</string>
 				</array>
 				<key>Updates</key>
 				<array>


### PR DESCRIPTION
I neglected to put the new licensing keys in the correct place in pfm_segments, so they appeared by default in Appearance. Moved them to Licenses, as they should be.
Sorry, my first time contributing to this project.