### PR TITLE
Removed note on Custom channel

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -201,7 +201,7 @@
 				<string>Preview (MAU 4.29+)</string>
 				<string>Office Insider Fast: "InsiderFast" (pre MAU 4.29)</string>
 				<string>Beta (MAU 4.29+)</string>
-				<string>Custom (pre MAU 4.29)</string>
+				<string>Custom</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Channel Name</string>


### PR DESCRIPTION
Custom is a valid channel name for all versions of MAU.