### PR TITLE
DigiDNA self-exclusion removed in the Passcode manifest

### DIFF
--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -164,22 +164,6 @@
 			<string>Minimum number of characters a passcode can contain.</string>
 			<key>pfm_description_reference</key>
 			<string>The minimum overall length of the passcode. This parameter is independent of the also optional minComplexChars argument.</string>
-			<key>pfm_exclude</key>
-			<array>
-				<dict>
-					<key>pfm_target_conditions</key>
-					<array>
-						<dict>
-							<key>pfm_range_list</key>
-							<array>
-								<integer>0</integer>
-							</array>
-							<key>pfm_target</key>
-							<string>minLength</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
 			<key>pfm_name</key>
 			<string>minLength</string>
 			<key>pfm_range_max</key>
@@ -198,22 +182,6 @@
 			<string>Minimum number of non-alphanumeric characters the passcode must contain.</string>
 			<key>pfm_description_reference</key>
 			<string>The minimum number of complex characters that a passcode must contain. A complex character is a character other than a number or a letter, such as &amp; % $ #.</string>
-			<key>pfm_exclude</key>
-			<array>
-				<dict>
-					<key>pfm_target_conditions</key>
-					<array>
-						<dict>
-							<key>pfm_range_list</key>
-							<array>
-								<integer>0</integer>
-							</array>
-							<key>pfm_target</key>
-							<string>minComplexChars</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
 			<key>pfm_name</key>
 			<string>minComplexChars</string>
 			<key>pfm_range_max</key>
@@ -248,22 +216,6 @@
 			<string>If the device isn't used for the period of time you specify, it automatically locks. It can be set to lock after 1 to 15 minutes, or turned off with a value of 0. In macOS, this inactivity value is translated to screen-saver settings.</string>
 			<key>pfm_description_reference</key>
 			<string>The maximum number of minutes for which the device can be idle, without being unlocked by the user, before it gets locked by the system. When this limit is reached, the device is locked and the passcode must be entered. The user can edit this setting, but the value cannot exceed the maxInactivity value. In macOS, this inactivity value is translated to screen-saver settings.</string>
-			<key>pfm_exclude</key>
-			<array>
-				<dict>
-					<key>pfm_target_conditions</key>
-					<array>
-						<dict>
-							<key>pfm_range_list</key>
-							<array>
-								<integer>0</integer>
-							</array>
-							<key>pfm_target</key>
-							<string>maxInactivity</string>
-						</dict>
-					</array>
-				</dict>
-			</array>
 			<key>pfm_name</key>
 			<string>maxInactivity</string>
 			<key>pfm_range_max</key>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2022-01-27T01:33:49Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -263,6 +263,8 @@
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>


### PR DESCRIPTION
This PR removes all conditionals that caused keys to exclude themselves in the Passcode manifest.

I believe that these conditions were some sort of an early attempt at preventing write-out of default values, at least in the case of `minLength` and `minComplexChars`. Since we do not prevent admins from reaffirming defaults, the conditions should be removed.

As per `maxInactivity` which has no default value, I can venture a guess that the condition was probably left there by mistake after copy-and-pasting, since it incorrectly prevented a value of `0` from being set on the key.

As a bonus, I've updated the conditional on `maxFailedAttempts` to explicitly represent requirement.