### PR TITLE
Adjust XML comment escaping for Nudge plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
@@ -15,7 +15,7 @@
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_last_modified</key>
-	<date>2021-02-22T06:55:52Z</date>
+	<date>2021-11-29T03:13:03Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
@@ -170,7 +170,7 @@
 			<key>pfm_description</key>
 			<string>When a major upgrade is required, Nudge will attempt to download it through the softwareupdate binary.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#attempttofetchmajorupgrade---type-boolean-default-value-false-required-no</string>
+			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#attempttofetchmajorupgrade\-\-\-type-boolean-default-value-false-required-no</string>
 			<key>pfm_name</key>
 			<string>attemptToFetchMajorUpgrade</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
@@ -170,7 +170,7 @@
 			<key>pfm_description</key>
 			<string>When a major upgrade is required, Nudge will attempt to download it through the softwareupdate binary.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#attempttofetchmajorupgrade\-\-\-type-boolean-default-value-false-required-no</string>
+			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#attempttofetchmajorupgrade&#45;&#45;&#45;type-boolean-default-value-false-required-no</string>
 			<key>pfm_name</key>
 			<string>attemptToFetchMajorUpgrade</string>
 			<key>pfm_title</key>
@@ -186,7 +186,7 @@
 			<key>pfm_description</key>
 			<string>When enabled Nudge will wait for Software Update to finish downloading (if any) updates before showing the UI.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#asyncronoussoftwareupdate\-\-\-type-boolean-default-value-true-required-no</string>
+			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#asyncronoussoftwareupdate&#45;&#45;&#45;type-boolean-default-value-true-required-no</string>
 			<key>pfm_macos_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -204,7 +204,7 @@
 			<key>pfm_description</key>
 			<string>When enabled, Nudge will enforce minor updates. This should likely never be disabled.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#enforceminorupdates\-\-\-type-boolean-default-value-true-required-no</string>
+			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#enforceminorupdates&#45;&#45;&#45;type-boolean-default-value-true-required-no</string>
 			<key>pfm_macos_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -223,7 +223,7 @@
 
 Specify one array to enforce a single Operating System version across all machines or specify multiple arrays for specific enforcements.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#osversionrequirements\-\-\-type-array-default-value-</string>
