### PR TITLE
DigiDNA Dock Hot Corners

### DIFF
--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2022-02-17T05:19:53Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -1215,6 +1215,374 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_type_input</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Action to be taken when the pointer enters the top left corner of the screen</string>
+		    <key>pfm_name</key>
+		    <string>wvous-tl-corner</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>5</integer>
+				<integer>6</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+				<integer>7</integer>
+				<integer>12</integer>
+				<integer>11</integer>
+				<integer>14</integer>
+				<integer>10</integer>
+				<integer>13</integer>
+				<integer>0</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Start Screen Saver</string>
+				<string>Disable Screen Saver</string>
+				<string>Mission Control</string>
+				<string>Application Windows</string>
+				<string>Desktop</string>
+				<string>Dashboard (removed from macOS 10.15)</string>
+				<string>Notification Center</string>
+				<string>Launchpad</string>
+				<string>Quick Note (introduced on macOS 12.0)</string>
+				<string>Put Display to Sleep</string>
+				<string>Lock Screen</string>
+				<string>No Action</string>
+			</array>
+		    <key>pfm_title</key>
+		    <string>Top Left Hot Corner Action</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Modifier keys required to activate the top left hot corner</string>
+		    <key>pfm_name</key>
+		    <string>wvous-tl-modifier</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1048576</integer>
+				<integer>1572864</integer>
+				<integer>1835008</integer>
+				<integer>1966080</integer>
+				<integer>1703936</integer>
+				<integer>1310720</integer>
+				<integer>1441792</integer>
+				<integer>1179648</integer>
+				<integer>524288</integer>
+				<integer>786432</integer>
+				<integer>917504</integer>
+				<integer>655360</integer>
+				<integer>262144</integer>
+				<integer>393216</integer>
+				<integer>131072</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>None</string>
+				<string>Command</string>
+				<string>Command+Option</string>
+				<string>Command+Option+Control</string>
+				<string>Command+Option+Control+Shift</string>
+				<string>Command+Option+Shift</string>
+				<string>Command+Control</string>
+				<string>Command+Control+Shift</string>
+				<string>Command+Shift</string>
+				<string>Option</string>
+				<string>Option+Control</string>
+				<string>Option+Control+Shift</string>
+				<string>Option+Shift</string>
+				<string>Control</string>
+				<string>Control+Shift</string>
+				<string>Shift</string>
+			</array>
+		    <key>pfm_title</key>
+		    <string>Top Left Hot Corner Modifier</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Action to be taken when the pointer enters the top right corner of the screen</string>
+		    <key>pfm_name</key>
+		    <string>wvous-tr-corner</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>5</integer>
+				<integer>6</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+				<integer>7</integer>
+				<integer>12</integer>
+				<integer>11</integer>
+				<integer>14</integer>
+				<integer>10</integer>
+				<integer>13</integer>
+				<integer>0</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Start Screen Saver</string>
+				<string>Disable Screen Saver</string>
+				<string>Mission Control</string>
+				<string>Application Windows</string>
+				<string>Desktop</string>
+				<string>Dashboard (removed from macOS 10.15)</string>
+				<string>Notification Center</string>
+				<string>Launchpad</string>
+				<string>Quick Note (introduced on macOS 12.0)</string>
+				<string>Put Display to Sleep</string>
+				<string>Lock Screen</string>
+				<string>No Action</string>
+			</array>
+			<key>pfm_title</key>
+		    <string>Top Right Hot Corner Action</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Modifier keys required to activate the top right hot corner</string>
+		    <key>pfm_name</key>
+		    <string>wvous-tr-modifier</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1048576</integer>
+				<integer>1572864</integer>
+				<integer>1835008</integer>
+				<integer>1966080</integer>
+				<integer>1703936</integer>
+				<integer>1310720</integer>
+				<integer>1441792</integer>
+				<integer>1179648</integer>
+				<integer>524288</integer>
+				<integer>786432</integer>
+				<integer>917504</integer>
+				<integer>655360</integer>
+				<integer>262144</integer>
+				<integer>393216</integer>
+				<integer>131072</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>None</string>
+				<string>Command</string>
+				<string>Command+Option</string>
+				<string>Command+Option+Control</string>
+				<string>Command+Option+Control+Shift</string>
+				<string>Command+Option+Shift</string>
+				<string>Command+Control</string>
+				<string>Command+Control+Shift</string>
+				<string>Command+Shift</string>
+				<string>Option</string>
+				<string>Option+Control</string>
+				<string>Option+Control+Shift</string>
+				<string>Option+Shift</string>
+				<string>Control</string>
+				<string>Control+Shift</string>
+				<string>Shift</string>
+			</array>
+		    <key>pfm_title</key>
+		    <string>Top Right Hot Corner Modifier</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Action to be taken when the pointer enters the bottom left corner of the screen</string>
+		    <key>pfm_name</key>
+		    <string>wvous-bl-corner</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>5</integer>
+				<integer>6</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+				<integer>7</integer>
+				<integer>12</integer>
+				<integer>11</integer>
+				<integer>14</integer>
+				<integer>10</integer>
+				<integer>13</integer>
+				<integer>0</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Start Screen Saver</string>
+				<string>Disable Screen Saver</string>
+				<string>Mission Control</string>
+				<string>Application Windows</string>
+				<string>Desktop</string>
+				<string>Dashboard (removed from macOS 10.15)</string>
+				<string>Notification Center</string>
+				<string>Launchpad</string>
+				<string>Quick Note (introduced on macOS 12.0)</string>
+				<string>Put Display to Sleep</string>
+				<string>Lock Screen</string>
+				<string>No Action</string>
+			</array>
+			<key>pfm_title</key>
+		    <string>Bottom Left Hot Corner Action</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Modifier keys required to activate the bottom left hot corner</string>
+		    <key>pfm_name</key>
+		    <string>wvous-bl-modifier</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1048576</integer>
+				<integer>1572864</integer>
+				<integer>1835008</integer>
+				<integer>1966080</integer>
+				<integer>1703936</integer>
+				<integer>1310720</integer>
+				<integer>1441792</integer>
+				<integer>1179648</integer>
+				<integer>524288</integer>
+				<integer>786432</integer>
+				<integer>917504</integer>
+				<integer>655360</integer>
+				<integer>262144</integer>
+				<integer>393216</integer>
+				<integer>131072</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>None</string>
+				<string>Command</string>
+				<string>Command+Option</string>
+				<string>Command+Option+Control</string>
+				<string>Command+Option+Control+Shift</string>
+				<string>Command+Option+Shift</string>
+				<string>Command+Control</string>
+				<string>Command+Control+Shift</string>
+				<string>Command+Shift</string>
+				<string>Option</string>
+				<string>Option+Control</string>
+				<string>Option+Control+Shift</string>
+				<string>Option+Shift</string>
+				<string>Control</string>
+				<string>Control+Shift</string>
+				<string>Shift</string>
+			</array>
+		    <key>pfm_title</key>
+		    <string>Bottom Left Hot Corner Modifier</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Action to be taken when the pointer enters the bottom right corner of the screen</string>
+		    <key>pfm_name</key>
+		    <string>wvous-br-corner</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>5</integer>
+				<integer>6</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+				<integer>7</integer>
+				<integer>12</integer>
+				<integer>11</integer>
+				<integer>14</integer>
+				<integer>10</integer>
+				<integer>13</integer>
+				<integer>0</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Start Screen Saver</string>
+				<string>Disable Screen Saver</string>
+				<string>Mission Control</string>
+				<string>Application Windows</string>
+				<string>Desktop</string>
+				<string>Dashboard (removed from macOS 10.15)</string>
+				<string>Notification Center</string>
+				<string>Launchpad</string>
+				<string>Quick Note (introduced on macOS 12.0)</string>
+				<string>Put Display to Sleep</string>
+				<string>Lock Screen</string>
+				<string>No Action</string>
+			</array>
+		    <key>pfm_title</key>
+		    <string>Bottom Right Hot Corner Action</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
+		<dict>
+		    <key>pfm_default</key>
+		    <integer>0</integer>
+		    <key>pfm_description</key>
+		    <string>Modifier keys required to activate the bottom right hot corner</string>
+		    <key>pfm_name</key>
+		    <string>wvous-br-modifier</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1048576</integer>
+				<integer>1572864</integer>
+				<integer>1835008</integer>
+				<integer>1966080</integer>
+				<integer>1703936</integer>
+				<integer>1310720</integer>
+				<integer>1441792</integer>
+				<integer>1179648</integer>
+				<integer>524288</integer>
+				<integer>786432</integer>
+				<integer>917504</integer>
+				<integer>655360</integer>
+				<integer>262144</integer>
+				<integer>393216</integer>
+				<integer>131072</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>None</string>
+				<string>Command</string>
+				<string>Command+Option</string>
+				<string>Command+Option+Control</string>
+				<string>Command+Option+Control+Shift</string>
+				<string>Command+Option+Shift</string>
+				<string>Command+Control</string>
+				<string>Command+Control+Shift</string>
+				<string>Command+Shift</string>
+				<string>Option</string>
+				<string>Option+Control</string>
+				<string>Option+Control+Shift</string>
+				<string>Option+Shift</string>
+				<string>Control</string>
+				<string>Control+Shift</string>
+				<string>Shift</string>
+			</array>
+		    <key>pfm_title</key>
+		    <string>Bottom Right Hot Corner Modifier</string>
+		    <key>pfm_type</key>
+		    <string>integer</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -1226,6 +1594,6 @@ The payload organization for a payload need not match the payload organization i
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -1216,104 +1216,12 @@ The payload organization for a payload need not match the payload organization i
 			<string>boolean</string>
 		</dict>
 		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Action to be taken when the pointer enters the top left corner of the screen</string>
