### PR TITLE
No need to make com.apple.dock "static-only" pref key an inverted value

### DIFF
--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-09-27T09:00:30Z</date>
+	<date>2021-10-2T21:15:06Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -1141,8 +1141,6 @@ The payload organization for a payload need not match the payload organization i
 			<string>Remove non-static apps and documents from Dock</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-			<key>pfm_value_inverted</key>
-			<true/>
 		</dict>
 		<dict>
 			<key>pfm_default</key>


### PR DESCRIPTION
Verbiage is clear that if set to true the dock will be set to the static apps/docs and if set to false the static apps/docs will merge with the user's current dock icons. The inverted value currently causes confusion and unexpected behavior when you create the profile.