### PR TITLE
added new install-or-defer keys

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-02-23T07:10:46Z</date>
+	<date>2022-06-24T22:27:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -167,21 +167,101 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>5.0</string>
+			<string>5.0.4</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log.</string>
+			<string>Whether to suppress the persistent alert to run updates.</string>
 			<key>pfm_description_reference</key>
-			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log. Defaults to false, instead writing all output to the system log for live diagnostics.</string>
+			<string>Whether to suppress the persistent alert to run updates. Defaults to False. If set to True, clicking the install button will only launch the Software Update pane without displaying a persistent alert to upgrade, until the deadline date is reached.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
-			<string>DiagnosticLog</string>
+			<string>DisablePostInstallAlert</string>
 			<key>pfm_title</key>
-			<string>Enable Diagnostic Log</string>
+			<string>Disable Post-Install Alert</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>5.0</string>
+			<key>pfm_description</key>
+			<string>File path to a logo that will be used in messaging.</string>
+			<key>pfm_description_reference</key>
+			<string>File path to a logo that will be used in messaging. Defaults to the Software Update icon. Recommend 512px, PNG format.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
+			<key>pfm_name</key>
+			<string>MessagingLogo</string>
+			<key>pfm_note</key>
+			<string>Recommend 512px, PNG format.</string>
+			<key>pfm_title</key>
+			<string>Messaging Logo</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>5.0</string>
+			<key>pfm_default</key>
+			<string>IT</string>
+			<key>pfm_description</key>
+			<string>Contact information for technical support included in messaging alerts.</string>
+			<key>pfm_description_reference</key>
+			<string>Contact information for technical support included in messaging alerts. Defaults to "IT". Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support").</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
+			<key>pfm_name</key>
+			<string>SupportContact</string>
+			<key>pfm_note</key>
+			<string>Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support").</string>
+			<key>pfm_title</key>
+			<string>Support Contact</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>5.0.5</string>
+			<key>pfm_default</key>
+			<integer>14400</integer>
+			<key>pfm_description</key>
+			<string>Number of seconds between when the user clicks "Defer" and the next prompt appears.</string>
+			<key>pfm_description_reference</key>
+			<string>Number of seconds between when the user clicks "Defer" and the next prompt appears. Defaults to 14400 (4 hours). This value must be less than the MaxDeferralTime value.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
+			<key>pfm_name</key>
+			<string>DeferralPeriod</string>
+			<key>pfm_note</key>
+			<string>This value must be less than the MaxDeferralTime value.</string>
+			<key>pfm_title</key>
+			<string>Deferral Period</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>seconds</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>5.0.5</string>
+			<key>pfm_default</key>
+			<integer>300</integer>
+			<key>pfm_description</key>
+			<string>Number of seconds to wait between attempting a soft restart and forcing a restart.</string>
+			<key>pfm_description_reference</key>
+			<string>Number of seconds to wait between attempting a soft restart and forcing a restart. Defaults to 300 (5 minutes).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
+			<key>pfm_name</key>
+			<string>HardRestartDelay</string>
+			<key>pfm_title</key>
+			<string>Hard Restart Delay</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>seconds</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -205,19 +285,25 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>5.0</string>
+			<string>5.0.5</string>
+			<key>pfm_default</key>
+			<integer>3600</integer>
 			<key>pfm_description</key>
-			<string>File path to a logo that will be used in messaging. Recommend 512px, PNG format.</string>
+			<string>Number of seconds to wait before timing out the Install or Defer prompt.</string>
 			<key>pfm_description_reference</key>
-			<string>File path to a logo that will be used in messaging. Recommend 512px, PNG format. Defaults to the Software Update icon.</string>
+			<string>Number of seconds to wait before timing out the Install or Defer prompt. Defaults to 3600 (1 hour). This value must be less than the DeferralPeriod value.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
-			<string>MessagingLogo</string>
+			<string>PromptTimeout</string>
+			<key>pfm_note</key>
+			<string>This value must be less than the DeferralPeriod value.</string>
 			<key>pfm_title</key>
-			<string>Messaging Logo</string>
+			<string>Prompt Timeout</string>
 			<key>pfm_type</key>
-			<string>string</string>
+			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>seconds</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -239,21 +325,25 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>5.0</string>
+			<string>5.0.5</string>
 			<key>pfm_default</key>
-			<string>IT</string>
+			<integer>600</integer>
 			<key>pfm_description</key>
-			<string>Contact information for technical support included in messaging alerts.</string>
+			<string>Number of seconds to wait between displaying the "install updates" message and applying updates, then attempting a soft restart.</string>
 			<key>pfm_description_reference</key>
-			<string>Contact information for technical support included in messaging alerts. Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support"). Defaults to "IT".</string>
+			<string>Number of seconds to wait between displaying the "install updates" message and applying updates, then attempting a soft restart. Defaults to 600 (10 minutes).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
-			<string>SupportContact</string>
+			<string>UpdateDelay</string>
+			<key>pfm_note</key>
+			<string>This value must be less than the DeferralPeriod value.</string>
 			<key>pfm_title</key>
