### PR TITLE
Set all `pfm_format_version` to `<integer>1</integer>`

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -11,7 +11,7 @@
 	<key>pfm_domain</key>
 	<string>com.apple.Safari.SandboxBroker</string>
 	<key>pfm_format_version</key>
-	<integer>4</integer>
+	<integer>1</integer>
 	<key>pfm_last_modified</key>
 	<date>2020-11-25T12:08:06Z</date>
 	<key>pfm_macos_min</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-11-25T12:08:06Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
@@ -7,7 +7,7 @@
 	<key>pfm_domain</key>
 	<string>com.apple.print.add</string>
 	<key>pfm_format_version</key>
-	<integer>3</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-02-01T09:50:53Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -11,7 +11,7 @@
 	<key>pfm_domain</key>
 	<string>com.apple.Safari</string>
 	<key>pfm_format_version</key>
-	<integer>4</integer>
+	<integer>1</integer>
 	<key>pfm_last_modified</key>
 	<date>2021-07-22T04:05:13Z</date>
 	<key>pfm_platforms</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-07-22T04:05:13Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -11,7 +11,7 @@
 	<key>pfm_domain</key>
 	<string>com.brave.Browser</string>
 	<key>pfm_format_version</key>
-	<integer>3</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-06-08T10:15:16Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.github.ants-framework.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.ants-framework.plist
@@ -11,7 +11,7 @@
 	<key>pfm_domain</key>
 	<string>com.github.ants-framework</string>
 	<key>pfm_format_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 	<key>pfm_last_modified</key>
 	<date>2019-09-17T08:52:30Z</date>
 	<key>pfm_platforms</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.ants-framework.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.ants-framework.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:30Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -11,7 +11,7 @@
 	<key>pfm_domain</key>
 	<string>com.google.Chrome</string>
 	<key>pfm_format_version</key>
-	<integer>3</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-06-08T10:15:16Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -11,7 +11,7 @@
 	<key>pfm_domain</key>
 	<string>com.microsoft.Edge</string>
 	<key>pfm_format_version</key>
-	<integer>3</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-06-08T10:15:16Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
@@ -14,7 +14,7 @@ This payload allows controls the authentication UI during mobile account creatio
 	<key>pfm_documentation_url</key>
 	<string>https://developer.apple.com/documentation/devicemanagement/mobileaccounts</string>
 	<key>pfm_format_version</key>
-	<integer>5</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
@@ -18,7 +18,7 @@ This payload allows controls the authentication UI during mobile account creatio
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-01-14T16:51:12Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.MCX-TimeServer.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-TimeServer.plist
@@ -18,7 +18,7 @@ This payload allows devices to connect to custom time servers.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-12-09T17:40:13Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.MCX-TimeServer.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-TimeServer.plist
@@ -14,7 +14,7 @@ This payload allows devices to connect to custom time servers.</string>
 	<key>pfm_documentation_url</key>
 	<string>https://developer.apple.com/documentation/devicemanagement/timeserver</string>
 	<key>pfm_format_version</key>
-	<integer>5</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -11,7 +11,7 @@
 		<key>pfm_domain</key>
 		<string>com.apple.applicationaccess</string>
 		<key>pfm_format_version</key>
-		<integer>5</integer>
+		<integer>1</integer>
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2021-12-13T04:14:09Z</date>
+		<date>2021-12-18T19:55:17Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -13,7 +13,7 @@
 	<key>pfm_domain</key>
 	<string>com.apple.applicationaccess</string>
 	<key>pfm_format_version</key>
-	<integer>5</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-13T04:22:44Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>tvOS</string>

--- a/Manifests/ManifestsApple/com.apple.asam.plist
+++ b/Manifests/ManifestsApple/com.apple.asam.plist
@@ -15,7 +15,7 @@ To be granted access, applications must be signed with the specified bundle iden
 	<key>pfm_domain</key>
 	<string>com.apple.asam</string>
 	<key>pfm_format_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManifestsApple/com.apple.asam.plist
+++ b/Manifests/ManifestsApple/com.apple.asam.plist
@@ -19,7 +19,7 @@ To be granted access, applications must be signed with the specified bundle iden
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-26T08:51:12Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.4</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -11,7 +11,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_domain</key>
 	<string>com.apple.dock</string>
 	<key>pfm_format_version</key>
-	<integer>3</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-02T21:15:06Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.security.firewall.plist
+++ b/Manifests/ManifestsApple/com.apple.security.firewall.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-19T17:30:08Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.firewall.plist
+++ b/Manifests/ManifestsApple/com.apple.security.firewall.plist
@@ -7,7 +7,7 @@
 	<key>pfm_domain</key>
 	<string>com.apple.security.firewall</string>
 	<key>pfm_format_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>

--- a/Manifests/ManifestsApple/com.apple.syspolicy.kernel-extension-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.syspolicy.kernel-extension-policy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-04-16T10:34:28Z</date>
+	<date>2021-12-18T19:55:17Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.2</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.syspolicy.kernel-extension-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.syspolicy.kernel-extension-policy.plist
@@ -7,7 +7,7 @@
 	<key>pfm_domain</key>
 	<string>com.apple.syspolicy.kernel-extension-policy</string>
 	<key>pfm_format_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>


### PR DESCRIPTION
The [Manifest Format Versions](https://github.com/ProfileCreator/ProfileManifests/wiki/Manifest-Format-Versions) wiki page says:

> IMPORTANT
> These versions will be reset to 1 when the first non-beta release will be available. This is for testing the version system, and on release, the first version will include all keys available at that time.

This PR adjusts all instances of `pfm_format_version` to `<integer>1</integer>` to match that statement.

It's worth noting that the old [Apple preference manifest documentation](https://developer.apple.com/library/archive/documentation/MacOSXServer/Conceptual/Preference_Manifest_Files/Preface/Preface.html) defines this key (and other version keys) as `<real>1.0</real>`. I'm choosing to use integer to match conventions already in use in this repo.

I have not included updates to the `pfm_last_modified` or `pfm_version` but could add those if needed.