### PR TITLE
DigiDNA MCX Wi-Fi Managed correction

### DIFF
--- a/Manifests/ManifestsApple/com.apple.MCX-WiFiManagedSettings.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-WiFiManagedSettings.plist
@@ -3,28 +3,28 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Wi-Fi Managed Settings</string>
+	<string>Use this section to define managed Wi-Fi settings</string>
 	<key>pfm_documentation_url</key>
 	<string>https://developer.apple.com/documentation/devicemanagement/wifimanagedsettings</string>
 	<key>pfm_domain</key>
-	<string>com.apple.MCX.WiFi</string>
+	<string>com.apple.MCX</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-06-26T00:59:53Z</date>
+	<date>2022-02-14T03:34:53Z</date>
+	<key>pfm_macos_min</key>
+	<string>10.9</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
 	</array>
-	<key>pfm_macos_min</key>
-	<string>10.9</string>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Configures Managed Wi-Fi settings</string>
+			<string>Configures managed Wi-Fi settings</string>
 			<key>pfm_description</key>
 			<string>Description of the payload</string>
 			<key>pfm_name</key>
@@ -50,7 +50,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.MCX.WiFi</string>
+			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
 			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
 			<key>pfm_name</key>
@@ -64,7 +64,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.MCX.WiFi</string>
+			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
 			<string>The type of the payload, a reverse dns string</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
The Wi-Fi Managed Settings manifest uses an incorrect preference domain when it should just be a subdomain of the greater MCX domain.

This PR renames the manifest file according to convention used on other subdomains of MCX and corrects the information inside the manifest to match. It also contains two minor rewording tweaks.