### PR TITLE
Update com.microsoft.autoupdate2.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -465,20 +465,15 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<string>https://apple.lib.utah.edu/jan-2022-macadmins-meeting/</string>
 			<key>pfm_name</key>
 			<string>UpdaterOptimization</string>
-			<key>pfm_title</key>
-			<string>Updater Optimization</string>
-			<key>pfm_type</key>
-			<string>string</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>Size</string>
 				<string>CPU</string>
 			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Size</string>
-				<string>CPU</string>
-			</array>
+			<key>pfm_title</key>
+			<string>Updater Optimization</string>
+			<key>pfm_type</key>
+			<string>string</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-01-06T05:49:35Z</date>
+	<date>2022-01-23T11:48:44Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -131,6 +131,7 @@
 					<string>UpdateCheckFrequency</string>
 					<string>UpdateDeadline.DaysBeforeForcedQuit</string>
 					<string>UpdateDeadline.StartAutomaticUpdates</string>
+					<string>UpdaterOptimization</string>
 				</array>
 				<key>Applications</key>
 				<array>
@@ -173,6 +174,22 @@
 		<dict>
 			<key>pfm_app_min</key>
 			<string>3.3</string>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<true/>
+							<key>pfm_target</key>
+							<string>ManifestServer</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_default</key>
 			<string>Production</string>
 			<key>pfm_description</key>
@@ -436,6 +453,32 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 			<string>integer</string>
 			<key>pfm_value_unit</key>
 			<string>Days</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>4.40</string>
+			<key>pfm_default</key>
+			<string>Size</string>
+			<key>pfm_description</key>
+			<string>If you have a security agent like CrowdStrike installed and updates cause beachballs; Set UpdaterOptimization preference to "CPU" to prefer file-based delta updates (instead of binary deltas). The trade-off will be larger monthly updates.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://apple.lib.utah.edu/jan-2022-macadmins-meeting/</string>
+			<key>pfm_name</key>
+			<string>UpdaterOptimization</string>
+			<key>pfm_title</key>
+			<string>Updater Optimization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>Size</string>
+				<string>CPU</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Size</string>
+				<string>CPU</string>
+			</array>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -1005,12 +1048,12 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 					<array>
 						<dict>
 							<key>pfm_default</key>
-							<string>TEAM01</string>
+							<string>TEAMS10</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
 							<array>
-								<string>TEAM01</string>
+								<string>TEAMS10</string>
 							</array>
 							<key>pfm_require</key>
 							<string>always</string>
@@ -1861,12 +1904,12 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 					<array>
 						<dict>
 							<key>pfm_default</key>
-							<string>TEAM01</string>
+							<string>TEAMS10</string>
 							<key>pfm_name</key>
 							<string>Application ID</string>
 							<key>pfm_range_list</key>
 							<array>
-								<string>TEAM01</string>
+								<string>TEAMS10</string>
 							</array>
 							<key>pfm_require</key>
 							<string>always</string>
@@ -2166,6 +2209,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>13</integer>
+	<integer>14</integer>
 </dict>
 </plist>


### PR DESCRIPTION
• Adds new `UpdaterOptimization` key
• Changes Teams ID to new value
• Sets `ChannelName` to be required if `ManifestServer` is configured