### PR TITLE
Adjustments to com.apple.finder, including addition of ShowRecentTags

### DIFF
--- a/Manifests/ManifestsApple/com.apple.finder.plist
+++ b/Manifests/ManifestsApple/com.apple.finder.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-05-03T15:38:44Z</date>
+	<date>2021-12-06T04:01:34Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -313,6 +313,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.finder.plist
+++ b/Manifests/ManifestsApple/com.apple.finder.plist
@@ -117,6 +117,8 @@
 			<string>Full</string>
 			<key>pfm_description</key>
 			<string>Select if the standard (Full) or Simple Finder should be used</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.3</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.finder.plist
+++ b/Manifests/ManifestsApple/com.apple.finder.plist
@@ -136,6 +136,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>Warning message requiring user approval before emptying the Trash</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>WarnOnEmptyTrash</string>
 			<key>pfm_title</key>
@@ -148,6 +150,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Opens a dialog box for finding servers on the network</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ProhibitConnectTo</string>
 			<key>pfm_title</key>
@@ -162,6 +166,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Ejects removable media and mountable volumes</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ProhibitEject</string>
 			<key>pfm_title</key>
@@ -197,6 +203,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Writes permanent information to a CD or DVD. Disc burning restrictions require both Disc Burning and Finder payloads.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ProhibitBurn</string>
 			<key>pfm_title</key>
@@ -211,6 +219,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Allows user to open files or folders by typing a pathname</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ProhibitGoToFolder</string>
 			<key>pfm_title</key>
@@ -225,6 +235,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Show hard disks on the desktop</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ShowHardDrivesOnDesktop</string>
 			<key>pfm_title</key>
@@ -237,6 +249,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>Show external disks on the desktop</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ShowExternalHardDrivesOnDesktop</string>
 			<key>pfm_title</key>
@@ -249,6 +263,8 @@
 			<true/>
 			<key>pfm_description</key>
 			<string>Show removable media on the desktop</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ShowRemovableMediaOnDesktop</string>
 			<key>pfm_title</key>
@@ -261,6 +277,8 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>Show connected servers on the desktop</string>
+			<key>pfm_documentation_url</key>
+			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
 			<string>ShowMountedServersOnDesktop</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.finder.plist
+++ b/Manifests/ManifestsApple/com.apple.finder.plist
@@ -268,6 +268,20 @@
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Show the Recent Tags section in the Finder sidebar</string>
+			<key>pfm_documentation_url</key>
+			<string>https://derflounder.wordpress.com/2021/11/29/disabling-recent-tags-in-the-finder-window-sidebar/</string>
+			<key>pfm_name</key>
+			<string>ShowRecentTags</string>
+			<key>pfm_title</key>
+			<string>Show Recent Tags</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>


### PR DESCRIPTION
As discussed here: https://derflounder.wordpress.com/2021/11/29/disabling-recent-tags-in-the-finder-window-sidebar/ 