### PR TITLE
Adjust range list values for AirServer audio buffer size

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
+++ b/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
@@ -507,6 +507,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
+++ b/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-05T19:00:12Z</date>
+	<date>2021-12-22T18:49:45Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -335,25 +335,25 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_range_list</key>
 			<array>
 				<real>0.0</real>
-				<real>0.050000000000000003</real>
-				<real>0.10000000000000001</real>
-				<real>0.15000000000000002</real>
-				<real>0.20000000000000001</real>
+				<real>0.05</real>
+				<real>0.1</real>
+				<real>0.15</real>
+				<real>0.2</real>
 				<real>0.25</real>
-				<real>0.30000000000000004</real>
-				<real>0.35000000000000003</real>
-				<real>0.40000000000000002</real>
-				<real>0.45000000000000001</real>
+				<real>0.3</real>
+				<real>0.35</real>
+				<real>0.4</real>
+				<real>0.45</real>
 				<real>0.5</real>
-				<real>0.55000000000000004</real>
-				<real>0.60000000000000009</real>
-				<real>0.65000000000000002</real>
-				<real>0.70000000000000007</real>
+				<real>0.55</real>
+				<real>0.6000000000000001</real>
+				<real>0.65</real>
+				<real>0.7000000000000001</real>
 				<real>0.75</real>
-				<real>0.80000000000000004</real>
-				<real>0.85000000000000009</real>
-				<real>0.90000000000000002</real>
-				<real>0.95000000000000007</real>
+				<real>0.8</real>
+				<real>0.8500000000000001</real>
+				<real>0.9</real>
+				<real>0.9500000000000001</real>
 				<real>1</real>
 			</array>
 			<key>pfm_range_list_titles</key>
@@ -507,6 +507,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
I used [plistwatch](https://github.com/catilac/plistwatch) to capture the numeric values for audio buffer size in the latest version (7.2.7) of AirServer for Mac. The values are slightly different than what's in the current manifest:

```% ./plistwatch
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '1'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.9500000000000001"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.9"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.8500000000000001"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.8"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.75"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.7000000000000001"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.65"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.6000000000000001"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.55"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.5"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.45"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.4"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.35"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.3"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.25"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.2"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.15"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.1"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '"0.05"'
defaults write "com.pratikkumar.airserver-mac" "com.airserverapp.audioBufferSize2" '0'
```

This PR adjusts the manifest to match the seen values.