### PR TITLE
Move orphaned pfm_title key into parent object

### DIFF
--- a/Manifests/ManifestsApple/com.apple.familycontrols.timelimits.v2.plist
+++ b/Manifests/ManifestsApple/com.apple.familycontrols.timelimits.v2.plist
@@ -226,9 +226,9 @@
 							<key>pfm_type</key>
 							<string>integer</string>
 						</dict>
-						<string>pfm_title</string>
-						<string>Weekday Allowance</string>
 					</array>
+					<key>pfm_title</key>
+					<string>Weekday Allowance</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>
 				</dict>


### PR DESCRIPTION
This matches the syntax of `Weekday Allowance` with the syntax of `Weekend Allowance` and  `Weekday Curfew`.