### PR TITLE
Replace instances of smart single and double quotes

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.apple.Enterprise-Connect.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.Enterprise-Connect.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-08-25T23:08:00Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.Enterprise-Connect.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.Enterprise-Connect.plist
@@ -122,9 +122,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The host name of your organization’s Active Directory domain.</string>
+			<string>The host name of your organization's Active Directory domain.</string>
 			<key>pfm_description_reference</key>
-			<string>The host name of your organization’s Active Directory domain. This is blank by default. Example - ad.pretendco.com</string>
+			<string>The host name of your organization's Active Directory domain. This is blank by default. Example - ad.pretendco.com</string>
 			<key>pfm_name</key>
 			<string>adRealm</string>
 			<key>pfm_title</key>
@@ -326,9 +326,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Automatically check the “Show Legacy Certificates” option in the certificate chooser window.</string>
+			<string>Automatically check the "Show Legacy Certificates" option in the certificate chooser window.</string>
 			<key>pfm_description_reference</key>
-			<string>This value, if set, tells Enterprise Connect PKI to automatically check the “Show Legacy Certificates” option in the certificate chooser window. The default value is false.</string>
+			<string>This value, if set, tells Enterprise Connect PKI to automatically check the "Show Legacy Certificates" option in the certificate chooser window. The default value is false.</string>
 			<key>pfm_name</key>
 			<string>checkShowLegacyCertificates</string>
 			<key>pfm_title</key>
@@ -340,9 +340,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Automatically check the “Show Legacy Certificates” option in the certificate chooser window.</string>
+			<string>Automatically check the "Show Legacy Certificates" option in the certificate chooser window.</string>
 			<key>pfm_description_reference</key>
-			<string>If enabled, identities in the user’s default keychain will be available to choose in the certificate chooser window. The default value is false.</string>
+			<string>If enabled, identities in the user's default keychain will be available to choose in the certificate chooser window. The default value is false.</string>
 			<key>pfm_name</key>
 			<string>showKeychainIdentities</string>
 			<key>pfm_title</key>
@@ -370,9 +370,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The path to a file containing your organization’s logo, in PNG, JPG or GIF format.</string>
+			<string>The path to a file containing your organization's logo, in PNG, JPG or GIF format.</string>
 			<key>pfm_description_reference</key>
-			<string>The path to a file containing your organization’s logo, in PNG, JPG or GIF format.</string>
+			<string>The path to a file containing your organization's logo, in PNG, JPG or GIF format.</string>
 			<key>pfm_name</key>
 			<string>orgLogoPath</string>
 			<key>pfm_title</key>
@@ -401,7 +401,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>Enables Active Directory to local account password sync. This only works if the user is logged into their Mac with a local account.</string>
 			<key>pfm_description_reference</key>
-			<string>Enables Active Directory to local account password sync. This only works if the user is logged into their Mac with a local account. Set to “true” to enable.</string>
+			<string>Enables Active Directory to local account password sync. This only works if the user is logged into their Mac with a local account. Set to "true" to enable.</string>
 			<key>pfm_name</key>
 			<string>syncLocalPassword</string>
 			<key>pfm_title</key>
@@ -411,9 +411,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Tells Enterprise Connect that passwords should meet Active Directory’s definition of complexity. Used to enable and configure live password testing.</string>
+			<string>Tells Enterprise Connect that passwords should meet Active Directory's definition of complexity. Used to enable and configure live password testing.</string>
 			<key>pfm_description_reference</key>
-			<string>Tells Enterprise Connect that passwords should meet Active Directory’s definition of complexity. Used to enable and configure live password testing. The default value is false.</string>
+			<string>Tells Enterprise Connect that passwords should meet Active Directory's definition of complexity. Used to enable and configure live password testing. The default value is false.</string>
 			<key>pfm_name</key>
 			<string>pwReqComplexity</string>
 			<key>pfm_title</key>
@@ -425,7 +425,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>Disables the "Has a Unicode character" password test from live password testing.</string>
 			<key>pfm_description_reference</key>
-			<string>If set to true, the “Has a Unicode character” password test is removed from live password testing. The default value is false. If set to true, the “Has a Unicode character” password test is removed from live password testing. The default value is false.</string>
+			<string>If set to true, the "Has a Unicode character" password test is removed from live password testing. The default value is false.</string>
 			<key>pfm_name</key>
 			<string>pwReqComplexityDisableUnicode</string>
 			<key>pfm_title</key>
@@ -489,9 +489,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Disable Enterprise Connect’s password management abilities, including expiration notices and the “Change Password” menu item. This is useful for customers who don’t change their passwords in AD.</string>
+			<string>Disable Enterprise Connect's password management abilities, including expiration notices and the "Change Password" menu item. This is useful for customers who don't change their passwords in AD.</string>
 			<key>pfm_description_reference</key>
-			<string>Set this key to true to disable Enterprise Connect’s password management abilities, including expiration notices and the “Change Password” menu item. This is useful for customers who don’t change their passwords in AD. The default value is false.</string>
+			<string>Set this key to true to disable Enterprise Connect's password management abilities, including expiration notices and the "Change Password" menu item. This is useful for customers who don't change their passwords in AD. The default value is false.</string>
 			<key>pfm_name</key>
 			<string>disablePasswordFunctions</string>
 			<key>pfm_title</key>
@@ -501,9 +501,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Disable Enterprise Connect’s password expiration checking, but still leave intact the ability for the user to change their password with Enterprise Connect.</string>
+			<string>Disable Enterprise Connect's password expiration checking, but still leave intact the ability for the user to change their password with Enterprise Connect.</string>
 			<key>pfm_description_reference</key>
-			<string>Set this key to true to disable Enterprise Connect’s password expiration checking, but still leave intact the ability for the user to change their password with Enterprise Connect.</string>
+			<string>Set this key to true to disable Enterprise Connect's password expiration checking, but still leave intact the ability for the user to change their password with Enterprise Connect.</string>
 			<key>pfm_name</key>
 			<string>disablePasswordExpirationChecking</string>
 			<key>pfm_title</key>
@@ -537,9 +537,9 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>URL to open in the user’s default web browser when they use Enterprise Connect to change their password. Standard password change functionality will no longer work.</string>
+			<string>URL to open in the user's default web browser when they use Enterprise Connect to change their password. Standard password change functionality will no longer work.</string>
 			<key>pfm_description_reference</key>
