### PR TITLE
Add note about Fast User Switching default behavior

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -11,7 +11,7 @@
 		<key>pfm_format_version</key>
 		<integer>1</integer>
 		<key>pfm_last_modified</key>
-		<date>2020-08-03T18:02:02Z</date>
+		<date>2022-03-03T16:35:44Z</date>
 		<key>pfm_platforms</key>
 		<array>
 			<string>macOS</string>
@@ -136,8 +136,6 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>Seconds</string>
 			</dict>
 			<dict>
-				<key>pfm_default</key>
-				<true/>
 				<key>pfm_description</key>
 				<string>If set to false, fast user switching is disabled.</string>
 				<key>pfm_description_reference</key>
@@ -148,6 +146,8 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>10.12</string>
 				<key>pfm_name</key>
 				<string>MultipleSessionEnabled</string>
+				<key>pfm_note</key>
+				<string>The default behavior of this key varies depending on the number of users on a computer and how they were created: System Preferences, MDM, etc.</string>
 				<key>pfm_title</key>
 				<string>Enable Fast User Switching</string>
 				<key>pfm_type</key>


### PR DESCRIPTION
and removes the `pfm_default` setting based on discussion in Slack.

Wasn't sure if this should include a `pfm_version` version bump or not.