### PR TITLE
Add pre-commit configuration that catches common issues with preference manifests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
     # Please use commit hash instead of tag
-    rev: 7d3cd4229a473ce0e797ef0bab821c6e838ef662
+    rev: c668a2da8236a983ffaa0761fbbe31f90c0f5822
     hooks:
       - id: check-preference-manifests
         exclude: "^Resources/|^Manifests/ManagedPreferencesDeveloper/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: v1.12.0
+    hooks:
+      - id: check-preference-manifests
+        exclude: "^Resources/|^Manifests/ManagedPreferencesDeveloper/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
       - id: check-preference-manifests
         exclude: "^Resources/|^Manifests/ManagedPreferencesDeveloper/"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
-    rev: v1.12.1
+    # Please use commit hash instead of tag
+    rev: 7d3cd4229a473ce0e797ef0bab821c6e838ef662
     hooks:
       - id: check-preference-manifests
         exclude: "^Resources/|^Manifests/ManagedPreferencesDeveloper/"

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -6369,6 +6369,8 @@ If you choose the value 'pac_script' as 'ProxyMode', the 'ProxyPacUrl' and 'Prox
 							<string>array</string>
 						</dict>
 					</array>
+					<key>pfm_type</key>
+					<string>array</string>
 				</dict>
 			</array>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T06:06:42Z</date>
+	<date>2021-12-23T00:31:31Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -6503,6 +6503,8 @@ If you choose the value 'pac_script' as 'ProxyMode', the 'ProxyPacUrl' and 'Prox
 							<string>array</string>
 						</dict>
 					</array>
+					<key>pfm_type</key>
+					<string>array</string>
 				</dict>
 			</array>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T06:06:42Z</date>
+	<date>2021-12-23T00:31:31Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
@@ -679,9 +679,7 @@
 					<key>pfm_name</key>
 					<string>ChangePasswordItem</string>
 					<key>pfm_subkeys</key>
-					<array>
-						<dict/>
-					</array>
+					<array/>
 					<key>pfm_title</key>
 					<string>ChangePasswordItem</string>
 					<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2021-12-23T00:31:31Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>


### PR DESCRIPTION
## Summary

This PR adds a configuration used by the [pre-commit](https://pre-commit.com/) framework, meant for catching common issues before they get committed and pushed. The configured `check-preference-manifests` hook is hosted in my [pre-commit-macadmin](https://github.com/homebysix/pre-commit-macadmin) repository, and the source code for the hook can be found [here](https://github.com/homebysix/pre-commit-macadmin/blob/main/pre_commit_hooks/check_preference_manifests.py).

## Installation

Upon merging this PR, frequent contributors should be encouraged to do the following in order to use the pre-commit configuration.

1. [Install pre-commit](https://pre-commit.com/#install).
2. Activate the hooks within this repo:
    ```
    cd ~/src/ProfileManifests
    pre-commit install
    ```

From that point on, every commit will be checked automatically.

The hooks will not run unless the above actions are taken, so this PR will not affect automated processes or the GitHub Actions configuration.

## Benefits

I've found pre-commit to be extremely helpful when managing repositories with large numbers of files in the same format (e.g. AutoPkg recipes, Munki pkginfo files, Python files, etc). I gave an introduction to pre-commit at [this 2019 PSU MacAdmins session](https://www.youtube.com/watch?v=mYKEM9Gplks&t=1940s) and in [this post](https://www.elliotjordan.com/posts/pre-commit-01-intro/).

Here are a few examples of errors that my pre-commit hook can catch:

### Plist syntax issues

A manifest with this syntax error:
```
<key>pfm_description</string>
<string>Configures available Share menu options</string>
```
Will produce this error when a commit attempt is made:
```
% git commit -m "test commit"
Check Apple Preference Manifests.........................................Failed
- hook id: check-preference-manifests
- exit code: 1

Manifests/ManifestsApple/com.apple.ShareKitHelper.plist: plist parsing error: mismatched tag: line 5, column 23
```

### Missing required keys

A manifest with missing title, domain, or description keys at the top level:
```
<key>pfm_domain</key>
<string></string>
```
Will produce this error when a commit attempt is made:
```
% git commit -m "test commit"
Check Apple Preference Manifests.........................................Failed
- hook id: check-preference-manifests
- exit code: 1

Manifests/ManagedPreferencesApplications/com.apple.logic10.plist: <root dict> missing required key pfm_domain
```

### Incorrect manifest format version

A manifest with `pfm_format_version` other than `1`:
```
<key>pfm_format_version</key>
<integer>3</integer>
```
Will produce this error when a commit attempt is made:
```
% git commit -m "test commit"
Check Apple Preference Manifests.........................................Failed
- hook id: check-preference-manifests
- exit code: 1

Manifests/ManagedPreferencesApplications/com.apple.logic10.plist: pfm_format_version should be 1, not 3 (https://github.com/ProfileCreator/ProfileManifests/wiki/Manifest-Format-Versions)
```

### Incorrect key types

A manifest with an incorrect key type:
```
<key>pfm_platforms</key>
<string>macOS</string>
```
Will produce this error when a commit attempt is made:
```
% git commit -m "test commit"
Check Apple Preference Manifests.........................................Failed
- hook id: check-preference-manifests
- exit code: 1

Manifests/ManagedPreferencesApplications/com.barebones.bbedit.plist: manifest key pfm_platforms should be type <class 'list'>, not type <class 'str'>
```

### Incorrect list item types

A manifest with an incorrectly typed list item:
```
<key>pfm_range_list_titles</key>
<array>
	<integer>0</integer>
	<integer>1</integer>
	<integer>5</integer>
	<integer>10</integer>
	<integer>50</integer>
	<integer>100</integer>
	<integer>500</integer>
</array>
```
Will produce this error when a commit attempt is made:
```
% git commit -m "test commit"
Check Apple Preference Manifests.........................................Failed
- hook id: check-preference-manifests
- exit code: 1

Manifests/ManagedPreferencesApple/com.apple.safari.plist: "pfm_range_list_titles" items should be type <class 'str'>, not type <class 'int'>
```

### Default value doesn't match setting type

A manifest with an incorrectly typed default item:
```
<dict>
	<key>pfm_name</key>
	<string>TMAFirstLaunchVersion</string>
	<key>pfm_type</key>
	<string>integer</string>
	<key>pfm_default</key>
	<false />
</dict>
```
Will produce this error when a commit attempt is made:
```
% git commit -m "test commit"
Check Apple Preference Manifests.........................................Failed
- hook id: check-preference-manifests
- exit code: 1

Manifests/ManagedPreferencesApple/com.apple.iWork.Numbers.plist: pfm_default value for TMAFirstLaunchVersion should be type <class 'int'>, not type <class 'bool'>
```

## Successful check output

When a commit is done and all tests pass, the output will look similar to this:

```
% git commit -m "test commit" testfile.plist
Check Apple Preference Manifests.........................................Passed
[testbranch 66c33bc] test commit
 1 file changed, 0 insertions(+), 0 deletions(-)
 create mode 100644 testfile.plist
```

## Forcing a check of all files

For troubleshooting or quality control purposes, you can initiate a check of all manifests using `pre-commit run --all-files`.

## Opting out per-commit

If you need to intentionally bypass the checks for a single commit, you can use `git commit -n` or `git commit --no-verify`.

## Hook contributions welcome

My [pre-commit-macadmin](https://github.com/homebysix/pre-commit-macadmin) repo is still evolving, and I'd love feedback and/or contributions if anybody is interested in adding more tests that manifest files should pass in order to be committed.