### PR TITLE
Remove default value for SlackDefaultSignInWorkspace

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-07T17:35:44Z</date>
+	<date>2021-12-15T17:17:24Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -132,8 +132,6 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_app_min</key>
 			<string>4.23</string>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
 			<string>Sets the default workspace for Slack sign-ins.</string>
 			<key>pfm_documentation_url</key>


### PR DESCRIPTION
There is no default value for this setting, as it varies per organization.