### PR TITLE
Slack: added Default Workspace key

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-08-25T23:24:00Z</date>
+	<date>2021-12-07T17:35:44Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -121,13 +121,29 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>When true, disables Slack's built-in automatic update mechanism. Useful if you update Slack using a tool like Munki.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://rickheil.com/disabling-slack-updates-in-v4-0/</string>
+			<string>https://slack.com/help/articles/360035635174-Deploy-Slack-for-macOS</string>
 			<key>pfm_name</key>
 			<string>SlackNoAutoUpdates</string>
 			<key>pfm_title</key>
 			<string>Disable Automatic Updates</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>4.23</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Sets the default workspace for Slack sign-ins.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://slack.com/help/articles/360041725993-Share-a-default-sign-in-file-with-members</string>
+			<key>pfm_name</key>
+			<string>SlackDefaultSignInWorkspace</string>
+			<key>pfm_title</key>
+			<string>Default Workspace</string>
+			<key>pfm_type</key>
+			<string>string</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>
@@ -140,6 +156,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Thanks to @MarshallOfSound for getting this functionality added after a request on the MacAdmins Slack.