-			<string>Support Contact</string>
+			<string>Update Delay</string>
 			<key>pfm_type</key>
-			<string>string</string>
+			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>seconds</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -395,6 +485,42 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>5.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log.</string>
+			<key>pfm_description_reference</key>
+			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log. If undefined or set to false, the script writes all output to the system log for live diagnostics.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
+			<key>pfm_name</key>
+			<string>DiagnosticLog</string>
+			<key>pfm_title</key>
+			<string>Enable Diagnostic Log</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>5.0.3</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Whether to prompt users to run updates manually via System Preferences.</string>
+			<key>pfm_description_reference</key>
+			<string>Whether to prompt users to run updates manually via System Preferences. This is always the behavior on Apple Silicon Macs and cannot be overridden. If undefined or set to false on Intel Macs, the script triggers updates via scripted softwareupdate commands.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
+			<key>pfm_name</key>
+			<string>ManualUpdates</string>
+			<key>pfm_title</key>
+			<string>Manual Updates</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -405,6 +531,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-06-24T22:27:00Z</date>
+	<date>2022-07-11T16:34:00Z</date>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
@@ -130,8 +130,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The label of the install button.</string>
 			<key>pfm_description_reference</key>
 			<string>The label of the install button. Defaults to "Install". Keep this string short since jamfHelper will cut off longer button labels.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>InstallButtonLabel</string>
 			<key>pfm_note</key>
@@ -152,8 +150,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The label of the defer button.</string>
 			<key>pfm_description_reference</key>
 			<string>The label of the defer button. Defaults to "Defer". Keep this string short since jamfHelper will cut off longer button labels.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DeferButtonLabel</string>
 			<key>pfm_note</key>
@@ -174,8 +170,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to suppress the persistent alert to run updates.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to suppress the persistent alert to run updates. Defaults to False. If set to True, clicking the install button will only launch the Software Update pane without displaying a persistent alert to upgrade, until the deadline date is reached.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DisablePostInstallAlert</string>
 			<key>pfm_title</key>
@@ -190,8 +184,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>File path to a logo that will be used in messaging.</string>
 			<key>pfm_description_reference</key>
 			<string>File path to a logo that will be used in messaging. Defaults to the Software Update icon. Recommend 512px, PNG format.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>MessagingLogo</string>
 			<key>pfm_note</key>
@@ -210,8 +202,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Contact information for technical support included in messaging alerts.</string>
 			<key>pfm_description_reference</key>
 			<string>Contact information for technical support included in messaging alerts. Defaults to "IT". Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support").</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>SupportContact</string>
 			<key>pfm_note</key>
@@ -230,8 +220,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds between when the user clicks "Defer" and the next prompt appears.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds between when the user clicks "Defer" and the next prompt appears. Defaults to 14400 (4 hours). This value must be less than the MaxDeferralTime value.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DeferralPeriod</string>
 			<key>pfm_note</key>
@@ -252,8 +240,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds to wait between attempting a soft restart and forcing a restart.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds to wait between attempting a soft restart and forcing a restart. Defaults to 300 (5 minutes).</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>HardRestartDelay</string>
 			<key>pfm_title</key>
@@ -272,8 +258,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds between the first script run and the updates being enforced.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds between the first script run and the updates being enforced. Defaults to 259200 (3 days).</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>MaxDeferralTime</string>
 			<key>pfm_title</key>
@@ -292,8 +276,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds to wait before timing out the Install or Defer prompt.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds to wait before timing out the Install or Defer prompt. Defaults to 3600 (1 hour). This value must be less than the DeferralPeriod value.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>PromptTimeout</string>
 			<key>pfm_note</key>
@@ -314,8 +296,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to bypass deferral time entirely and skip straight to update enforcement.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to bypass deferral time entirely and skip straight to update enforcement (useful for script testing purposes). Defaults to false.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>SkipDeferral</string>
 			<key>pfm_title</key>
@@ -332,8 +312,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds to wait between displaying the "install updates" message and applying updates, then attempting a soft restart.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds to wait between displaying the "install updates" message and applying updates, then attempting a soft restart. Defaults to 600 (10 minutes).</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>UpdateDelay</string>
 			<key>pfm_note</key>
@@ -352,8 +330,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The hour that a workday starts in your organization.</string>
 			<key>pfm_description_reference</key>
 			<string>The hour that a workday starts in your organization. This value must be an integer between 0 and 22, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>WorkdayStartHour</string>
 			<key>pfm_note</key>
@@ -422,8 +398,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The hour that a workday ends in your organization.</string>
 			<key>pfm_description_reference</key>
 			<string>The hour that a workday ends in your organization. This value must be an integer between 1 and 23, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>WorkdayEndHour</string>
 			<key>pfm_note</key>
@@ -494,8 +468,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log. If undefined or set to false, the script writes all output to the system log for live diagnostics.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DiagnosticLog</string>
 			<key>pfm_title</key>