-		    <key>pfm_name</key>
-		    <string>wvous-tl-corner</string>
-			<key>pfm_range_list</key>
-			<array>
-				<integer>5</integer>
-				<integer>6</integer>
-				<integer>2</integer>
-				<integer>3</integer>
-				<integer>4</integer>
-				<integer>7</integer>
-				<integer>12</integer>
-				<integer>11</integer>
-				<integer>14</integer>
-				<integer>10</integer>
-				<integer>13</integer>
-				<integer>0</integer>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Start Screen Saver</string>
-				<string>Disable Screen Saver</string>
-				<string>Mission Control</string>
-				<string>Application Windows</string>
-				<string>Desktop</string>
-				<string>Dashboard (removed from macOS 10.15)</string>
-				<string>Notification Center</string>
-				<string>Launchpad</string>
-				<string>Quick Note (introduced on macOS 12.0)</string>
-				<string>Put Display to Sleep</string>
-				<string>Lock Screen</string>
-				<string>No Action</string>
-			</array>
-		    <key>pfm_title</key>
-		    <string>Top Left Hot Corner Action</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
-		</dict>
-		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Modifier keys required to activate the top left hot corner</string>
-		    <key>pfm_name</key>
-		    <string>wvous-tl-modifier</string>
-			<key>pfm_range_list</key>
-			<array>
-				<integer>0</integer>
-				<integer>1048576</integer>
-				<integer>1572864</integer>
-				<integer>1835008</integer>
-				<integer>1966080</integer>
-				<integer>1703936</integer>
-				<integer>1310720</integer>
-				<integer>1441792</integer>
-				<integer>1179648</integer>
-				<integer>524288</integer>
-				<integer>786432</integer>
-				<integer>917504</integer>
-				<integer>655360</integer>
-				<integer>262144</integer>
-				<integer>393216</integer>
-				<integer>131072</integer>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>None</string>
-				<string>Command</string>
-				<string>Command+Option</string>
-				<string>Command+Option+Control</string>
-				<string>Command+Option+Control+Shift</string>
-				<string>Command+Option+Shift</string>
-				<string>Command+Control</string>
-				<string>Command+Control+Shift</string>
-				<string>Command+Shift</string>
-				<string>Option</string>
-				<string>Option+Control</string>
-				<string>Option+Control+Shift</string>
-				<string>Option+Shift</string>
-				<string>Control</string>
-				<string>Control+Shift</string>
-				<string>Shift</string>
-			</array>
-		    <key>pfm_title</key>
-		    <string>Top Left Hot Corner Modifier</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
-		</dict>
-		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Action to be taken when the pointer enters the top right corner of the screen</string>
-		    <key>pfm_name</key>
-		    <string>wvous-tr-corner</string>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Action to be taken when the pointer enters the top left corner of the screen</string>
+			<key>pfm_name</key>
+			<string>wvous-tl-corner</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>5</integer>
@@ -1345,17 +1253,17 @@ The payload organization for a payload need not match the payload organization i
 				<string>No Action</string>
 			</array>
 			<key>pfm_title</key>
