### PR TITLE
DigiDNA September 2021 tweaks

### DIFF
--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -20,7 +20,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-01-14T16:53:36Z</date>
+	<date>2021-09-10T14:14:37Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -5653,7 +5653,7 @@ UrlbarInterventions Don't offer Firefox specific suggestions in the URL bar. (Fi
 	<key>pfm_title</key>
 	<string>Firefox</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_user_approved</key>
 	<false/>
 	<key>pfm_version</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-05-03T15:38:43Z</date>
+	<date>2021-08-12T08:39:19Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -211,7 +211,6 @@ The payload organization for a payload need not match the payload organization i
 					<string>allowWallpaperModification</string>
 					<string>forceAuthenticationBeforeAutoFill</string>
 					<string>forceAutomaticDateAndTime</string>
-					<string>forceClassroomUnpromptedScreenObservation</string>
 					<string>forceEncryptedBackup</string>
 					<string>forceITunesStorePasswordEntry</string>
 					<string>forceLimitAdTracking</string>
@@ -271,6 +270,7 @@ The payload organization for a payload need not match the payload organization i
 				<array>
 					<string>forceClassroomAutomaticallyJoinClasses</string>
 					<string>forceClassroomRequestPermissionToLeaveClasses</string>
+					<string>forceClassroomUnpromptedScreenObservation</string>
 					<string>forceClassroomUnpromptedAppAndDeviceLock</string>
 					<string>forceUnpromptedManagedClassroomScreenObservation</string>
 				</array>
@@ -769,7 +769,7 @@ This key should be nested beneath allowScreenShot as a sub-restriction. If allow
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>If Allow screenshots and screen recording is set to 'false' or Allow AirPlay and View Screen by Classroom app, they also override this preference and prevents the Classroom app from unprompted remote AirPlay and view screens.
 
@@ -1253,7 +1253,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -1271,7 +1271,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
@@ -1289,7 +1289,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2021-05-03T15:38:44Z</date>
+		<date>2021-08-12T08:39:19Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>
@@ -745,7 +745,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			</dict>
 			<dict>
 				<key>pfm_default</key>
-				<true/>
+				<false/>
 				<key>pfm_description</key>
 				<string/>
 				<key>pfm_description_reference</key>
@@ -763,7 +763,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			</dict>
 			<dict>
 				<key>pfm_default</key>
-				<true/>
+				<false/>
 				<key>pfm_description</key>
 				<string/>
 				<key>pfm_description_reference</key>
@@ -781,7 +781,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			</dict>
 			<dict>
 				<key>pfm_default</key>
-				<true/>
+				<false/>
 				<key>pfm_description</key>
 				<string/>
 				<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.caldav.account.plist
+++ b/Manifests/ManifestsApple/com.apple.caldav.account.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:50Z</date>
+	<date>2021-09-16T16:18:39Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -237,7 +237,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Enable Secure Socket Layer communication with CalDAV server</string>
 			<key>pfm_description_reference</key>
@@ -245,6 +245,8 @@ In macOS, this key is required.</string>
 In macOS, this key is optional.</string>
 			<key>pfm_name</key>
 			<string>CalDAVUseSSL</string>
+			<key>pfm_note</key>
+			<string>The official documentation as of writing shows the value of this property to be 'true', however in user reports and in further testing it was found to be the opposite case.</string>
 			<key>pfm_title</key>
 			<string>Use SSL</string>
 			<key>pfm_type</key>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2021-08-13T15:15:14Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -1138,7 +1138,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_name</key>
 			<string>static-only</string>
 			<key>pfm_title</key>
-			<string>Merge with User's Dock</string>
+			<string>Remove non-static apps and documents from Dock</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 			<key>pfm_value_inverted</key>

--- a/Manifests/ManifestsApple/com.apple.system.logging.plist
+++ b/Manifests/ManifestsApple/com.apple.system.logging.plist
@@ -13,14 +13,12 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-02-04T21:42:00Z</date>
+	<date>2021-09-17T12:35:55Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
 	<array>
-		<string>iOS</string>
 		<string>macOS</string>
-		<string>tvOS</string>
 	</array>
 	<key>pfm_subkeys</key>
 	<array>


### PR DESCRIPTION
This PR contains a number of housekeeping updates:
 - Tweaked the _Restrictions_ and _Firefox_ manifests to better align with the documentation.
 - Reworded a key's title in the _Dock_ manifest to better explain its role after testing.
 - Removed iOS and tvOS support from the _System Logging_ manifest. The removed platforms actually do support this preference domain, and Apple has a page of ready-made profiles using the domain on the aforementioned platforms (https://developer.apple.com/bug-reporting/profiles-and-logs). However, as currently implemented in the repository, the domain is only supported on macOS.
 - Similar to #433, in contrast to the official documentation the default value of the `CalDAVUseSSL` property in `com.apple.caldav.account` is in fact `false`. This was reported by iMazing Profile Editor users and confirmed through testing. This PR modifies the default value to prevent admins from inadvertently configuring insecure accounts. Feedback also submitted to Apple (FB9631029).
