### PR TITLE
DigiDNA limit automation to upstream ProfileManifests only

### DIFF
--- a/.github/workflows/ProfileManifestsMirror.yml
+++ b/.github/workflows/ProfileManifestsMirror.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'ProfileCreator/ProfileManifests'
     runs-on: ubuntu-latest
     steps:
       - name: POST to ProfileManifestsMirror rebuild workflow

--- a/.github/workflows/updateIndexes.yml
+++ b/.github/workflows/updateIndexes.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'ProfileCreator/ProfileManifests'
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository


### PR DESCRIPTION
This PR limits the new automations to work on this, the `ProfileCreator/ProfileManifests` repository, only.

Leaving the current automations to run on forked repositories leads to undesirable commits when synchronizing the `master` branch and therefore to loss of synchronizability. It also leads to unnecessary calls to rebuild the Jamf Schema repository (albeit these are assumed harmless since the fork does not have the access credentials).