### PR TITLE
Fix plist syntax error in menu.nomad.actions

### DIFF
--- a/Resources/ManifestsToConvert/menu.nomad.actions.plist
+++ b/Resources/ManifestsToConvert/menu.nomad.actions.plist
@@ -8,10 +8,10 @@
 		<string>NoMAD Actions</string>
 		<key>pfm_format_version</key>
 		<integer>1</integer>
-		<key>pfm_last_modified</string>
-		<date>2021-12-08T03:02:13Z</date>
+		<key>pfm_last_modified</key>
+		<date>2021-12-18T18:04:57Z</date>
 		<key>pfm_version</key>
-		<integer>1</integer>
+		<integer>2</integer>
 		<key>pfm_icon</key>
 		<data></data>
 		<key>pfm_domain</key>
@@ -24,9 +24,9 @@
 		<string>https://nomad.menu/help-center/preferences-and-what-they-do/</string>
 		<key>pfm_subkeys</key>
 		<array>
-		
+
 			<!-- Default Payload Keys -->
-		
+
 			<dict>
 				<key>pfm_name</key>
 				<string>PayloadDescription</string>
@@ -121,9 +121,9 @@
 				<key>pfm_type</key>
 				<string>string</string>
 			</dict>
-		
+
 			<!-- Custom Payload Keys -->
-		
+
 			<dict>
 				<key>pfm_name</key>
 				<string>Actions</string>


### PR DESCRIPTION
Key tag was `<key>pfm_last_modified</string>` but should be `<key>pfm_last_modified</key>`