### PR TITLE
Update de.fau.rrze.NetworkShareMounter.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
+++ b/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
@@ -22,7 +22,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-98-30T14:50:00Z</date>
+	<date>2022-09-30T14:50:00Z</date>
 	<key>pfm_title</key>
 	<string>Network Share Mounter</string>
 	<key>pfm_unique</key>

--- a/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
+++ b/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
@@ -22,7 +22,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-06-09T14:28:00Z</date>
+	<date>2022-98-30T14:50:00Z</date>
 	<key>pfm_title</key>
 	<string>Network Share Mounter</string>
 	<key>pfm_unique</key>

--- a/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
+++ b/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
@@ -163,7 +163,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_description</key>
 			<string>Array with all network shares. Example: smb://filer.your.domain/share
-Note: %USERNAME% which will be replaced with the login name of the current user.</string>
+Note: %USERNAME% will be replaced with the login name of the current user.</string>
 			<key>pfm_name</key>
 			<string>networkShares</string>
 			<key>pfm_subkeys</key>
@@ -172,7 +172,7 @@ Note: %USERNAME% which will be replaced with the login name of the current user.
 					<key>pfm_type</key>
 					<string>string</string>
 					<key>pfm_format</key>
-					<string>^smb:\/\/\S*$</string>
+					<string>^smb:\/\/\S*\/.+$</string>
 					<key>pfm_value_placeholder</key>
 					<string>smb://filer.your.domain/share</string>
 				</dict>


### PR DESCRIPTION
Change regex value for network shares to allow spaces in the pathname after the server address