@@ -512,8 +484,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to prompt users to run updates manually via System Preferences.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to prompt users to run updates manually via System Preferences. This is always the behavior on Apple Silicon Macs and cannot be overridden. If undefined or set to false on Intel Macs, the script triggers updates via scripted softwareupdate commands.</string>
-			<key>pfm_documentation_url</key>
-			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>ManualUpdates</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
@@ -130,6 +130,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The label of the install button.</string>
 			<key>pfm_description_reference</key>
 			<string>The label of the install button. Defaults to "Install". Keep this string short since jamfHelper will cut off longer button labels.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>InstallButtonLabel</string>
 			<key>pfm_note</key>
@@ -150,6 +152,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The label of the defer button.</string>
 			<key>pfm_description_reference</key>
 			<string>The label of the defer button. Defaults to "Defer". Keep this string short since jamfHelper will cut off longer button labels.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DeferButtonLabel</string>
 			<key>pfm_note</key>
@@ -170,6 +174,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to suppress the persistent alert to run updates.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to suppress the persistent alert to run updates. Defaults to False. If set to True, clicking the install button will only launch the Software Update pane without displaying a persistent alert to upgrade, until the deadline date is reached.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DisablePostInstallAlert</string>
 			<key>pfm_title</key>
@@ -184,6 +190,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>File path to a logo that will be used in messaging.</string>
 			<key>pfm_description_reference</key>
 			<string>File path to a logo that will be used in messaging. Defaults to the Software Update icon. Recommend 512px, PNG format.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>MessagingLogo</string>
 			<key>pfm_note</key>
@@ -202,6 +210,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Contact information for technical support included in messaging alerts.</string>
 			<key>pfm_description_reference</key>
 			<string>Contact information for technical support included in messaging alerts. Defaults to "IT". Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support").</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>SupportContact</string>
 			<key>pfm_note</key>
@@ -220,6 +230,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds between when the user clicks "Defer" and the next prompt appears.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds between when the user clicks "Defer" and the next prompt appears. Defaults to 14400 (4 hours). This value must be less than the MaxDeferralTime value.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DeferralPeriod</string>
 			<key>pfm_note</key>
@@ -240,6 +252,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds to wait between attempting a soft restart and forcing a restart.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds to wait between attempting a soft restart and forcing a restart. Defaults to 300 (5 minutes).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>HardRestartDelay</string>
 			<key>pfm_title</key>
@@ -258,6 +272,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds between the first script run and the updates being enforced.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds between the first script run and the updates being enforced. Defaults to 259200 (3 days).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>MaxDeferralTime</string>
 			<key>pfm_title</key>
@@ -276,6 +292,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds to wait before timing out the Install or Defer prompt.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds to wait before timing out the Install or Defer prompt. Defaults to 3600 (1 hour). This value must be less than the DeferralPeriod value.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>PromptTimeout</string>
 			<key>pfm_note</key>
@@ -296,6 +314,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to bypass deferral time entirely and skip straight to update enforcement.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to bypass deferral time entirely and skip straight to update enforcement (useful for script testing purposes). Defaults to false.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>SkipDeferral</string>
 			<key>pfm_title</key>
@@ -312,6 +332,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Number of seconds to wait between displaying the "install updates" message and applying updates, then attempting a soft restart.</string>
 			<key>pfm_description_reference</key>
 			<string>Number of seconds to wait between displaying the "install updates" message and applying updates, then attempting a soft restart. Defaults to 600 (10 minutes).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>UpdateDelay</string>
 			<key>pfm_note</key>
@@ -330,6 +352,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The hour that a workday starts in your organization.</string>
 			<key>pfm_description_reference</key>
 			<string>The hour that a workday starts in your organization. This value must be an integer between 0 and 22, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>WorkdayStartHour</string>
 			<key>pfm_note</key>
@@ -398,6 +422,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>The hour that a workday ends in your organization.</string>
 			<key>pfm_description_reference</key>
 			<string>The hour that a workday ends in your organization. This value must be an integer between 1 and 23, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>WorkdayEndHour</string>
 			<key>pfm_note</key>
@@ -468,6 +494,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to write to a persistent log file at /var/log/install-or-defer.log. If undefined or set to false, the script writes all output to the system log for live diagnostics.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>DiagnosticLog</string>
 			<key>pfm_title</key>
@@ -484,6 +512,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Whether to prompt users to run updates manually via System Preferences.</string>
 			<key>pfm_description_reference</key>
 			<string>Whether to prompt users to run updates manually via System Preferences. This is always the behavior on Apple Silicon Macs and cannot be overridden. If undefined or set to false on Intel Macs, the script triggers updates via scripted softwareupdate commands.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mpanighetti/install-or-defer#configuration-profile</string>
 			<key>pfm_name</key>
 			<string>ManualUpdates</string>
 			<key>pfm_title</key>


### PR DESCRIPTION
- added new install-or-defer keys from versions 5.0.3, 5.0.4, and 5.0.5 (see https://github.com/mpanighetti/install-or-defer#configuration-profile for current docs)
- reorganized keys to match docs (now grouped by category)