### PR TITLE
DigiDNA Restrictions tweaks

### DIFF
--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -2100,6 +2100,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -238,7 +238,6 @@ The payload organization for a payload need not match the payload organization i
 					<string>allowAirPrint</string>
 					<string>allowAirPrintCredentialsStorage</string>
 					<string>allowAirPrintiBeaconDiscovery</string>
-					<string>forceAirPlayOutgoingRequestsPairingPassword</string>
 					<string>forceAirPrintTrustedTLSRequirement</string>
 				</array>
 				<key>Apps</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-01-12T12:36:32Z</date>
+	<date>2022-01-13T11:05:45Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -143,6 +143,7 @@ The payload organization for a payload need not match the payload organization i
 			<array>
 				<string>General</string>
 				<string>AirDrop</string>
+				<string>AirPlay</string>
 				<string>AirPrint</string>
 				<string>Apps</string>
 				<string>Classroom</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2022-01-12T12:36:32Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-01-13T11:05:45Z</date>
+	<date>2022-01-17T08:55:06Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -313,6 +313,7 @@ The payload organization for a payload need not match the payload organization i
 					<string>allowPasswordAutoFill</string>
 					<string>allowPasswordProximityRequests</string>
 					<string>allowPasswordSharing</string>
+					<string>enforcedFingerprintTimeout</string>
 				</array>
 				<key>Siri</key>
 				<array>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2021-12-22T05:49:22Z</date>
+		<date>2022-01-17T09:15:12Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>
@@ -175,6 +175,7 @@ A profile can consist of payloads with different version numbers. For example, c
 						<string>allowPasswordAutoFill</string>
 						<string>allowPasswordProximityRequests</string>
 						<string>allowPasswordSharing</string>
+						<string>enforcedFingerprintTimeout</string>
 					</array>
 					<key>Updates</key>
 					<array>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2022-01-17T09:15:12Z</date>
+		<date>2022-01-19T03:34:39Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>
@@ -726,8 +726,6 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string/>
 				<key>pfm_description_reference</key>
 				<string>If false, disables saving a screenshot of the display and capturing a screen recording. It also disables the Classroom app from observing remote screens. Available in iOS 4 and later, and macOS 10.14.4 and later. Also available for user enrollment.</string>
-				<key>pfm_documentation_url</key>
-				<string>https://developer.apple.com/documentation/devicemanagement/restrictions</string>
 				<key>pfm_macos_min</key>
 				<string>10.14.4</string>
 				<key>pfm_name</key>
@@ -744,8 +742,6 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>If 'Allow Screenshots and Screen Recording' is set to 'false', it also overrides this preference and prevents the Classroom app from observing remote screens.</string>
 				<key>pfm_description_reference</key>
 				<string>If false, disables remote screen observation by the Classroom app. Nest this key beneath allowScreenShot as a subrestriction. If allowScreenShot is set to false, the Classroom app doesn't observe remote screens. Required a supervised device until iOS 13 and macOS 10.15. Available in iOS 12 and later, and macOS 10.14.4 and later.</string>
-				<key>pfm_documentation_url</key>
-				<string>https://developer.apple.com/documentation/devicemanagement/restrictions</string>
 				<key>pfm_macos_min</key>
 				<string>10.14.4</string>
 				<key>pfm_name</key>


### PR DESCRIPTION
This PR makes two miscellaneous tweaks in the Restrictions manifest:
* Removes redundant appearance of key name in segment
*  Adds default value to key