+			<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#osversionrequirements&#45;&#45;&#45;type-array-default-value-</string>
 			<key>pfm_macos_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -241,7 +241,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>A list of arrays, enabling localization of the More Info button URL path. Please see the aboutUpdateURLs wiki article for more information.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#aboutupdateurls\-\-\-type-array-default-value--required-no</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#aboutupdateurls&#45;&#45;&#45;type-array-default-value--required-no</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -287,7 +287,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The app path for a major upgrade.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#majorupgradeapppath\-\-\-type-string-default-value--required-no</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#majorupgradeapppath&#45;&#45;&#45;type-string-default-value--required-no</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -305,7 +305,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The required installation date for Nudge to enforce the required operating system version.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredinstallationdate\-\-\-type-string-default-value--required-yes</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredinstallationdate&#45;&#45;&#45;type-string-default-value--required-yes</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -321,7 +321,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The required minimum operating system version. </string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredminimumosversion\-\-\-type-string-default-value--required-yes</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredminimumosversion&#45;&#45;&#45;type-string-default-value--required-yes</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -339,7 +339,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The versions of macOS that require a security update. You can specify single version or multiple versions.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#targetedosversions\-\-\-type-array-default-value-</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#targetedosversions&#45;&#45;&#45;type-array-default-value-</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -386,7 +386,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>This will disable ALL functionality related to the User Experience preference domain.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#notimers\-\-\-type-boolean-default-value-false</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#notimers&#45;&#45;&#45;type-boolean-default-value-false</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -404,7 +404,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of times a user can defer Nudge (change it from the currently active window) in the current user session before the "aggressive user experience" is enabled.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferrals\-\-\-type-integer-default-value-1000000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferrals&#45;&#45;&#45;type-integer-default-value-1000000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -426,7 +426,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of times a user can defer Nudge (change it from the currently active window) in the current user session before the both quit buttons need to be actioned.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferralsuntilforcedsecondaryquitbutton\-\-\-type-integer-default-value-14</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferralsuntilforcedsecondaryquitbutton&#45;&#45;&#45;type-integer-default-value-14</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -448,7 +448,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingrefreshcycle\-\-\-type-integer-default-value-6000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingrefreshcycle&#45;&#45;&#45;type-integer-default-value-6000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -470,7 +470,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in hours Nudge will use to determine that the requiredInstallationDate is "approaching".</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingwindowtime\-\-\-type-integer-default-value-72</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingwindowtime&#45;&#45;&#45;type-integer-default-value-72</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -492,7 +492,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window. This key is triggered once the requiredInstallationDate has expired.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#elapsedrefreshcycle\-\-\-type-integer-default-value-6000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#elapsedrefreshcycle&#45;&#45;&#45;type-integer-default-value-6000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -512,7 +512,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentrefeshcycle\-\-\-type-integer-default-value-600</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentrefeshcycle&#45;&#45;&#45;type-integer-default-value-600</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -532,7 +532,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in hours Nudge will use to determine that the requiredInstallationDate is "imminent".</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentwindowtime\-\-\-type-integer-default-value-24</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentwindowtime&#45;&#45;&#45;type-integer-default-value-24</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -552,7 +552,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window. This key is triggered for all Nudge launches until the approachingWindowTime has been passed.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#initialrefreshcycle\-\-\-type-integer-default-value-18000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#initialrefreshcycle&#45;&#45;&#45;type-integer-default-value-18000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -572,7 +572,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The maximum amount of delay Nudge will utilize before launching the UI. This is useful if you do not want your users to all receive the Nudge prompt at the exact time of the LaunchAgent.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#maxrandomdelayinseconds\-\-\-type-integer-default-value-1200</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#maxrandomdelayinseconds&#45;&#45;&#45;type-integer-default-value-1200</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -610,7 +610,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as its core timer to refresh all the core code paths.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle\-\-\-type-integer-default-value-60</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle&#45;&#45;&#45;type-integer-default-value-60</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -648,7 +648,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>Enables an initial delay Nudge before launching the UI. This is useful if you do not want your users to all receive the Nudge prompt at the exact time of the LaunchAgent.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle\-\-\-type-integer-default-value-60</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle&#45;&#45;&#45;type-integer-default-value-60</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -682,7 +682,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>Enables Nudge to launch in the simplified user experience.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#simplemode\-\-\-type-boolean-default-value-false</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#simplemode&#45;&#45;&#45;type-boolean-default-value-false</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -700,7 +700,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>Force the built-in ScreenShot icon to render in the UI if a ScreenShot path is not passed.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#forcescreenshoticon\-\-\-type-boolean-default-value-false</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#forcescreenshoticon&#45;&#45;&#45;type-boolean-default-value-false</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -716,7 +716,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the icon for dark mode. This will replace the Apple logo on the left side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#icondarkpath\-\-\-type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#icondarkpath&#45;&#45;&#45;type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -734,7 +734,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the icon for light mode. This will replace the Apple logo on the left side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#iconlightpath\-\-\-type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#iconlightpath&#45;&#45;&#45;type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -752,7 +752,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the screen shot for dark mode. This will replace the Big Sur logo on the lower right side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotdarkpath\-\-\-type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotdarkpath&#45;&#45;&#45;type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -770,7 +770,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the screen shot for light mode. This will replace the Big Sur logo on the lower right side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotlightpath\-\-\-type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotlightpath&#45;&#45;&#45;type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -806,7 +806,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>The targeted language locale for the user interface.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#_language\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#_language&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -824,7 +824,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the informationButton, also known as the 'More Info' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#informationbuttontext\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#informationbuttontext&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -840,7 +840,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentHeader. This is the 'Your device will restart during this update' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentheader\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentheader&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -856,7 +856,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentSubHeader. This is the 'Updates can take around 30 minutes to complete' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentsubheader\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentsubheader&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -872,7 +872,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentText. This is the 'A fully up-to-date device is required to ensure that IT can your accurately protect your device.\n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks.\n\nTo begin the update, simply click on the button below and follow the provided steps.' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontenttext\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontenttext&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -890,7 +890,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentNote. This is the 'Important Notes' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentnote\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentnote&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -906,7 +906,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainHeader. This is the 'Your device requires a security update' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#mainheader\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#mainheader&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -922,7 +922,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the actionButton, also known as the 'Update Device' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#actionbuttontext\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#actionbuttontext&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -938,7 +938,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the primaryQuitButton, also known as the 'Later' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#primaryquitbuttontext\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#primaryquitbuttontext&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -954,7 +954,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the secondaryQuitButton, also known as the 'I understand' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#secondaryquitbuttontext\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#secondaryquitbuttontext&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -970,7 +970,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the subHeader. This is the 'A friendly reminder from your local IT team' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#subheader\-\-\-type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#subheader&#45;&#45;&#45;type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
@@ -186,7 +186,7 @@
 			<key>pfm_description</key>
 			<string>When enabled Nudge will wait for Software Update to finish downloading (if any) updates before showing the UI.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#asyncronoussoftwareupdate---type-boolean-default-value-true-required-no</string>
