### PR TITLE
DigiDNA October 2021 tweaks

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-08-21T21:21:00Z</date>
+	<date>2021-09-27T09:00:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -112,7 +112,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<array>
 				<string>1</string>
 			</array>
-			<key>pfm_required</key>
+			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_title</key>
 			<string>Jamf Connect Shares PLIST Version</string>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-01-18T20:48:00Z</date>
+	<date>2021-09-27T09:00:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -130,7 +130,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<array>
 				<string>1</string>
 			</array>
-			<key>pfm_required</key>
+			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_title</key>
 			<string>NoMAD Shares PLIST Version</string>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2021-09-27T09:00:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -161,7 +161,7 @@ The payload organization for a payload need not match the payload organization i
 							<string>The type of the tile. Values may be file-tile, directory-tile, or url-tile. If you are unsure whether the file item is a file or a directory, set this key to file-tile.</string>
 							<key>pfm_description_reference</key>
 							<string>Required. The type of the tile. Values may be file-tile, directory-tile, or url-tile. If you are unsure whether the file item is a file or a directory, set this key to file-tile.</string>
-							<key>pfm_required</key>
+							<key>pfm_require</key>
 							<string>always</string>
 							<key>pfm_default</key>
 							<string>file-tile</string>
@@ -198,7 +198,7 @@ The payload organization for a payload need not match the payload organization i
 									<string>Label of a dock item.</string>
 									<key>pfm_description_reference</key>
 									<string>Required. Label of a dock item.</string>
-									<key>pfm_required</key>
+									<key>pfm_require</key>
 									<string>always</string>
 									<key>pfm_name</key>
 									<string>label</string>
@@ -236,7 +236,7 @@ The payload organization for a payload need not match the payload organization i
 									<string>The type of the tile expressed as a number.</string>
 									<key>pfm_description_reference</key>
 									<string>Required. The type of the tile expressed as a number. 3 = directory, 0 = URL, 1 = file.</string>
-									<key>pfm_required</key>
+									<key>pfm_require</key>
 									<string>always</string>
 									<key>pfm_name</key>
 									<string>file-type</string>
@@ -364,7 +364,7 @@ The payload organization for a payload need not match the payload organization i
 							<string>The type of the tile. Values may be file-tile, directory-tile, or url-tile. If you are unsure whether the file item is a file or a directory, set this key to file-tile.</string>
 							<key>pfm_description_reference</key>
 							<string>Required. The type of the tile. Values may be file-tile, directory-tile, or url-tile. If you are unsure whether the file item is a file or a directory, set this key to file-tile.</string>
-							<key>pfm_required</key>
+							<key>pfm_require</key>
 							<string>always</string>
 							<key>pfm_default</key>
 							<string>file-tile</string>
@@ -403,7 +403,7 @@ The payload organization for a payload need not match the payload organization i
 									<string>Label of a dock item.</string>
 									<key>pfm_description_reference</key>
 									<string>Required. Label of a dock item.</string>
-									<key>pfm_required</key>
+									<key>pfm_require</key>
 									<string>always</string>
 									<key>pfm_name</key>
 									<string>label</string>
@@ -453,7 +453,7 @@ The payload organization for a payload need not match the payload organization i
 									<string>The type of the tile expressed as a number.</string>
 									<key>pfm_description_reference</key>
 									<string>Required. The type of the tile expressed as a number. 3 = directory, 0 = URL, 1 = file.</string>
-									<key>pfm_required</key>
+									<key>pfm_require</key>
 									<string>always</string>
 									<key>pfm_name</key>
 									<string>file-type</string>

--- a/Manifests/ManifestsApple/com.apple.profileRemovalPassword.plist
+++ b/Manifests/ManifestsApple/com.apple.profileRemovalPassword.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-06-11T07:41:38Z</date>
+	<date>2021-09-27T09:00:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -119,7 +119,7 @@
 			<string>The password for profile removal.</string>
 			<key>pfm_name</key>
 			<string>RemovalPassword</string>
-			<key>pfm_required</key>
+			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_sensitive</key>
 			<true/>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-08-10T10:42:06Z</date>
+	<date>2021-10-06T09:34:46Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -123,7 +123,7 @@
 			<key>pfm_default</key>
 			<string>BuiltIn</string>
 			<key>pfm_description_reference</key>
-			<string>The type of filter, built-in or plug-in.</string>
+			<string>The type of filter, built-in or plug-in. Built-in filtering is available on iOS only.</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>BuiltIn</string>
@@ -131,7 +131,7 @@
 			</array>
 			<key>pfm_range_list_titles</key>
 			<array>
-				<string>Built-In</string>
+				<string>Built-In (iOS only)</string>
 				<string>Plug-In</string>
 			</array>
 			<key>pfm_name</key>


### PR DESCRIPTION
This PR contains two housekeeping items:
* `pfm_required` keys changed to`pfm_require` (no trailing 'd') on preference keys where the associated value was appropriate for the latter
* Clarified lack of support for built-in filtering in the Web Content Filter manifest on macOS