-		    <string>Top Right Hot Corner Action</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
+			<string>Top Left Hot Corner Action</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Modifier keys required to activate the top right hot corner</string>
-		    <key>pfm_name</key>
-		    <string>wvous-tr-modifier</string>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Modifier keys required to activate the top left hot corner</string>
+			<key>pfm_name</key>
+			<string>wvous-tl-modifier</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>0</integer>
@@ -1394,18 +1302,18 @@ The payload organization for a payload need not match the payload organization i
 				<string>Control+Shift</string>
 				<string>Shift</string>
 			</array>
-		    <key>pfm_title</key>
-		    <string>Top Right Hot Corner Modifier</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
+			<key>pfm_title</key>
+			<string>Top Left Hot Corner Modifier</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Action to be taken when the pointer enters the bottom left corner of the screen</string>
-		    <key>pfm_name</key>
-		    <string>wvous-bl-corner</string>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Action to be taken when the pointer enters the top right corner of the screen</string>
+			<key>pfm_name</key>
+			<string>wvous-tr-corner</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>5</integer>
@@ -1437,17 +1345,17 @@ The payload organization for a payload need not match the payload organization i
 				<string>No Action</string>
 			</array>
 			<key>pfm_title</key>
-		    <string>Bottom Left Hot Corner Action</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
+			<string>Top Right Hot Corner Action</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Modifier keys required to activate the bottom left hot corner</string>
-		    <key>pfm_name</key>
-		    <string>wvous-bl-modifier</string>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Modifier keys required to activate the top right hot corner</string>
+			<key>pfm_name</key>
+			<string>wvous-tr-modifier</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>0</integer>
@@ -1486,18 +1394,18 @@ The payload organization for a payload need not match the payload organization i
 				<string>Control+Shift</string>
 				<string>Shift</string>
 			</array>