+			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#asyncronoussoftwareupdate\-\-\-type-boolean-default-value-true-required-no</string>
 			<key>pfm_macos_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -204,7 +204,7 @@
 			<key>pfm_description</key>
 			<string>When enabled, Nudge will enforce minor updates. This should likely never be disabled.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#enforceminorupdates---type-boolean-default-value-true-required-no</string>
+			<string>https://github.com/macadmins/nudge/wiki/optionalFeatures#enforceminorupdates\-\-\-type-boolean-default-value-true-required-no</string>
 			<key>pfm_macos_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -223,7 +223,7 @@
 
 Specify one array to enforce a single Operating System version across all machines or specify multiple arrays for specific enforcements.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#osversionrequirements---type-array-default-value-</string>
+			<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#osversionrequirements\-\-\-type-array-default-value-</string>
 			<key>pfm_macos_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -241,7 +241,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>A list of arrays, enabling localization of the More Info button URL path. Please see the aboutUpdateURLs wiki article for more information.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#aboutupdateurls---type-array-default-value--required-no</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#aboutupdateurls\-\-\-type-array-default-value--required-no</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -287,7 +287,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The app path for a major upgrade.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#majorupgradeapppath---type-string-default-value--required-no</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#majorupgradeapppath\-\-\-type-string-default-value--required-no</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -305,7 +305,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The required installation date for Nudge to enforce the required operating system version.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredinstallationdate---type-string-default-value--required-yes</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredinstallationdate\-\-\-type-string-default-value--required-yes</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -321,7 +321,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The required minimum operating system version. </string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredminimumosversion---type-string-default-value--required-yes</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#requiredminimumosversion\-\-\-type-string-default-value--required-yes</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -339,7 +339,7 @@ Specify one array to enforce a single Operating System version across all machin
 							<key>pfm_description</key>
 							<string>The versions of macOS that require a security update. You can specify single version or multiple versions.</string>
 							<key>pfm_documentation_url</key>
-							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#targetedosversions---type-array-default-value-</string>
+							<string>https://github.com/macadmins/nudge/wiki/osVersionRequirements#targetedosversions\-\-\-type-array-default-value-</string>
 							<key>pfm_macos_min</key>
 							<string>11.0</string>
 							<key>pfm_name</key>
@@ -386,7 +386,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>This will disable ALL functionality related to the User Experience preference domain.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#notimers---type-boolean-default-value-false</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#notimers\-\-\-type-boolean-default-value-false</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -404,7 +404,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of times a user can defer Nudge (change it from the currently active window) in the current user session before the "aggressive user experience" is enabled.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferrals---type-integer-default-value-1000000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferrals\-\-\-type-integer-default-value-1000000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -426,7 +426,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of times a user can defer Nudge (change it from the currently active window) in the current user session before the both quit buttons need to be actioned.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferralsuntilforcedsecondaryquitbutton---type-integer-default-value-14</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#alloweddeferralsuntilforcedsecondaryquitbutton\-\-\-type-integer-default-value-14</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -448,7 +448,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingrefreshcycle---type-integer-default-value-6000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingrefreshcycle\-\-\-type-integer-default-value-6000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -470,7 +470,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in hours Nudge will use to determine that the requiredInstallationDate is "approaching".</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingwindowtime---type-integer-default-value-72</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#approachingwindowtime\-\-\-type-integer-default-value-72</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -492,7 +492,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window. This key is triggered once the requiredInstallationDate has expired.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#elapsedrefreshcycle---type-integer-default-value-6000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#elapsedrefreshcycle\-\-\-type-integer-default-value-6000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -512,7 +512,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentrefeshcycle---type-integer-default-value-600</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentrefeshcycle\-\-\-type-integer-default-value-600</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -532,7 +532,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in hours Nudge will use to determine that the requiredInstallationDate is "imminent".</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentwindowtime---type-integer-default-value-24</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#imminentwindowtime\-\-\-type-integer-default-value-24</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -552,7 +552,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as a timer to refresh the user interface if it is not the currently active window. This key is triggered for all Nudge launches until the approachingWindowTime has been passed.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#initialrefreshcycle---type-integer-default-value-18000</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#initialrefreshcycle\-\-\-type-integer-default-value-18000</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -572,7 +572,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The maximum amount of delay Nudge will utilize before launching the UI. This is useful if you do not want your users to all receive the Nudge prompt at the exact time of the LaunchAgent.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#maxrandomdelayinseconds---type-integer-default-value-1200</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#maxrandomdelayinseconds\-\-\-type-integer-default-value-1200</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -610,7 +610,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>The amount of time in seconds Nudge will use as its core timer to refresh all the core code paths.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle---type-integer-default-value-60</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle\-\-\-type-integer-default-value-60</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -648,7 +648,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>Enables an initial delay Nudge before launching the UI. This is useful if you do not want your users to all receive the Nudge prompt at the exact time of the LaunchAgent.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle---type-integer-default-value-60</string>
+					<string>https://github.com/macadmins/nudge/wiki/userExperience#nudgerefreshcycle\-\-\-type-integer-default-value-60</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -682,7 +682,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>Enables Nudge to launch in the simplified user experience.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#simplemode---type-boolean-default-value-false</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#simplemode\-\-\-type-boolean-default-value-false</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -700,7 +700,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>Force the built-in ScreenShot icon to render in the UI if a ScreenShot path is not passed.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#forcescreenshoticon---type-boolean-default-value-false</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#forcescreenshoticon\-\-\-type-boolean-default-value-false</string>
 					<key>pfm_macos_min</key>
 					<string>11.0</string>
 					<key>pfm_name</key>
