### PR TITLE
DigiDNA Python correction

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.python.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.python.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-11-27T08:58:48Z</date>
+	<date>2021-12-13T12:09:45Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -123,7 +123,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Controls whether warnings are shown to the user when an app or process calls the macOS-bundled Python2 interpreter. This interpreter has been deprecated and will be removed in a future version of macOS.</string>
 			<key>pfm_description_reference</key>
@@ -131,7 +131,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>DisablePythonAlert</string>
 			<key>pfm_title</key>
-			<string>Disable Python Alert</string>
+			<string>Disable Python Deprecation Alert</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>


### PR DESCRIPTION
This PR corrects a key's default value in the bundled Python manifest. As a bonus, it also expands the same key's title for when the description is not displayed.