-		    <key>pfm_title</key>
-		    <string>Bottom Left Hot Corner Modifier</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
+			<key>pfm_title</key>
+			<string>Top Right Hot Corner Modifier</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Action to be taken when the pointer enters the bottom right corner of the screen</string>
-		    <key>pfm_name</key>
-		    <string>wvous-br-corner</string>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Action to be taken when the pointer enters the bottom left corner of the screen</string>
+			<key>pfm_name</key>
+			<string>wvous-bl-corner</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>5</integer>
@@ -1528,18 +1436,18 @@ The payload organization for a payload need not match the payload organization i
 				<string>Lock Screen</string>
 				<string>No Action</string>
 			</array>
-		    <key>pfm_title</key>
-		    <string>Bottom Right Hot Corner Action</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
+			<key>pfm_title</key>
+			<string>Bottom Left Hot Corner Action</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
-		    <key>pfm_default</key>
-		    <integer>0</integer>
-		    <key>pfm_description</key>
-		    <string>Modifier keys required to activate the bottom right hot corner</string>
-		    <key>pfm_name</key>
-		    <string>wvous-br-modifier</string>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Modifier keys required to activate the bottom left hot corner</string>
+			<key>pfm_name</key>
+			<string>wvous-bl-modifier</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>0</integer>
@@ -1578,10 +1486,102 @@ The payload organization for a payload need not match the payload organization i
 				<string>Control+Shift</string>
 				<string>Shift</string>
 			</array>
-		    <key>pfm_title</key>
-		    <string>Bottom Right Hot Corner Modifier</string>
-		    <key>pfm_type</key>
-		    <string>integer</string>
+			<key>pfm_title</key>
+			<string>Bottom Left Hot Corner Modifier</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Action to be taken when the pointer enters the bottom right corner of the screen</string>
+			<key>pfm_name</key>
+			<string>wvous-br-corner</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>5</integer>
+				<integer>6</integer>
+				<integer>2</integer>
+				<integer>3</integer>
+				<integer>4</integer>
+				<integer>7</integer>
+				<integer>12</integer>
+				<integer>11</integer>
+				<integer>14</integer>
+				<integer>10</integer>
+				<integer>13</integer>
+				<integer>0</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Start Screen Saver</string>
+				<string>Disable Screen Saver</string>
+				<string>Mission Control</string>
+				<string>Application Windows</string>
+				<string>Desktop</string>
+				<string>Dashboard (removed from macOS 10.15)</string>
+				<string>Notification Center</string>
+				<string>Launchpad</string>
+				<string>Quick Note (introduced on macOS 12.0)</string>
+				<string>Put Display to Sleep</string>
+				<string>Lock Screen</string>
+				<string>No Action</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Bottom Right Hot Corner Action</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>0</integer>
+			<key>pfm_description</key>
+			<string>Modifier keys required to activate the bottom right hot corner</string>
+			<key>pfm_name</key>
+			<string>wvous-br-modifier</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>0</integer>
+				<integer>1048576</integer>
+				<integer>1572864</integer>
+				<integer>1835008</integer>
+				<integer>1966080</integer>
+				<integer>1703936</integer>
+				<integer>1310720</integer>
+				<integer>1441792</integer>
+				<integer>1179648</integer>
+				<integer>524288</integer>
+				<integer>786432</integer>
+				<integer>917504</integer>
+				<integer>655360</integer>
+				<integer>262144</integer>
+				<integer>393216</integer>
+				<integer>131072</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>None</string>
+				<string>Command</string>
+				<string>Command+Option</string>
+				<string>Command+Option+Control</string>
+				<string>Command+Option+Control+Shift</string>
+				<string>Command+Option+Shift</string>
+				<string>Command+Control</string>
+				<string>Command+Control+Shift</string>
+				<string>Command+Shift</string>
+				<string>Option</string>
+				<string>Option+Control</string>
+				<string>Option+Control+Shift</string>
+				<string>Option+Shift</string>
+				<string>Control</string>
+				<string>Control+Shift</string>
+				<string>Shift</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Bottom Right Hot Corner Modifier</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>


### PR DESCRIPTION
This PR adds the Hot Corner preferences to the Dock manifest.

As neither iMazing Profile Editor nor ProfileCreator currently have a dedicated way of handling bit masks, and thanks to the narrow range of mask options, I've elected to implement the modifier keys as ranged lists.

Note that while the PR makes a small progress towards #295, it doesn't fully address it.