@@ -716,7 +716,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the icon for dark mode. This will replace the Apple logo on the left side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#icondarkpath---type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#icondarkpath\-\-\-type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -734,7 +734,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the icon for light mode. This will replace the Apple logo on the left side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#iconlightpath---type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#iconlightpath\-\-\-type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -752,7 +752,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the screen shot for dark mode. This will replace the Big Sur logo on the lower right side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotdarkpath---type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotdarkpath\-\-\-type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -770,7 +770,7 @@ Specify one array to enforce a single Operating System version across all machin
 					<key>pfm_description</key>
 					<string>A path to a local jpg, png, icns that contains the screen shot for light mode. This will replace the Big Sur logo on the lower right side of Nudge.</string>
 					<key>pfm_documentation_url</key>
-					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotlightpath---type-string-default-value-</string>
+					<string>https://github.com/macadmins/nudge/wiki/userInterface#screenshotlightpath\-\-\-type-string-default-value-</string>
 					<key>pfm_format</key>
 					<string>^.*\.(icns|jpg|png)</string>
 					<key>pfm_macos_min</key>
@@ -806,7 +806,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>The targeted language locale for the user interface.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#_language---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#_language\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -824,7 +824,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the informationButton, also known as the 'More Info' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#informationbuttontext---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#informationbuttontext\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -840,7 +840,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentHeader. This is the 'Your device will restart during this update' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentheader---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentheader\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -856,7 +856,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentSubHeader. This is the 'Updates can take around 30 minutes to complete' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentsubheader---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentsubheader\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -872,7 +872,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentText. This is the 'A fully up-to-date device is required to ensure that IT can your accurately protect your device.\n\nIf you do not update your device, you may lose access to some items necessary for your day-to-day tasks.\n\nTo begin the update, simply click on the button below and follow the provided steps.' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontenttext---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontenttext\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -890,7 +890,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainContentNote. This is the 'Important Notes' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentnote---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#maincontentnote\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -906,7 +906,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the mainHeader. This is the 'Your device requires a security update' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#mainheader---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#mainheader\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -922,7 +922,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the actionButton, also known as the 'Update Device' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#actionbuttontext---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#actionbuttontext\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -938,7 +938,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the primaryQuitButton, also known as the 'Later' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#primaryquitbuttontext---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#primaryquitbuttontext\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -954,7 +954,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the secondaryQuitButton, also known as the 'I understand' button.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#secondaryquitbuttontext---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#secondaryquitbuttontext\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>
@@ -970,7 +970,7 @@ Specify one array to enforce a single Operating System version across all machin
 									<key>pfm_description</key>
 									<string>Modifies the subHeader. This is the 'A friendly reminder from your local IT team' text.</string>
 									<key>pfm_documentation_url</key>
-									<string>https://github.com/macadmins/nudge/wiki/updateElements#subheader---type-string-default-value-</string>
+									<string>https://github.com/macadmins/nudge/wiki/updateElements#subheader\-\-\-type-string-default-value-</string>
 									<key>pfm_macos_min</key>
 									<string>11.0</string>
 									<key>pfm_name</key>


### PR DESCRIPTION
The link to the Nudge wiki in the commented-out `attemptToFetchMajorUpgrade` setting is preventing the plist from being parsed by Python's `plistlib`. This is probably because the `---` in the URL is being parsed as the end of a comment.

Adding backslashes to escape the hyphens successfully allows the plist to be parsed, while still allowing the URL to be usable without manual changes.

Another alternative would be to encode the hyphens as `&#45;&#45;&#45;` but I thought the backslashes would be more readable.