### PR TITLE
DigiDNA Restrictions macOS update

### DIFF
--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>combined</string>
 		<key>pfm_last_modified</key>
-		<date>2022-02-02T09:29:41Z</date>
+		<date>2022-02-14T04:18:56Z</date>
 		<key>pfm_note</key>
 		<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 		<key>pfm_platforms</key>
@@ -316,6 +316,20 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>allowActivityContinuation</string>
 				<key>pfm_title</key>
 				<string>Allow Handoff</string>
+				<key>pfm_type</key>
+				<string>boolean</string>
+			</dict>
+			<dict>
+				<key>pfm_default</key>
+				<true/>
+				<key>pfm_description</key>
+				<string></string>
+				<key>pfm_macos_min</key>
+				<string>10.13</string>
+				<key>pfm_name</key>
+				<string>allowDiagnosticSubmission</string>
+				<key>pfm_title</key>
+				<string>Allow submitting diagnostic and usage data to Apple</string>
 				<key>pfm_type</key>
 				<string>boolean</string>
 			</dict>
@@ -1141,6 +1155,6 @@ Available in macOS 11 and later.</string>
 		<key>pfm_unique</key>
 		<true/>
 		<key>pfm_version</key>
-		<integer>8</integer>
+		<integer>9</integer>
 	</dict>
 </plist>


### PR DESCRIPTION
This PR adds `allowDiagnosticSubmission`, which was already available on iOS, to macOS too.