### PR TITLE
Add scheme to front of example URL in com.profilecreator.developer.substitution_variables

### DIFF
--- a/Manifests/ManagedPreferencesDeveloper/com.profilecreator.developer.substitution_variables.plist
+++ b/Manifests/ManagedPreferencesDeveloper/com.profilecreator.developer.substitution_variables.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:49Z</date>
+	<date>2021-12-22T09:41:49Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -114,9 +114,9 @@
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		
+
 		<!-- Custom Keys -->
-		
+
 		<dict>
 			<key>pfm_description</key>
 			<string>TextField with substitution variables: &lt;&lt;serial&gt;&gt;</string>
@@ -125,7 +125,7 @@
 			<key>pfm_macos_min</key>
 			<string>10.13.1</string>
 			<key>pfm_documentation_url</key>
-			<string>www.apple.com</string>
+			<string>https://www.apple.com</string>
 			<key>pfm_substitution_variables</key>
 			<dict>
 				<key>&lt;&lt;serial&gt;&gt;</key>


### PR DESCRIPTION
This is currently the only documentation URL without a scheme, so adjusting this will allow consistent linting of manifests in the future.