### PR TITLE
Automatically rebuild downstream profilecreator-schemas repository

### DIFF
--- a/.github/workflows/profilecreator-schemas.yml
+++ b/.github/workflows/profilecreator-schemas.yml
@@ -1,0 +1,19 @@
+name: Trigger profilecreator-schemas rebuild
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST to profilecreator-schemas rebuild workflow
+        run: |
+          curl -XPOST -u "${{secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Content-Type: application/json" \
+          --url "https://api.github.com/repos/Jamf-Custom-Profile-Schemas/profilecreator-schemas/actions/workflows/build.yml/dispatches" \
+          --data '{"ref": "main"}'


### PR DESCRIPTION
I've been working on a repository that automatically converts the contents of ProfileManifests into a JSON format that can be used for [Jamf's custom schemas for app management](https://www.youtube.com/watch?v=3ZdFzWBTkjg).

At the moment, rebuilds in my mirror repository are triggered by pushes to that repository. However, the most useful trigger would be when changes are merged into _this_ repository's default branch. This PR includes a GitHub Actions build file that will submit the necessary POST request to kick that off.

If you approve, there is something you'll need to do prior to merging this in: generating a new GitHub personal access token (PAT) with `public_repo` access and creating a new secret in the ProfileManifests repository to store it.

1. [Click here](https://github.com/settings/tokens/new) to generate a new GitHub PAT. Giving it a unique name like `profilecreator-schemas workflow trigger` or something like that is a good idea. Set expiration date to never.
2. Copy the resulting token.
3. [Click here](https://github.com/ProfileCreator/ProfileManifests/settings/secrets/actions) to go to the ProfileManifests settings for secrets.
4. Add a new secret called `PAT_USERNAME` with your GitHub username.
5. Add a new secret called `PAT_TOKEN` with the token you copied.
6. Now merge the PR and watch [the repo's actions](https://github.com/ProfileCreator/ProfileManifests/actions) to ensure the build occurred successfully. You can also watch [my repo's actions](https://github.com/Jamf-Custom-Profile-Schemas/profilecreator-schemas/actions) to verify the rebuild was triggered.

Thanks for considering!