### PR TITLE
Delete the Disable UAC Prompt Key in us.zoom.config.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/us.zoom.config.plist
+++ b/Manifests/ManagedPreferencesApplications/us.zoom.config.plist
@@ -323,18 +323,6 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
-			<key>pfm_description</key>
-			<string>Disable UAC prompt when logging into Zoom</string>
-			<key>pfm_name</key>
-			<string>AddFWException</string>
-			<key>pfm_title</key>
-			<string>Disable UAC Prompt</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
 			<string>Remember the last login type used</string>


### PR DESCRIPTION
Delete the Disable UAC Prompt Key.
macOS has no UAC. UAC is the Windows User Account Control.
https://docs.microsoft.com/en-us/windows/security/identity-protection/user-account-control/how-user-account-control-works

In the Zoom docs you can also not find a UAC key for macOS.
https://support.zoom.us/hc/en-us/articles/115001799006-Mass-deploying-preconfigured-settings-for-Mac