-			<string>If set, Enterprise Connect will open this URL in the user’s default web browser when they use Enterprise Connect to change their password. Standard password change functionality will no longer work. (Example - https://reset.pretendco.com/ForgotPass)</string>
+			<string>If set, Enterprise Connect will open this URL in the user's default web browser when they use Enterprise Connect to change their password. Standard password change functionality will no longer work. (Example - https://reset.pretendco.com/ForgotPass)</string>
 			<key>pfm_name</key>
 			<string>passwordChangeURL</string>
 			<key>pfm_title</key>
@@ -584,7 +584,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>Check for a host in your organization's network.</string>
 			<key>pfm_description_reference</key>
-			<string>Tells Enterprise Connect how to check for your organization’s network. Set to “false” for default behavior, and set to “true” to check for a specific host. Should you do this, you must also set checkForNetworkServer.</string>
+			<string>Tells Enterprise Connect how to check for your organization's network. Set to "false" for default behavior, and set to "true" to check for a specific host. Should you do this, you must also set checkForNetworkServer.</string>
 			<key>pfm_name</key>
 			<string>checkForNetworkType</string>
 			<key>pfm_title</key>
@@ -596,7 +596,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string>The host Enterprise Connect should check for when connecting.</string>
 			<key>pfm_description_reference</key>
-			<string>Set this to the host Enterprise Connect should check for when connecting. This is blank by default. Only set if you set the above key to “true.”</string>
+			<string>Set this to the host Enterprise Connect should check for when connecting. This is blank by default. Only set if you set the above key to "true."</string>
 			<key>pfm_name</key>
 			<string>checkForNetworkServer</string>
 			<key>pfm_title</key>
@@ -648,9 +648,9 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Delay starting the connection process when your organization’s network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are performed.</string>
+			<string>Delay starting the connection process when your organization's network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are performed.</string>
 			<key>pfm_description_reference</key>
-			<string>This value, if set, tells Enterprise Connect to delay starting its connection process when your organization’s network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are
+			<string>This value, if set, tells Enterprise Connect to delay starting its connection process when your organization's network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are
 performed. Set connectDelay to the value in seconds that you need to delay connections for. The default value is 0.</string>
 			<key>pfm_name</key>
 			<string>connectDelay</string>
@@ -736,9 +736,9 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 		
 		<dict>
 			<key>pfm_description</key>
-			<string>Determines if Enterprise Connect mounts the user’s network home directory.</string>
+			<string>Determines if Enterprise Connect mounts the user's network home directory.</string>
 			<key>pfm_description_reference</key>
-			<string>Determines if Enterprise Connect mounts the user’s network home directory. This is “false” by default. Set to “true” to enable.</string>
+			<string>Determines if Enterprise Connect mounts the user's network home directory. This is "false" by default. Set to "true" to enable.</string>
 			<key>pfm_name</key>
 			<string>mountNetworkHomeDirectory</string>
 			<key>pfm_title</key>
@@ -860,9 +860,9 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Delay the mounting of network shares when your organization’s network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are performed.</string>
+			<string>Delay the mounting of network shares when your organization's network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are performed.</string>
 			<key>pfm_description_reference</key>
-			<string>This value, if set, tells Enterprise Connect to delay the mounting of network shares when your organization’s network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are performed. Set shareMountWaitSeconds to the value in seconds that you need to delay share mounting for. The default value is 0.</string>
+			<string>This value, if set, tells Enterprise Connect to delay the mounting of network shares when your organization's network is detected. This may be useful for customers who use Cisco NAC and need to delay connection while host checks are performed. Set shareMountWaitSeconds to the value in seconds that you need to delay share mounting for. The default value is 0.</string>
 			<key>pfm_name</key>
 			<string>shareMountWaitSeconds</string>
 			<key>pfm_title</key>
@@ -910,7 +910,7 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
-			<string>If set to false, the user’s Kerberos ticket will not be destroyed upon smart card removal. The default value is true.</string>
+			<string>If set to false, the user's Kerberos ticket will not be destroyed upon smart card removal. The default value is true.</string>
 			<key>pfm_name</key>
 			<string>destroyKerbTicketUponCardRemoval</string>
 			<key>pfm_title</key>
@@ -925,7 +925,7 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 		
 		<dict>
 			<key>pfm_description_reference</key>
-			<string>The distinguished name of your domain’s configuration container. This value may be useful from scripts that perform LDAP queries. (Example - CN=Configuration,DC=pretendco,DC=com</string>
+			<string>The distinguished name of your domain's configuration container. This value may be useful from scripts that perform LDAP queries. (Example - CN=Configuration,DC=pretendco,DC=com</string>
 			<key>pfm_name</key>
 			<string>configurationNamingContext</string>
 			<key>pfm_title</key>
@@ -945,7 +945,7 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 		</dict>
 		<dict>
 			<key>pfm_description_reference</key>
-			<string>This key contains the date that the user’s password expires.</string>
+			<string>This key contains the date that the user's password expires.</string>
 			<key>pfm_name</key>
 			<string>datePasswordExpires</string>
 			<key>pfm_title</key>
@@ -955,7 +955,7 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 		</dict>
 		<dict>
 			<key>pfm_description_reference</key>
-			<string>The amount of days until the user’s password expires.</string>
+			<string>The amount of days until the user's password expires.</string>
 			<key>pfm_name</key>
 			<string>daysToExpire</string>
 			<key>pfm_title</key>
@@ -965,7 +965,7 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 		</dict>
 		<dict>
 			<key>pfm_description_reference</key>
-			<string>The distinguished name of your domain’s default container. This value may be useful from scripts that perform LDAP queries.</string>
+			<string>The distinguished name of your domain's default container. This value may be useful from scripts that perform LDAP queries.</string>
 			<key>pfm_name</key>
 			<string>defaultNamingContext</string>
 			<key>pfm_title</key>
@@ -995,7 +995,7 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 		</dict>
 		<dict>
 			<key>pfm_description_reference</key>
-			<string>This key, if set to true, indicates that the user’s local and Active Directory passwords are in sync. This value is useful for inventory purposes.</string>
+			<string>This key, if set to true, indicates that the user's local and Active Directory passwords are in sync. This value is useful for inventory purposes.</string>
 			<key>pfm_name</key>
 			<string>localADPasswordsInSync</string>
 			<key>pfm_title</key>
@@ -1005,7 +1005,7 @@ performed. Set connectDelay to the value in seconds that you need to delay conne
 		</dict>
 		<dict>
 			<key>pfm_description_reference</key>
-			<string>The distinguished name of your forest’s default container. This value may be useful from scripts that perform LDAP queries. (Example -DC=pretendco,DC=com)</string>
+			<string>The distinguished name of your forest's default container. This value may be useful from scripts that perform LDAP queries. (Example -DC=pretendco,DC=com)</string>
 			<key>pfm_name</key>
 			<string>rootDomainNamingContext</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -5012,13 +5012,13 @@ If this policy is left not set the user can disable any plugin installed on the 
 			<key>pfm_app_min</key>
 			<string>86</string>
 			<key>pfm_description</key>
-			<string>This policy controls checking URLs in real time to identify unsafe URLs. If this policy is left not set or set to ‘Disabled’, the consumer Safe Browsing checks will be applied. If this policy is set to ‘Enabled’, URLs will be sent to be scanned in real time under enterprise ToS. It will result in Brave Browser sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.</string>
+			<string>This policy controls checking URLs in real time to identify unsafe URLs. If this policy is left not set or set to ‘Disabled', the consumer Safe Browsing checks will be applied. If this policy is set to ‘Enabled', URLs will be sent to be scanned in real time under enterprise ToS. It will result in Brave Browser sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.</string>
 			<key>pfm_description_reference</key>
 			<string>This policy controls checking URLs in real time to identify unsafe URLs.
 
-If this policy is left not set or set to ‘Disabled’, the consumer Safe Browsing checks will be applied. Consumer Safe Browsing checks can still include real time lookups, depending on the value of the “Make searches and browsing better” setting and the value of the UrlKeyedAnonymizedDataCollectionEnabled policy.
+If this policy is left not set or set to ‘Disabled', the consumer Safe Browsing checks will be applied. Consumer Safe Browsing checks can still include real time lookups, depending on the value of the "Make searches and browsing better" setting and the value of the UrlKeyedAnonymizedDataCollectionEnabled policy.
 
-If this policy is set to ‘Enabled’, URLs will be sent to be scanned in real time under enterprise ToS. It will result in Brave Browser sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.
+If this policy is set to ‘Enabled', URLs will be sent to be scanned in real time under enterprise ToS. It will result in Brave Browser sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.
 
 This policy can only be set from the Google Admin console.
 

--- a/Manifests/ManagedPreferencesApplications/com.citrix.receiver.nomas.plist
+++ b/Manifests/ManagedPreferencesApplications/com.citrix.receiver.nomas.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T09:37:17Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.citrix.receiver.nomas.plist
+++ b/Manifests/ManagedPreferencesApplications/com.citrix.receiver.nomas.plist
@@ -333,9 +333,9 @@ Disabled: Citrix Receiver Updates disabled for Clients.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Sets the security compliance mode for the policy. If you don’t configure SecurityComplianceMode, FIPS is used as the default value.</string>
+			<string>Sets the security compliance mode for the policy. If you don't configure SecurityComplianceMode, FIPS is used as the default value.</string>
 			<key>pfm_description_reference</key>
-			<string>Sets the security compliance mode for the policy. If you don’t configure SecurityComplianceMode, FIPS is used as the default value.</string>
+			<string>Sets the security compliance mode for the policy. If you don't configure SecurityComplianceMode, FIPS is used as the default value.</string>
 			<key>pfm_name</key>
 			<string>SecurityComplianceMode</string>
 			<key>pfm_type</key>
@@ -382,11 +382,11 @@ Disabled: Citrix Receiver Updates disabled for Clients.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This setting governs how a given trusted root certificate authority is treated during an attempt to open a remote session through SSL. When you enable this setting, the client checks whether or not the server’s certificate is revoked.</string>
+			<string>This setting governs how a given trusted root certificate authority is treated during an attempt to open a remote session through SSL. When you enable this setting, the client checks whether or not the server's certificate is revoked.</string>
 			<key>pfm_description_reference</key>
 			<string>This feature improves the cryptographic authentication of the Citrix server and improves the overall security of the SSL/TLS connections between a client and a server. This setting governs how a given trusted root certificate authority is treated during an attempt to open a remote session through SSL when using the client for OS X.
 
-When you enable this setting, the client checks whether or not the server’s certificate is revoked. There are several levels of certificate revocation list checking. For example, the client can be configured to check only its local certificate list, or to check the local and network certificate lists. In addition, certificate checking can be configured to allow users to log on only if all Certificate Revocation lists are verified.
+When you enable this setting, the client checks whether or not the server's certificate is revoked. There are several levels of certificate revocation list checking. For example, the client can be configured to check only its local certificate list, or to check the local and network certificate lists. In addition, certificate checking can be configured to allow users to log on only if all Certificate Revocation lists are verified.
 
 Certificate Revocation List (CRL) checking is an advanced feature supported by some certificate issuers. It allows an administrator to revoke security certificates (invalidated before their expiry date) in the case of cryptographic compromise of the certificate private key, or simply an unexpected change in DNS name.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -5086,13 +5086,13 @@ If this policy is left not set the user can disable any plugin installed on the 
 			<key>pfm_app_min</key>
 			<string>86</string>
 			<key>pfm_description</key>
-			<string>This policy controls checking URLs in real time to identify unsafe URLs. If this policy is left not set or set to ‘Disabled’, the consumer Safe Browsing checks will be applied. If this policy is set to ‘Enabled’, URLs will be sent to be scanned in real time under enterprise ToS. It will result in Chrome sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.</string>
+			<string>This policy controls checking URLs in real time to identify unsafe URLs. If this policy is left not set or set to ‘Disabled', the consumer Safe Browsing checks will be applied. If this policy is set to ‘Enabled', URLs will be sent to be scanned in real time under enterprise ToS. It will result in Chrome sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.</string>
 			<key>pfm_description_reference</key>
 			<string>This policy controls checking URLs in real time to identify unsafe URLs.
 
-If this policy is left not set or set to ‘Disabled’, the consumer Safe Browsing checks will be applied. Consumer Safe Browsing checks can still include real time lookups, depending on the value of the “Make searches and browsing better” setting and the value of the UrlKeyedAnonymizedDataCollectionEnabled policy.
+If this policy is left not set or set to ‘Disabled', the consumer Safe Browsing checks will be applied. Consumer Safe Browsing checks can still include real time lookups, depending on the value of the "Make searches and browsing better" setting and the value of the UrlKeyedAnonymizedDataCollectionEnabled policy.
 
-If this policy is set to ‘Enabled’, URLs will be sent to be scanned in real time under enterprise ToS. It will result in Chrome sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.
+If this policy is set to ‘Enabled', URLs will be sent to be scanned in real time under enterprise ToS. It will result in Chrome sending URLs to Google Cloud or third parties of your choosing to check them in real time. The consumer version of Safe Browsing real time lookup will be switched off.
 
 This policy can only be set from the Google Admin console.
 

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-Okta.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-Okta.plist
@@ -314,23 +314,23 @@ If set to false, the Local Auth button is available, and users can choose to aut
 			<key>pfm_name</key>
 			<string>Migrate</string>
 			<key>pfm_description</key>
-			<string>Allows local accounts to be migrated to network accounts. This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user’s Okta identity.</string>
+			<string>Allows local accounts to be migrated to network accounts. This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user's Okta identity.</string>
 			<key>pfm_description_reference</key>
 			<string>Allows local accounts to be migrated to Okta-based accounts.
-This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user’s Okta identity.
+This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user's Okta identity.
 
 Jamf Connect Login does this by forcing the user to sign in via Okta, and then attempts to match the user with an existing local account. Consider the following user migration scenarios:
 
 If a user's Okta username and password match a local username and password, the account is considered migrated. No additional steps are needed.
 If a user's Okta username matches a local username but the passwords do not match, the user will be prompted to enter their current local password. Once successfully entered, Jamf Connect Login will use the current local password and the current Okta password to sync the account to the current Okta password.
 If a user's Okta username does not match any local account, the user will be given the option to create or migrate a local account. To migrate an account, the user must provide the existing local password. At this point Jamf Connect Login will synchronize the password to the Okta password, and then add the Okta username as an alias to the local account. This way the user can sign in to the system as their Okta username.
-Additionally, Okta can migrate users from local accounts to accounts associated with an Okta identity. With the Migrate and DenyLocal preference keys, all subsequent sign-ins will be authenticated to Okta, and then the system verifies if the user record has an “OktaUser” attribute. If this attribute cannot be verified, the user will be asked to select a local account to associate with the user’s Okta account. If the local account shortname does not match the Okta shortname, the Okta name will be added as an alias to the account so the user will be able to use either one. This also keeps the home folder path and other elements of the user record the same.
+Additionally, Okta can migrate users from local accounts to accounts associated with an Okta identity. With the Migrate and DenyLocal preference keys, all subsequent sign-ins will be authenticated to Okta, and then the system verifies if the user record has an "OktaUser" attribute. If this attribute cannot be verified, the user will be asked to select a local account to associate with the user's Okta account. If the local account shortname does not match the Okta shortname, the Okta name will be added as an alias to the account so the user will be able to use either one. This also keeps the home folder path and other elements of the user record the same.
 
-Note: For every successful Okta authentication of a user, the user’s record will be updated with the “NetworkSignIn” attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
+Note: For every successful Okta authentication of a user, the user's record will be updated with the "NetworkSignIn" attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 			<key>pfm_note</key>
-			<string>For every successful Okta authentication of a user, the user’s record will be updated with the “NetworkSignIn” attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
+			<string>For every successful Okta authentication of a user, the user's record will be updated with the "NetworkSignIn" attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.jamf.com/jamf-connect/1.2.3/administrator-guide/Configuring_with_Okta.html</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-Okta.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-Okta.plist
@@ -11,7 +11,7 @@
 		<string>system</string>
 	</array>
 	<key>pfm_last_modified</key>
-	<date>2019-10-10T09:37:17Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
@@ -325,30 +325,30 @@ If set to false, the Local Auth button is available, and users can choose to aut
 				<key>pfm_name</key>
 				<string>Migrate</string>
 				<key>pfm_description</key>
-				<string>Allows local accounts to be migrated to network accounts. This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user’s Okta identity.</string>
+				<string>Allows local accounts to be migrated to network accounts. This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user's Okta identity.</string>
 				<key>pfm_description_extended</key>
 				<string>Jamf Connect Login does this by forcing the user to sign in with their IdP, and then attempts to match the user with an existing local account. Consider the following user migration scenarios:
 
 If a user's network username and password match a local username and password, the account is considered migrated. No additional steps are needed.
 If a user's network username matches a local username but the passwords do not match, the user will be prompted to enter their current local password. Once successfully entered, Jamf Connect Login will use the current local password and the current network password to sync the account to the current network password.
 If a user's network username does not match any local account, the user will be given the option to create or migrate a local account. To migrate an account, the user must provide the existing local password. At this point Jamf Connect Login will synchronize the password to the network password, and then add the network username as an alias to the local account. This way the user can sign in to the system as their network username.
-Additionally, IdPs can migrate users from local accounts to accounts associated with network identity. With the Migrate and DenyLocal preference keys, all subsequent sign-ins will be authenticated to your IdP, and then the system verifies if the user record has an IdPUser attribute. If this attribute cannot be verified, the user will be asked to select a local account to associate with the user’s network account. If the local account shortname does not match the network shortname, the network name will be added as an alias to the account so the user will be able to use either one. This also keeps the home folder path and other elements of the user record the same.</string>
+Additionally, IdPs can migrate users from local accounts to accounts associated with network identity. With the Migrate and DenyLocal preference keys, all subsequent sign-ins will be authenticated to your IdP, and then the system verifies if the user record has an IdPUser attribute. If this attribute cannot be verified, the user will be asked to select a local account to associate with the user's network account. If the local account shortname does not match the network shortname, the network name will be added as an alias to the account so the user will be able to use either one. This also keeps the home folder path and other elements of the user record the same.</string>
 				<key>pfm_description_reference</key>
 				<string>Allows local accounts to be migrated to network accounts.
-This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user’s cloud identity.
+This is typically used when the user account was already created on the system, but you want the accounts to have the same username and password as the user's cloud identity.
 
 Jamf Connect Login does this by forcing the user to sign in with their IdP, and then attempts to match the user with an existing local account. Consider the following user migration scenarios:
 
 If a user's network username and password match a local username and password, the account is considered migrated. No additional steps are needed.
 If a user's network username matches a local username but the passwords do not match, the user will be prompted to enter their current local password. Once successfully entered, Jamf Connect Login will use the current local password and the current network password to sync the account to the current network password.
 If a user's network username does not match any local account, the user will be given the option to create or migrate a local account. To migrate an account, the user must provide the existing local password. At this point Jamf Connect Login will synchronize the password to the network password, and then add the network username as an alias to the local account. This way the user can sign in to the system as their network username.
-Additionally, IdPs can migrate users from local accounts to accounts associated with network identity. With the Migrate and DenyLocal preference keys, all subsequent sign-ins will be authenticated to your IdP, and then the system verifies if the user record has an IdPUser attribute. If this attribute cannot be verified, the user will be asked to select a local account to associate with the user’s network account. If the local account shortname does not match the network shortname, the network name will be added as an alias to the account so the user will be able to use either one. This also keeps the home folder path and other elements of the user record the same.
+Additionally, IdPs can migrate users from local accounts to accounts associated with network identity. With the Migrate and DenyLocal preference keys, all subsequent sign-ins will be authenticated to your IdP, and then the system verifies if the user record has an IdPUser attribute. If this attribute cannot be verified, the user will be asked to select a local account to associate with the user's network account. If the local account shortname does not match the network shortname, the network name will be added as an alias to the account so the user will be able to use either one. This also keeps the home folder path and other elements of the user record the same.
 
-Note: For every successful network authentication of a user, the user’s record will be updated with the “NetworkSignIn” attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
+Note: For every successful network authentication of a user, the user's record will be updated with the "NetworkSignIn" attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
 				<key>pfm_type</key>
 				<string>boolean</string>
 				<key>pfm_note</key>
-				<string>For every successful network authentication of a user, the user’s record will be updated with the “NetworkSignIn” attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
+				<string>For every successful network authentication of a user, the user's record will be updated with the "NetworkSignIn" attribute. If the user was only authenticated locally, this attribute will not be updated.</string>
 				<key>pfm_documentation_url</key>
 				<string>https://docs.jamf.com/jamf-connect/1.2.3/administrator-guide/Configuring_with_Okta.html</string>
 			</dict>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
@@ -23,7 +23,7 @@
 		<key>pfm_format_version</key>
 		<integer>1</integer>
 		<key>pfm_last_modified</key>
-		<date>2021-01-14T16:51:12Z</date>
+		<date>2021-12-22T05:49:22Z</date>
 		<key>pfm_title</key>
 		<string>Jamf Connect Login (OIDC)</string>
 		<key>pfm_unique</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-09-27T09:00:30Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
@@ -161,7 +161,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_app_min</key>
 			<string>1.1.0</string>
 			<key>pfm_description</key>
-			<string>This is a dictionary of attributes for scenarios where the user’s home profile should be mounted.</string>
+			<string>This is a dictionary of attributes for scenarios where the user's home profile should be mounted.</string>
 			<key>pfm_description_reference</key>
 			<string>Determines if a user's home profile should be mounted. This is written as a dictionary of keys including the Groups and Options keys.</string>
 			<key>pfm_documentation_url</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
@@ -318,7 +318,7 @@ Note: A Preceding "https:" is not required.</string>
 		
 		<dict>
 			<key>pfm_description_reference</key>
-			<string>Determines whether the Okta password is stored in the user’s Keychain.</string>
+			<string>Determines whether the Okta password is stored in the user's Keychain.</string>
 			<key>pfm_name</key>
 			<string>UseKeychain</string>
 			<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-08T03:02:13Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -1622,7 +1622,7 @@ If this policy is left not set, 'AskNotifications' will be used and the user wil
 			<key>pfm_description_reference</key>
 			<string>Allows you to create a list of url patterns to specify sites that are allowed to display notifications.
 
-If you don’t set this policy, the global default value will be used for all sites. This default value will be from the `DefaultNotificationsSetting` policy if it’s set, or from the user's personal configuration. For detailed information on valid url patterns, see https://cloud.google.com/docs/chrome-enterprise/policies/url-patterns.</string>
+If you don't set this policy, the global default value will be used for all sites. This default value will be from the `DefaultNotificationsSetting` policy if it's set, or from the user's personal configuration. For detailed information on valid url patterns, see https://cloud.google.com/docs/chrome-enterprise/policies/url-patterns.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#notificationsallowedforurls</string>
 			<key>pfm_name</key>
@@ -1651,7 +1651,7 @@ If you don’t set this policy, the global default value will be used for all si
 			<key>pfm_description_reference</key>
 			<string>Allows you to create a list of url patterns to specify sites that are not allowed to display notifications.
 
-If you don’t set this policy, the global default value will be used for all sites. This default value will be from the [DefaultNotificationsSetting](#defaultnotificationssetting) policy if it’s set, or from the user's personal configuration. For detailed information on valid url patterns, see https://cloud.google.com/docs/chrome-enterprise/policies/url-patterns.</string>
+If you don't set this policy, the global default value will be used for all sites. This default value will be from the [DefaultNotificationsSetting](#defaultnotificationssetting) policy if it's set, or from the user's personal configuration. For detailed information on valid url patterns, see https://cloud.google.com/docs/chrome-enterprise/policies/url-patterns.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#notificationsblockedforurls</string>
 			<key>pfm_name</key>
@@ -4077,9 +4077,9 @@ If you disable or don't configure this policy, the default link for the Help men
 			<key>pfm_description_reference</key>
 			<string>This detection might not be necessary in an enterprise environment where the network configuration is known. It can be disabled to avoid additional DNS and HTTP traffic on start-up and each DNS configuration change.
 
-If you enable or don’t set this policy, the DNS interception checks are performed.
+If you enable or don't set this policy, the DNS interception checks are performed.
 
-If you disable this policy, DNS interception checks aren’t performed.</string>
+If you disable this policy, DNS interception checks aren't performed.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#dnsinterceptionchecksenabled</string>
 			<key>pfm_name</key>
@@ -4793,13 +4793,13 @@ If you don't configure this policy, on an unmanaged device the behavior is the s
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If you set to True, when an external protocol confirmation prompt is shown, the user can select "Always open". The user won’t get any future confirmation prompts for this protocol.</string>
+			<string>If you set to True, when an external protocol confirmation prompt is shown, the user can select "Always open". The user won't get any future confirmation prompts for this protocol.</string>
 			<key>pfm_description_reference</key>
 			<string>This policy controls whether the "Always open" checkbox is shown on external protocol launch confirmation prompts.
 
-If you set this policy to True, when an external protocol confirmation prompt is shown, the user can select "Always open". The user won’t get any future confirmation prompts for this protocol.
+If you set this policy to True, when an external protocol confirmation prompt is shown, the user can select "Always open". The user won't get any future confirmation prompts for this protocol.
 
-If you set this policy to False, or the policy is unset, the "Always open" checkbox isn’t displayed. The user will be prompted for confirmation every time an external protocol is invoked.</string>
+If you set this policy to False, or the policy is unset, the "Always open" checkbox isn't displayed. The user will be prompted for confirmation every time an external protocol is invoked.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#externalprotocoldialogshowalwaysopencheckbox</string>
 			<key>pfm_name</key>
@@ -5078,7 +5078,7 @@ If you enable this policy, the second auto-suggest result in the address bar sug
 
 Two effects of enabling this policy are:
 
-Navigation to sites in response to single word queries that would typically resolve to a history item will no longer happen. Instead, the browser will attempt navigate to internal sites that may not exist in an organization’s intranet. This will result in a 404 error.
+Navigation to sites in response to single word queries that would typically resolve to a history item will no longer happen. Instead, the browser will attempt navigate to internal sites that may not exist in an organization's intranet. This will result in a 404 error.
 
 Popular, single-word search terms will require manual selection of search suggestions to properly conduct a search.</string>
 			<key>pfm_documentation_url</key>
@@ -5225,9 +5225,9 @@ If it is not set, the user may be asked whether to import, or importing may happ
 			<key>pfm_description_reference</key>
 			<string>If you enable this policy, the Browser settings check box is automatically selected in the Import browser data dialog box.
 
-If you disable this policy, browser settings aren't imported at first run, and users can’t import them manually.
+If you disable this policy, browser settings aren't imported at first run, and users can't import them manually.
 
-If you don’t configure this policy, browser settings are imported at first run, and users can choose whether to import them manually during later browsing sessions.
+If you don't configure this policy, browser settings are imported at first run, and users can choose whether to import them manually during later browsing sessions.
 
 You can also set this policy as a recommendation. This means that Microsoft Edge imports the settings on first run, but users can select or clear the browser settings option during manual import.</string>
 			<key>pfm_documentation_url</key>
@@ -5392,9 +5392,9 @@ You can also set this policy as a recommendation. This means that Microsoft Edge
 			<key>pfm_description_reference</key>
 			<string>If you enable this policy, the payment info check box is automatically selected in the Import browser data dialog box.
 
-If you disable this policy, payment info isn’t imported at first run, and users can’t import it manually.
+If you disable this policy, payment info isn't imported at first run, and users can't import it manually.
 
-If you don’t configure this policy, payment info is imported at first run, and users can choose whether to import it manually during later browsing sessions.
+If you don't configure this policy, payment info is imported at first run, and users can choose whether to import it manually during later browsing sessions.
 
 You can also set this policy as a recommendation. This means that Microsoft Edge imports payment info on first run, but users can select or clear the payment info option during manual import.</string>
 			<key>pfm_documentation_url</key>
@@ -5982,7 +5982,7 @@ If you enable this policy or don't set this policy, websites can check if the us
 			<key>pfm_description_reference</key>
 			<string>This setting is only available for users with a Microsoft account. This setting is not available for child accounts or enterprise accounts.
 
-If you disable this policy, users can't change or override the setting. If this policy is enabled or not configured, Microsoft Edge will default to the user’s preference.</string>
+If you disable this policy, users can't change or override the setting. If this policy is enabled or not configured, Microsoft Edge will default to the user's preference.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#personalizationreportingenabled</string>
 			<key>pfm_name</key>
@@ -6668,7 +6668,7 @@ URLs (like https://example.com/some/path) will only match as U2F appIDs. Domains
 			<key>pfm_description_reference</key>
 			<string>Enable this policy to send info about websites visited in Microsoft Edge to Microsoft. Disable this policy to not send info about websites visited in Microsoft Edge to Microsoft. In both cases, users can't change or override the setting.
 
-This policy controls sending info about websites visited. If this policy is not configured, Microsoft Edge will default to the user’s preference.</string>
+This policy controls sending info about websites visited. If this policy is not configured, Microsoft Edge will default to the user's preference.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployedge/microsoft-edge-policies#sendsiteinfotoimproveservices</string>
 			<key>pfm_name</key>
@@ -6812,7 +6812,7 @@ If this policy is disabled, the user is not allowed to use spellcheck. The Spell
 
 This policy controls the treatment for mixed content (HTTP content in HTTPS sites) in the browser.
 
-If you set this policy to true or not set, audio and video mixed content will be automatically upgraded to HTTPS (that is, the URL will be rewritten as HTTPS, without a fallback if the resource isn’t available over HTTPS) and a 'Not Secure' warning will be shown in the URL bar for image mixed content.
+If you set this policy to true or not set, audio and video mixed content will be automatically upgraded to HTTPS (that is, the URL will be rewritten as HTTPS, without a fallback if the resource isn't available over HTTPS) and a 'Not Secure' warning will be shown in the URL bar for image mixed content.
 
 If you set the policy to false, auto upgrades will be disabled for audio and video, and no warning will be shown for images.
 
@@ -6874,7 +6874,7 @@ This policy should not be enabled when RoamingProfileSupportEnabled policy is se
 			<key>pfm_description_reference</key>
 			<string>If you enable this policy all the specified data types will be excluded from synchronization. This policy can be used to limit the type of data uploaded to the Microsoft Edge synchronization service.
 
-You can provide one of the following data types for this policy: "favorites", "settings", "passwords", "addressesAndMore", "extensions", and “collections”. Note that these data type names are case sensitive.
+You can provide one of the following data types for this policy: "favorites", "settings", "passwords", "addressesAndMore", "extensions", and "collections". Note that these data type names are case sensitive.
 
 Users will not be able to override the disabled data types.</string>
 			<key>pfm_documentation_url</key>
@@ -8234,9 +8234,9 @@ This policy is available only on Windows instances that are joined to a Microsof
 			<key>pfm_description_reference</key>
 			<string>This policy setting lets you configure whether Microsoft Defender SmartScreen checks download reputation from a trusted source.
 
-If you enable or don't configure this setting, Microsoft Defender SmartScreen checks the download’s reputation regardless of source.
+If you enable or don't configure this setting, Microsoft Defender SmartScreen checks the download's reputation regardless of source.
 
-If you disable this setting, Microsoft Defender SmartScreen doesn’t check the download’s reputation when downloading from a trusted source.
+If you disable this setting, Microsoft Defender SmartScreen doesn't check the download's reputation when downloading from a trusted source.
 
 This policy is available only on Windows instances that are joined to a Microsoft Active Directory domain; or on Windows 10 Pro or Enterprise instances that are enrolled for device management.</string>
 			<key>pfm_documentation_url</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-23T07:21:28Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
@@ -427,9 +427,9 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Hide the “Did you know? Outlook supports…” text in the Set Up Your Email success dialog box. Only hides text. Does not impact ability to add non-corporate mailboxes.</string>
+			<string>Hide the "Did you know? Outlook supports…" text in the Set Up Your Email success dialog box. Only hides text. Does not impact ability to add non-corporate mailboxes.</string>
 			<key>pfm_description_reference</key>
-			<string>Hide the “Did you know? Outlook supports…” text in the Set Up Your Email success dialog box. Only hides text. Does not impact ability to add non-corporate mailboxes.</string>
+			<string>Hide the "Did you know? Outlook supports…" text in the Set Up Your Email success dialog box. Only hides text. Does not impact ability to add non-corporate mailboxes.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://docs.microsoft.com/en-us/deployoffice/mac/preferences-outlook#hide-text-about-adding-non-corporate-mailboxes</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-09-14T23:29:16Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -178,7 +178,7 @@
 			<key>pfm_description</key>
 			<string>Set the update channel that is used to check for updates.</string>
 			<key>pfm_description_reference</key>
-			<string>Controls which audience and update channel to use for retrieving product updates. By default, users are placed in the ‘production’ channel which receives the highestquality updates around the middle of each month. Through the UI, users can join the Insider Slow (Exeternal) and Insider Fast (InsiderFast) program to receive more frequent updates at slightly lower quality. IT administrators can also set a Custom channel when deploying an internal MAU server.</string>
+			<string>Controls which audience and update channel to use for retrieving product updates. By default, users are placed in the ‘production' channel which receives the highestquality updates around the middle of each month. Through the UI, users can join the Insider Slow (Exeternal) and Insider Fast (InsiderFast) program to receive more frequent updates at slightly lower quality. IT administrators can also set a Custom channel when deploying an internal MAU server.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://macadmins.software/docs/MAU_38.pdf</string>
 			<key>pfm_name</key>
@@ -327,7 +327,7 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_description</key>
 			<string>Enable this option to trigger the MAU Daemon when other Office applications are launched.</string>
 			<key>pfm_description_reference</key>
-			<string>Controls whether the ‘Microsoft AU Daemon’ should be launched when an Office application is launched. If this value is set to 0, updates will not be detected, regardless of the ‘HowToCheck’ preference, and users will need to use the Help -> Check for Updates menu option to see if updates are available.</string>
+			<string>Controls whether the ‘Microsoft AU Daemon' should be launched when an Office application is launched. If this value is set to 0, updates will not be detected, regardless of the ‘HowToCheck' preference, and users will need to use the Help -> Check for Updates menu option to see if updates are available.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://macadmins.software/docs/MAU_38.pdf</string>
 			<key>pfm_name</key>
@@ -1337,7 +1337,7 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<key>pfm_name</key>
 			<string>UpdateDeadline.ApplicationsForcedUpdateSchedule</string>
 			<key>pfm_note</key>
-			<string>If you use a specific date and time for the deadline, it’s tied to a specific version that you’re updating to. That means for the next set of updates that Microsoft releases, you would need to configure a new date and time for the deadline.</string>
+			<string>If you use a specific date and time for the deadline, it's tied to a specific version that you're updating to. That means for the next set of updates that Microsoft releases, you would need to configure a new date and time for the deadline.</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -381,7 +381,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When set to true will force the open/save panel to ‘On My Mac’ instead of 'Online Locations'.</string>
+			<string>When set to true will force the open/save panel to ‘On My Mac' instead of 'Online Locations'.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://derflounder.wordpress.com/2017/04/17/office-2016-defaultstolocalopensave-setting-change-as-of-office-2016-15-33-x/</string>
 			<key>pfm_name</key>
@@ -705,9 +705,9 @@ user must make a choice whether to allow or deny macros for each individual file
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including “do shell script ...” in the AppleScript code.</string>
+			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including "do shell script ..." in the AppleScript code.</string>
 			<key>pfm_description_reference</key>
-			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including “do shell script ...” in the AppleScript code. 
+			<string>The DisableVisualBasicMacScript setting determines if macros are allowed to invoke the MacScript() Visual Basic API. This API allows macros to execute arbitrary processes via AppleScript by including "do shell script ..." in the AppleScript code. 
 The default value for this setting allows using MacScript, as there are a number of legitimate uses of AppleScript that do not rely on external processes. When this setting is set to NO, macros that attempt to use MacScript will fail with an error at the point where MacScript is invoked.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://macadmins.software/docs/VBSecurityControls.pdf</string>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-06-01T14:22:23Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
+++ b/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
@@ -118,7 +118,7 @@
 			<key>pfm_app_min</key>
 			<string>1.0</string>
 			<key>pfm_description</key>
-			<string>Defines the AD domain you’re working with.</string>
+			<string>Defines the AD domain you're working with.</string>
 			<key>pfm_name</key>
 			<string>ADDomain</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
+++ b/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-05-20T13:35:11Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
@@ -540,7 +540,7 @@
 			<key>pfm_app_min</key>
 			<string>1.0</string>
 			<key>pfm_description</key>
-			<string>Determines if the Okta password is stored in the user’s keychain.</string>
+			<string>Determines if the Okta password is stored in the user's keychain.</string>
 			<key>pfm_name</key>
 			<string>UseKeychain</string>
 			<key>pfm_type</key>
@@ -769,7 +769,7 @@
 			<key>pfm_app_min</key>
 			<string>1.1</string>
 			<key>pfm_description</key>
-			<string>Shows a menu item beneath the current user’s name showing the user’s password expiration as determined by AD.</string>
+			<string>Shows a menu item beneath the current user's name showing the user's password expiration as determined by AD.</string>
 			<key>pfm_name</key>
 			<string>ADExpirationShow</string>
 			<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-08T03:02:13Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -479,7 +479,7 @@
 			<key>pfm_app_min</key>
 			<string>1.4</string>
 			<key>pfm_description</key>
-			<string>Maps NT to AD Domains. e.g. NOMAD: nomad.menu, would allow a user to sign in as “NOMAD\user” and that would be converted to “user@nomad.menu” before authenticating to AD.</string>
+			<string>Maps NT to AD Domains. e.g. NOMAD: nomad.menu, would allow a user to sign in as "NOMAD\user" and that would be converted to "user@nomad.menu" before authenticating to AD.</string>
 			<key>pfm_name</key>
 			<string>NTtoADDomainMappings</string>
 			<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-10-13T23:55:35Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
@@ -166,7 +166,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_app_min</key>
 			<string>1.1</string>
 			<key>pfm_description</key>
-			<string>This is a dictionary of attributes for scenarios where the user’s home profile should be mounted.</string>
+			<string>This is a dictionary of attributes for scenarios where the user's home profile should be mounted.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://nomad.menu/help/nomad-shares-menu/</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-09-27T09:00:30Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
+++ b/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-02-18T13:40:33Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0.1</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
+++ b/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
@@ -206,7 +206,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>string</string>
 			<key>pfm_value_placeholder</key>
-			<string>“Your Company Name“, “IT Helpdesk“ etc.</string>
+			<string>"Your Company Name", "IT Helpdesk" etc.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>

--- a/Manifests/ManifestsApple/Configuration.plist
+++ b/Manifests/ManifestsApple/Configuration.plist
@@ -161,8 +161,8 @@
 			<string>Optional. A dictionary containing these keys and values:
 • For each language in which a consent or license agreement is available, a key consisting of the IETF BCP 47 identifier for that language (for example, en or jp) and a value consisting of the agreement localized to that language. The agreement is displayed in a dialog to which the user must agree before installing the profile.
 • The optional key default with its value consisting of the unlocalized agreement (usually in en).
-The system chooses a localized version in the order of preference specified by the user (macOS) or based on the userʼs current language setting (iOS). If no exact match is found, the default localization is used. If there is no default localization, the en localization is used. If there is no en localization, then the first available localization is used.
-You should provide a default value if possible. No warning will be displayed if the userʼs locale does not match any localization in the ConsentText dictionary.</string>
+The system chooses a localized version in the order of preference specified by the user (macOS) or based on the user's current language setting (iOS). If no exact match is found, the default localization is used. If there is no default localization, the en localization is used. If there is no en localization, then the first available localization is used.
+You should provide a default value if possible. No warning will be displayed if the user's locale does not match any localization in the ConsentText dictionary.</string>
 			<key>pfm_name</key>
 			<string>ConsentText</string>
 			<key>pfm_subkeys</key>
@@ -195,7 +195,7 @@ You should provide a default value if possible. No warning will be displayed if 
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The system chooses a localized version in the order of preference specified by the user (macOS) or based on the user’s current language setting (iOS). If no exact match is found, the default localization is used. If there is no default localization, the en localization is used. If there is no en localization, then the first available localization is used.</string>
+					<string>The system chooses a localized version in the order of preference specified by the user (macOS) or based on the user's current language setting (iOS). If no exact match is found, the default localization is used. If there is no default localization, the en localization is used. If there is no en localization, then the first available localization is used.</string>
 					<key>pfm_description_reference</key>
 					<string></string>
 					<key>pfm_name</key>

--- a/Manifests/ManifestsApple/Configuration.plist
+++ b/Manifests/ManifestsApple/Configuration.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-11-25T12:08:06Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.ADCertificate.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.ADCertificate.managed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:49Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.ADCertificate.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.ADCertificate.managed.plist
@@ -152,7 +152,7 @@
 			<key>pfm_default</key>
 			<string>User</string>
 			<key>pfm_description</key>
-			<string>The name of the certificate template as it appears in the General tab of the template’s object in the Certificate Templates’ Microsoft Management Console snap-in component. Usually Machine or User</string>
+			<string>The name of the certificate template as it appears in the General tab of the template's object in the Certificate Templates' Microsoft Management Console snap-in component. Usually Machine or User</string>
 			<key>pfm_name</key>
 			<string>CertTemplate</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
@@ -511,7 +511,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_description</key>
 			<string>Network protocol to be used to mount home directory.</string>
 			<key>pfm_description_reference</key>
-			<string>Network home protocol to use: “afp” or “smb”.</string>
+			<string>Network home protocol to use: "afp" or "smb".</string>
 			<key>pfm_name</key>
 			<string>ADMountStyle</string>
 			<key>pfm_range_list</key>
@@ -1118,7 +1118,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_description</key>
 			<string>Set primary user account naming convention: "forest" or "domain".</string>
 			<key>pfm_description_reference</key>
-			<string>Set primary user account naming convention: “forest” or “domain”; “domain” is default.</string>
+			<string>Set primary user account naming convention: "forest" or "domain"; "domain" is default.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1199,7 +1199,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_description</key>
 			<string>Packet signing.</string>
 			<key>pfm_description_reference</key>
-			<string>Packet signing: ”allow”, ”disable” or ”require”; “allow” is default.</string>
+			<string>Packet signing: "allow", "disable" or "require"; "allow" is default.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1281,7 +1281,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_description</key>
 			<string>Packet encryption.</string>
 			<key>pfm_description_reference</key>
-			<string>Packet encryption: ”allow”, ”disable”, ”require” or ”ssl”; “allow” is default.</string>
+			<string>Packet encryption: "allow", "disable", "require" or "ssl"; "allow" is default.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1453,7 +1453,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_description</key>
 			<string>How often to change computer trust account password in days.</string>
 			<key>pfm_description_reference</key>
-			<string>How often to require change of the computer trust account password in days; “0” is disabled.</string>
+			<string>How often to require change of the computer trust account password in days; "0" is disabled.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
@@ -18,7 +18,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-12-10T13:51:15Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-13T03:59:07Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -1160,7 +1160,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables the “Erase All Content And Settings” option in the Reset UI.</string>
+			<string>Supervised only. If set to false, disables the "Erase All Content And Settings" option in the Reset UI.</string>
 			<key>pfm_name</key>
 			<string>allowEraseContentAndSettings</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -566,7 +566,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				<key>pfm_description</key>
 				<string></string>
 				<key>pfm_description_reference</key>
-				<string>Supervised only. If set to false, disables the “Erase All Content And Settings” option in the Reset UI.</string>
+				<string>Supervised only. If set to false, disables the "Erase All Content And Settings" option in the Reset UI.</string>
 				<key>pfm_macos_min</key>
 				<string>12.0</string>
 				<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2021-12-18T19:55:17Z</date>
+		<date>2021-12-22T05:49:22Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.asam.plist
+++ b/Manifests/ManifestsApple/com.apple.asam.plist
@@ -8,7 +8,7 @@
 	<string>The payload is designated by specifying com.apple.asam as the PayloadType.
 This payload grants Autonomous Single App Mode capabilities for specific applications. Available in macOS 10.13.4
 and later.
-It must be installed as a device profile. Only one payload of this type can be installed on a system. This payload can only be installed via a “user approved” MDM server.
+It must be installed as a device profile. Only one payload of this type can be installed on a system. This payload can only be installed via a "user approved" MDM server.
 To be granted access, applications must be signed with the specified bundle identifier and team identifier using an Apple-issued production developer certificate. Applications must specify the com.apple.developer.assessment entitlement with a value of true.</string>
 	<key>pfm_note</key>
 	<string>Applications listed in this payload will have low-level access to the system, including, but not limited to, key logging and user interface manipulation outside of the applicationʼs context.</string>

--- a/Manifests/ManifestsApple/com.apple.asam.plist
+++ b/Manifests/ManifestsApple/com.apple.asam.plist
@@ -19,7 +19,7 @@ To be granted access, applications must be signed with the specified bundle iden
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.4</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.caldav.account.plist
+++ b/Manifests/ManifestsApple/com.apple.caldav.account.plist
@@ -180,9 +180,9 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The base URL to the user's calendar. In macOS this URL is required if the user doesn’t provide a password, because auto-discovery of the service will fail and the account won’t be created.</string>
+			<string>The base URL to the user's calendar. In macOS this URL is required if the user doesn't provide a password, because auto-discovery of the service will fail and the account won't be created.</string>
 			<key>pfm_description_reference</key>
-			<string>Optional. The base URL to the userʼs calendar. In macOS this URL is required if the user doesnʼt provide a password, because auto-discovery of the service will fail and the account wonʼt be created.</string>
+			<string>Optional. The base URL to the user's calendar. In macOS this URL is required if the user doesn't provide a password, because auto-discovery of the service will fail and the account won't be created.</string>
 			<key>pfm_name</key>
 			<string>CalDAVPrincipalURL</string>
 			<key>pfm_title</key>
@@ -210,7 +210,7 @@ In macOS, this key is required.</string>
 			<key>pfm_description</key>
 			<string>The user name for the CalDAV account.</string>
 			<key>pfm_description_reference</key>
-			<string>The userʼs login name.
+			<string>The user's login name.
 In macOS, this key is required.</string>
 			<key>pfm_name</key>
 			<string>CalDAVUsername</string>
@@ -225,7 +225,7 @@ In macOS, this key is required.</string>
 			<key>pfm_description</key>
 			<string>The CalDAV password</string>
 			<key>pfm_description_reference</key>
-			<string>Optional. The userʼs password.</string>
+			<string>Optional. The user's password.</string>
 			<key>pfm_name</key>
 			<string>CalDAVPassword</string>
 			<key>pfm_sensitive</key>

--- a/Manifests/ManifestsApple/com.apple.caldav.account.plist
+++ b/Manifests/ManifestsApple/com.apple.caldav.account.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-09-16T16:18:39Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.dashboard.plist
+++ b/Manifests/ManifestsApple/com.apple.dashboard.plist
@@ -14,7 +14,7 @@ It is used to define a white list of dashboard widgets.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-09-16T02:20:42Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.dashboard.plist
+++ b/Manifests/ManifestsApple/com.apple.dashboard.plist
@@ -169,9 +169,9 @@ The payload organization for a payload need not match the payload organization i
 							<key>pfm_default</key>
 							<string>bundleID</string>
 							<key>pfm_description</key>
-							<string>Set to "bundleID" to use a widget’s bundle ID as its ID.</string>
+							<string>Set to "bundleID" to use a widget's bundle ID as its ID.</string>
 							<key>pfm_description_reference</key>
-							<string>Required. Set to bundleID to use a widgetʼs bundle ID as its ID.</string>
+							<string>Required. Set to bundleID to use a widget's bundle ID as its ID.</string>
 							<key>pfm_hidden</key>
 							<string>all</string>
 							<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -1132,7 +1132,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Whether these settings will merge with the user’s existing Dock settings.</string>
+			<string>Whether these settings will merge with the user's existing Dock settings.</string>
 			<key>pfm_description_reference</key>
 			<string>Optional. If true, the device will use the static-apps and static-others dictionaries for the dock and ignore any items in the persistent-apps and persistent-others dictionaries. If false, the contents will be merged with the static items listed first.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -209,7 +209,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_description</key>
 			<string>Cycle through the hostname, macOS version, and IP address when the menu bar is clicked.</string>
 			<key>pfm_description_reference</key>
-			<string>Optional. If this key is included in the payload, its value will be displayed as additional computer information on the login window. Before macOS 10.10, this string could contain only particular information (HostName, SystemVersion, or IPAddress). After macOS 10.10, setting this key to any value will allow the user to click the “time” area of the menu bar to toggle through various computer information values.</string>
+			<string>Optional. If this key is included in the payload, its value will be displayed as additional computer information on the login window. Before macOS 10.10, this string could contain only particular information (HostName, SystemVersion, or IPAddress). After macOS 10.10, setting this key to any value will allow the user to click the "time" area of the menu bar to toggle through various computer information values.</string>
 			<key>pfm_name</key>
 			<string>AdminHostInfo</string>
 			<key>pfm_title</key>
@@ -219,7 +219,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enter a message that’s displayed above the login prompt. You might use this to provide a warning about unauthorized use.</string>
+			<string>Enter a message that's displayed above the login prompt. You might use this to provide a warning about unauthorized use.</string>
 			<key>pfm_description_reference</key>
 			<string>Optional. Text to display in the login window.</string>
 			<key>pfm_name</key>
@@ -368,7 +368,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_name</key>
 			<string>HideAdminUsers</string>
 			<key>pfm_title</key>
-			<string>Show Mac computer’s administrator accounts</string>
+			<string>Show Mac computer's administrator accounts</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 			<key>pfm_value_inverted</key>
@@ -400,7 +400,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_name</key>
 			<string>SHOWOTHERUSERS_MANAGED</string>
 			<key>pfm_title</key>
-			<string>Show “Other”</string>
+			<string>Show "Other"</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -566,7 +566,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_description</key>
 			<string>Allows users to use &gt;console at the login window.</string>
 			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Other user will disregard use of the ʼ>consoleʼ special user name.</string>
+			<string>Optional. If set to true, the Other user will disregard use of the '>console' special user name.</string>
 			<key>pfm_name</key>
 			<string>DisableConsoleAccess</string>
 			<key>pfm_title</key>
@@ -628,7 +628,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_description</key>
 			<string>User or group GUIDs of users that are allowed to log in. An asterisk '*' string specifies all users or groups.</string>
 			<key>pfm_description_reference</key>
-			<string>Optional. User or group GUIDs of users that are allowed to log in. An asterisk ʼ*ʼ string specifies all users or groups.</string>
+			<string>Optional. User or group GUIDs of users that are allowed to log in. An asterisk '*' string specifies all users or groups.</string>
 			<key>pfm_name</key>
 			<string>AllowList</string>
 			<key>pfm_subkeys</key>
@@ -684,7 +684,7 @@ Availability: Available in macOS 10.13 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Permit only local users to log in. Network users won’t be allowed to log in.</string>
+			<string>Permit only local users to log in. Network users won't be allowed to log in.</string>
 			<key>pfm_description_reference</key>
 			<string></string>
 			<key>pfm_documentation_source</key>
@@ -712,7 +712,7 @@ Availability: Available in macOS 10.13 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If users are part of a nested workgroup, only the settings of the user’s workgroup are enforced.</string>
+			<string>If users are part of a nested workgroup, only the settings of the user's workgroup are enforced.</string>
 			<key>pfm_description_reference</key>
 			<string></string>
 			<key>pfm_documentation_source</key>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -14,7 +14,7 @@ window payloads may be installed together.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-05-14T11:47:11Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.mcxloginscripts.plist
+++ b/Manifests/ManifestsApple/com.apple.mcxloginscripts.plist
@@ -183,7 +183,7 @@
 			<key>pfm_name</key>
 			<string>skipLoginHook</string>
 			<key>pfm_title</key>
-			<string>Execute the Mac computer’s LoginHook script</string>
+			<string>Execute the Mac computer's LoginHook script</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 			<key>pfm_value_inverted</key>
@@ -260,7 +260,7 @@
 			<key>pfm_name</key>
 			<string>skipLogoutHook</string>
 			<key>pfm_title</key>
-			<string>Execute the Mac computer’s LogoutHook script</string>
+			<string>Execute the Mac computer's LogoutHook script</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 			<key>pfm_value_inverted</key>

--- a/Manifests/ManifestsApple/com.apple.mcxloginscripts.plist
+++ b/Manifests/ManifestsApple/com.apple.mcxloginscripts.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-11-25T12:08:06Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-11-21T16:57:57Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -245,7 +245,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If the device isn’t used for the period of time you specify, it automatically locks. It can be set to lock after 1 to 15 minutes, or turned off with a value of 0. In macOS, this inactivity value is translated to screen-saver settings.</string>
+			<string>If the device isn't used for the period of time you specify, it automatically locks. It can be set to lock after 1 to 15 minutes, or turned off with a value of 0. In macOS, this inactivity value is translated to screen-saver settings.</string>
 			<key>pfm_description_reference</key>
 			<string>The maximum number of minutes for which the device can be idle, without being unlocked by the user, before it gets locked by the system. When this limit is reached, the device is locked and the passcode must be entered. The user can edit this setting, but the value cannot exceed the maxInactivity value. In macOS, this inactivity value is translated to screen-saver settings.</string>
 			<key>pfm_exclude</key>

--- a/Manifests/ManifestsApple/com.apple.security.scep.plist
+++ b/Manifests/ManifestsApple/com.apple.security.scep.plist
@@ -270,7 +270,7 @@
 						<key>%ComputerName%</key>
 						<dict>
 							<key>pfm_description</key>
-							<string>The computer’s name, as set in System Preferences > Sharing.</string>
+							<string>The computer's name, as set in System Preferences > Sharing.</string>
 							<key>pfm_value_placeholder</key>
 							<string>ProfileCreator's MacBook Pro</string>
 							<key>pfm_substitution_source</key>
@@ -279,7 +279,7 @@
 						<key>%HardwareUUID%</key>
 						<dict>
 							<key>pfm_description</key>
-							<string>The computer’s unique identifier.</string>
+							<string>The computer's unique identifier.</string>
 							<key>pfm_value_placeholder</key>
 							<string>7CD8DFF1-70B5-403D-81C2-A41A5F29CFF9</string>
 							<key>pfm_substitution_source</key>
@@ -288,7 +288,7 @@
 						<key>%HostName%</key>
 						<dict>
 							<key>pfm_description</key>
-							<string>The computer’s DNS name, such as mac1.example.com.</string>
+							<string>The computer's DNS name, such as mac1.example.com.</string>
 							<key>pfm_value_placeholder</key>
 							<string>ProfileCreators-MBP.domain.com</string>
 							<key>pfm_substitution_source</key>
@@ -297,7 +297,7 @@
 						<key>%LocalHostName%</key>
 						<dict>
 							<key>pfm_description</key>
-							<string>The computer’s local network name, such as Mac1.local.</string>
+							<string>The computer's local network name, such as Mac1.local.</string>
 							<key>pfm_value_placeholder</key>
 							<string>ProfileCreators-MacBook-Pro</string>
 							<key>pfm_substitution_source</key>
@@ -306,7 +306,7 @@
 						<key>%MACAddress%</key>
 						<dict>
 							<key>pfm_description</key>
-							<string>The computer’s Ethernet (en0) MAC address.</string>
+							<string>The computer's Ethernet (en0) MAC address.</string>
 							<key>pfm_value_placeholder</key>
 							<string>a1:b2:c3:d4:e5:f6</string>
 							<key>pfm_substitution_source</key>
@@ -315,7 +315,7 @@
 						<key>%SerialNumber%</key>
 						<dict>
 							<key>pfm_description</key>
-							<string>The computer’s serial number.</string>
+							<string>The computer's serial number.</string>
 							<key>pfm_value_placeholder</key>
 							<string>C02LZ9Q1CC55</string>
 							<key>pfm_substitution_source</key>
@@ -503,7 +503,7 @@
 								<key>%ComputerName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s name, as set in System Preferences > Sharing.</string>
+									<string>The computer's name, as set in System Preferences > Sharing.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreator's MacBook Pro</string>
 									<key>pfm_substitution_source</key>
@@ -512,7 +512,7 @@
 								<key>%HardwareUUID%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s unique identifier.</string>
+									<string>The computer's unique identifier.</string>
 									<key>pfm_value_placeholder</key>
 									<string>7CD8DFF1-70B5-403D-81C2-A41A5F29CFF9</string>
 									<key>pfm_substitution_source</key>
@@ -521,7 +521,7 @@
 								<key>%HostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s DNS name, such as mac1.example.com.</string>
+									<string>The computer's DNS name, such as mac1.example.com.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MBP.domain.com</string>
 									<key>pfm_substitution_source</key>
@@ -530,7 +530,7 @@
 								<key>%LocalHostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s local network name, such as Mac1.local.</string>
+									<string>The computer's local network name, such as Mac1.local.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MacBook-Pro</string>
 									<key>pfm_substitution_source</key>
@@ -539,7 +539,7 @@
 								<key>%MACAddress%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s Ethernet (en0) MAC address.</string>
+									<string>The computer's Ethernet (en0) MAC address.</string>
 									<key>pfm_value_placeholder</key>
 									<string>a1:b2:c3:d4:e5:f6</string>
 									<key>pfm_substitution_source</key>
@@ -548,7 +548,7 @@
 								<key>%SerialNumber%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s serial number.</string>
+									<string>The computer's serial number.</string>
 									<key>pfm_value_placeholder</key>
 									<string>C02LZ9Q1CC55</string>
 									<key>pfm_substitution_source</key>
@@ -624,7 +624,7 @@
 								<key>%ComputerName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s name, as set in System Preferences > Sharing.</string>
+									<string>The computer's name, as set in System Preferences > Sharing.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreator's MacBook Pro</string>
 									<key>pfm_substitution_source</key>
@@ -633,7 +633,7 @@
 								<key>%HardwareUUID%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s unique identifier.</string>
+									<string>The computer's unique identifier.</string>
 									<key>pfm_value_placeholder</key>
 									<string>7CD8DFF1-70B5-403D-81C2-A41A5F29CFF9</string>
 									<key>pfm_substitution_source</key>
@@ -642,7 +642,7 @@
 								<key>%HostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s DNS name, such as mac1.example.com.</string>
+									<string>The computer's DNS name, such as mac1.example.com.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MBP.domain.com</string>
 									<key>pfm_substitution_source</key>
@@ -651,7 +651,7 @@
 								<key>%LocalHostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s local network name, such as Mac1.local.</string>
+									<string>The computer's local network name, such as Mac1.local.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MacBook-Pro</string>
 									<key>pfm_substitution_source</key>
@@ -660,7 +660,7 @@
 								<key>%MACAddress%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s Ethernet (en0) MAC address.</string>
+									<string>The computer's Ethernet (en0) MAC address.</string>
 									<key>pfm_value_placeholder</key>
 									<string>a1:b2:c3:d4:e5:f6</string>
 									<key>pfm_substitution_source</key>
@@ -669,7 +669,7 @@
 								<key>%SerialNumber%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s serial number.</string>
+									<string>The computer's serial number.</string>
 									<key>pfm_value_placeholder</key>
 									<string>C02LZ9Q1CC55</string>
 									<key>pfm_substitution_source</key>
@@ -745,7 +745,7 @@
 								<key>%ComputerName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s name, as set in System Preferences > Sharing.</string>
+									<string>The computer's name, as set in System Preferences > Sharing.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreator's MacBook Pro</string>
 									<key>pfm_substitution_source</key>
@@ -754,7 +754,7 @@
 								<key>%HardwareUUID%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s unique identifier.</string>
+									<string>The computer's unique identifier.</string>
 									<key>pfm_value_placeholder</key>
 									<string>7CD8DFF1-70B5-403D-81C2-A41A5F29CFF9</string>
 									<key>pfm_substitution_source</key>
@@ -763,7 +763,7 @@
 								<key>%HostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s DNS name, such as mac1.example.com.</string>
+									<string>The computer's DNS name, such as mac1.example.com.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MBP.domain.com</string>
 									<key>pfm_substitution_source</key>
@@ -772,7 +772,7 @@
 								<key>%LocalHostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s local network name, such as Mac1.local.</string>
+									<string>The computer's local network name, such as Mac1.local.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MacBook-Pro</string>
 									<key>pfm_substitution_source</key>
@@ -781,7 +781,7 @@
 								<key>%MACAddress%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s Ethernet (en0) MAC address.</string>
+									<string>The computer's Ethernet (en0) MAC address.</string>
 									<key>pfm_value_placeholder</key>
 									<string>a1:b2:c3:d4:e5:f6</string>
 									<key>pfm_substitution_source</key>
@@ -790,7 +790,7 @@
 								<key>%SerialNumber%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s serial number.</string>
+									<string>The computer's serial number.</string>
 									<key>pfm_value_placeholder</key>
 									<string>C02LZ9Q1CC55</string>
 									<key>pfm_substitution_source</key>
@@ -866,7 +866,7 @@
 								<key>%ComputerName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s name, as set in System Preferences > Sharing.</string>
+									<string>The computer's name, as set in System Preferences > Sharing.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreator's MacBook Pro</string>
 									<key>pfm_substitution_source</key>
@@ -875,7 +875,7 @@
 								<key>%HardwareUUID%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s unique identifier.</string>
+									<string>The computer's unique identifier.</string>
 									<key>pfm_value_placeholder</key>
 									<string>7CD8DFF1-70B5-403D-81C2-A41A5F29CFF9</string>
 									<key>pfm_substitution_source</key>
@@ -884,7 +884,7 @@
 								<key>%HostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s DNS name, such as mac1.example.com.</string>
+									<string>The computer's DNS name, such as mac1.example.com.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MBP.domain.com</string>
 									<key>pfm_substitution_source</key>
@@ -893,7 +893,7 @@
 								<key>%LocalHostName%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s local network name, such as Mac1.local.</string>
+									<string>The computer's local network name, such as Mac1.local.</string>
 									<key>pfm_value_placeholder</key>
 									<string>ProfileCreators-MacBook-Pro</string>
 									<key>pfm_substitution_source</key>
@@ -902,7 +902,7 @@
 								<key>%MACAddress%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s Ethernet (en0) MAC address.</string>
+									<string>The computer's Ethernet (en0) MAC address.</string>
 									<key>pfm_value_placeholder</key>
 									<string>a1:b2:c3:d4:e5:f6</string>
 									<key>pfm_substitution_source</key>
@@ -911,7 +911,7 @@
 								<key>%SerialNumber%</key>
 								<dict>
 									<key>pfm_description</key>
-									<string>The computer’s serial number.</string>
+									<string>The computer's serial number.</string>
 									<key>pfm_value_placeholder</key>
 									<string>C02LZ9Q1CC55</string>
 									<key>pfm_substitution_source</key>

--- a/Manifests/ManifestsApple/com.apple.security.scep.plist
+++ b/Manifests/ManifestsApple/com.apple.security.scep.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.security.smartcard.plist
+++ b/Manifests/ManifestsApple/com.apple.security.smartcard.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-06T03:42:51Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12.4</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.smartcard.plist
+++ b/Manifests/ManifestsApple/com.apple.security.smartcard.plist
@@ -132,7 +132,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If set to integer 1, allows users who aren’t paired with a smart card to log in with password.</string>
+			<string>If set to integer 1, allows users who aren't paired with a smart card to log in with password.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.apple.com/guide/deployment/configure-macos-smart-cardonly-authentication-depfce8de48b/web</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.shareddeviceconfiguration.plist
+++ b/Manifests/ManifestsApple/com.apple.shareddeviceconfiguration.plist
@@ -122,7 +122,7 @@
 			<key>pfm_name</key>
 			<string>IfLostReturnToMessage</string>
 			<key>pfm_title</key>
-			<string>“If lost, return to”</string>
+			<string>"If lost, return to"</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>

--- a/Manifests/ManifestsApple/com.apple.shareddeviceconfiguration.plist
+++ b/Manifests/ManifestsApple/com.apple.shareddeviceconfiguration.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>9.3</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:52Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.systempolicy.control.plist
+++ b/Manifests/ManifestsApple/com.apple.systempolicy.control.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-08-15T04:59:18Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.8</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.systempolicy.control.plist
+++ b/Manifests/ManifestsApple/com.apple.systempolicy.control.plist
@@ -126,7 +126,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If the key is present and has a value of YES, Gatekeeper’s “Mac App Store and identified developers” option is chosen. If the key is present and has a value of NO, Gatekeeper’s “Mac App Store” option is chosen. If EnableAssessment is not true, this key has no effect.</string>
+			<string>If the key is present and has a value of YES, Gatekeeper's "Mac App Store and identified developers” option is chosen. If the key is present and has a value of NO, Gatekeeper's "Mac App Store” option is chosen. If EnableAssessment is not true, this key has no effect.</string>
 			<key>pfm_name</key>
 			<string>AllowIdentifiedDevelopers</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.webClip.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.webClip.managed.plist
@@ -145,9 +145,9 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The URL that’s displayed when users open the Web Clip. The URL must begin with HTTP or HTTPS</string>
+			<string>The URL that's displayed when users open the Web Clip. The URL must begin with HTTP or HTTPS</string>
 			<key>pfm_description_reference</key>
-			<string>The URL that the Web Clip should open when clicked. The URL must begin with HTTP or HTTPS or it wonʼt work.</string>
+			<string>The URL that the Web Clip should open when clicked. The URL must begin with HTTP or HTTPS or it won't work.</string>
 			<key>pfm_name</key>
 			<string>URL</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.webClip.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.webClip.managed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-06-08T12:04:37Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-11-11T15:23:11Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -281,7 +281,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If present, these URLs are added to the browser’s bookmarks, and the user is not allowed to visit any sites other than these. The number of these URLs should be limited to about 500.</string>
+			<string>If present, these URLs are added to the browser's bookmarks, and the user is not allowed to visit any sites other than these. The number of these URLs should be limited to about 500.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -366,7 +366,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If present, these URLs are added to the browser’s bookmarks, and the user is not allowed to visit any sites other than these. The number of these URLs should be limited to about 500.</string>
+			<string>If present, these URLs are added to the browser's bookmarks, and the user is not allowed to visit any sites other than these. The number of these URLs should be limited to about 500.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-08-10T10:42:06Z</date>
+	<date>2021-12-22T05:49:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -295,7 +295,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Users won’t have an opportunity to join networks that require agreements or other information prior to network access.</string>
+			<string>Users won't have an opportunity to join networks that require agreements or other information prior to network access.</string>
 			<key>pfm_ios_min</key>
 			<string>10.0</string>
 			<key>pfm_name</key>
@@ -804,7 +804,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enter a series of digits corresponding to one of the service provider’s Passpoint network.</string>
+			<string>Enter a series of digits corresponding to one of the service provider's Passpoint network.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>


### PR DESCRIPTION
Smart quotes and apostrophes are now just regular double or single quotes