### PR TITLE
DigiDNA Web Content Filter further work

### DIFF
--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -219,6 +219,11 @@ The search algorithm is complex and may vary from release to release, but it is 
 							<key>pfm_target</key>
 							<string>FilterType</string>
 						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
 						<dict>
 							<key>pfm_n_range_list</key>
 							<array>
@@ -229,7 +234,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 						</dict>
 					</array>
 				</dict>
-			</array>			
+			</array>
 			<key>pfm_name</key>
 			<string>PermittedURLs</string>
 			<key>pfm_subkeys</key>
@@ -292,10 +297,15 @@ The search algorithm is complex and may vary from release to release, but it is 
 							<key>pfm_target</key>
 							<string>FilterType</string>
 						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
 						<dict>
-							<key>pfm_n_range_list</key>
+							<key>pfm_range_list</key>
 							<array>
-								<false/>
+								<true/>
 							</array>
 							<key>pfm_target</key>
 							<string>AutoFilterEnabled</string>
@@ -372,10 +382,15 @@ The search algorithm is complex and may vary from release to release, but it is 
 							<key>pfm_target</key>
 							<string>FilterType</string>
 						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
 						<dict>
-							<key>pfm_n_range_list</key>
+							<key>pfm_range_list</key>
 							<array>
-								<false/>
+								<true/>
 							</array>
 							<key>pfm_target</key>
 							<string>AutoFilterEnabled</string>
@@ -454,8 +469,13 @@ The search algorithm is complex and may vary from release to release, but it is 
 							<key>pfm_target</key>
 							<string>FilterType</string>
 						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
 						<dict>
-							<key>pfm_n_range_list</key>
+							<key>pfm_range_list</key>
 							<array>
 								<true/>
 							</array>
@@ -505,8 +525,13 @@ The search algorithm is complex and may vary from release to release, but it is 
 							<key>pfm_target</key>
 							<string>FilterType</string>
 						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
 						<dict>
-							<key>pfm_n_range_list</key>
+							<key>pfm_range_list</key>
 							<array>
 								<true/>
 							</array>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-10-06T09:34:46Z</date>
+	<date>2021-11-10T13:36:01Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -756,7 +756,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description_reference</key>
 			<string>If true, enables the filtering of socket traffic.</string>
 			<key>pfm_exclude</key>
@@ -910,7 +910,7 @@ Available in macOS 10.15 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -192,8 +192,6 @@
 			</array>
 			<key>pfm_name</key>
 			<string>AutoFilterEnabled</string>
-			<key>pfm_note</key>
-			<string>The official documentation as of writing shows the default value of this property to be 'true', however in user reports and in further testing it was found to be the opposite case.</string>
 			<key>pfm_title</key>
 			<string>Limit adult content automatically</string>
 			<key>pfm_description</key>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-11-10T13:36:01Z</date>
+	<date>2021-11-10T16:45:51Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-11-10T16:45:51Z</date>
+	<date>2021-11-11T15:23:11Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -801,7 +801,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<key>pfm_name</key>
 			<string>FilterSockets</string>
 			<key>pfm_note</key>
-			<string>Either FilterPackets or FilterSockets must be true for the filter to have any effect.</string>
+			<string>Either FilterPackets or FilterSockets must be true for the filter to have any effect. The official documentation as of writing shows the default value of this property to be 'true', however in user reports and in further testing it was found to be the opposite case.</string>
 			<key>pfm_title</key>
 			<string>Enable Socket Filtering</string>
 			<key>pfm_type</key>
@@ -965,7 +965,7 @@ Available in macOS 10.15 and later.</string>
 			<key>pfm_name</key>
 			<string>FilterPackets</string>
 			<key>pfm_note</key>
-			<string>Either FilterPackets or FilterSockets must be true for the filter to have any effect.</string>
+			<string>Either FilterPackets or FilterSockets must be true for the filter to have any effect. The official documentation as of writing shows the default value of this property to be 'true', however in user reports and in further testing it was found to be the opposite case.</string>
 			<key>pfm_platforms</key>
 			<array>
 				<string>macOS</string>


### PR DESCRIPTION
This PR contains an additional number of important changes to the Web Content Filter manifest:
* Conditionals were changed from an AND relationship to an OR one due to co-dependency on `FilterType` which may lead to race conditions on evaluation.
* Incorrect conditional tests on the new _allow_ and _deny_ list keys are now fixed.
* Similarly to #435, in contrast to the official documentation the default values of both the `FilterSockets` and the `FilterPackets` properties are in fact `false`. This was reported by iMazing Profile Editor users and confirmed through testing. This PR modifies the default values to prevent admins from creating uninstallable profiles. Notes were added accordingly and feedback was submitted to Apple (FB9077169).
* A note added as part of #435 was removed since a recent documentation update made it no longer necessary.