### PR TITLE
Change Fast User Switching default

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -11,7 +11,7 @@
 		<key>pfm_format_version</key>
 		<integer>1</integer>
 		<key>pfm_last_modified</key>
-		<date>2020-08-03T18:02:02Z</date>
+		<date>2022-03-02T21:18:44Z</date>
 		<key>pfm_platforms</key>
 		<array>
 			<string>macOS</string>
@@ -137,7 +137,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			</dict>
 			<dict>
 				<key>pfm_default</key>
-				<true/>
+				<false/>
 				<key>pfm_description</key>
 				<string>If set to false, fast user switching is disabled.</string>
 				<key>pfm_description_reference</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -139,7 +139,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				<key>pfm_default</key>
 				<false/>
 				<key>pfm_description</key>
-				<string>If set to false, fast user switching is disabled.</string>
+				<string>If set to true, fast user switching is enabled.</string>
 				<key>pfm_description_reference</key>
 				<string>Optional. If set to false, fast user switching is disabled. Defaults to true.</string>
 				<key>pfm_documentation_url</key>


### PR DESCRIPTION
Discussion in Slack made us realize that the default behavior of `MultipleSessionEnabled` is actually `false` contrary to Apple's documentation.