### PR TITLE
Add new/updated MAU update channel names

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2022-01-04T10:14:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -176,26 +176,32 @@
 			<key>pfm_default</key>
 			<string>Production</string>
 			<key>pfm_description</key>
-			<string>Set the update channel that is used to check for updates.</string>
-			<key>pfm_description_reference</key>
-			<string>Controls which audience and update channel to use for retrieving product updates. By default, users are placed in the ‘production' channel which receives the highestquality updates around the middle of each month. Through the UI, users can join the Insider Slow (Exeternal) and Insider Fast (InsiderFast) program to receive more frequent updates at slightly lower quality. IT administrators can also set a Custom channel when deploying an internal MAU server.</string>
+			<string>Set the update channel that is used to check for updates. Click the documentation link for more information about which channel to use.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/docs/MAU_38.pdf</string>
+			<string>https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/mac-updates?view=o365-worldwide#set-the-channel-name</string>
 			<key>pfm_name</key>
 			<string>ChannelName</string>
+			<key>pfm_note</key>
+			<string>Microsoft AutoUpdate pre 4.29 had different update channel names. While these still work post 4.29, it's recommended to use the new values if using MAU 4.29 or later</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>Production</string>
+				<string>Current</string>
 				<string>External</string>
+				<string>Preview</string>
 				<string>InsiderFast</string>
+				<string>Beta</string>
 				<string>Custom</string>
 			</array>
 			<key>pfm_range_list_titles</key>
 			<array>
-				<string>Production</string>
-				<string>Office Insider Slow: "External"</string>
-				<string>Office Insider Fast: "InsiderFast"</string>
-				<string>Custom</string>
+				<string>Production (pre MAU 4.29)</string>
+				<string>Current (MAU 4.29+)</string>
+				<string>Office Insider Slow: "External" (pre MAU 4.29)</string>
+				<string>Preview (MAU 4.29+)</string>
+				<string>Office Insider Fast: "InsiderFast" (pre MAU 4.29)</string>
+				<string>Beta (MAU 4.29+)</string>
+				<string>Custom (pre MAU 4.29)</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Channel Name</string>


### PR DESCRIPTION
Closes #373

- Update documentation URL
- Add pfm_range_list, leaving old names for compatibility
- Update pfm_range_list_titles to clearly differentiate pre 4.29 and 4.29 and later channel options