### PR TITLE
Add EnableAppleLogin Preference to Zoom payload

### DIFF
--- a/Manifests/ManagedPreferencesApplications/us.zoom.config.plist
+++ b/Manifests/ManagedPreferencesApplications/us.zoom.config.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-01-30T18:07:22Z</date>
+	<date>2022-10-04T16:22:26Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -159,6 +159,7 @@
 					<string>Login_Domain</string>
 					<string>NoGoogle</string>
 					<string>NoFacebook</string>
+					<string>EnableAppleLogin</string>
 					<string>NoSSO</string>
 					<string>PresentInMeetingOption</string>
 					<string>PresentToRoomOptimizeVideo</string>
@@ -350,6 +351,18 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Allow access to Apple login option</string>
+			<key>pfm_name</key>
+			<string>EnableAppleLogin</string>
+			<key>pfm_title</key>
+			<string>Allow Apple Login</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
 			<string>Disable the SSO login option</string>
@@ -419,7 +432,7 @@
 			<string>Set Default Web Domain</string>
 			<key>pfm_type</key>
 			<string>string</string>
-		</dict>	
+		</dict>
 		<dict>
 			<key>pfm_description</key>
 			<string>Set the email address domain that users can login with</string>
@@ -1723,6 +1736,6 @@ Audio: 8803</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Added the following preference (EnableAppleLogin) to Zoom payload. Information on preference can be found [here](https://support.zoom.us/hc/en-us/articles/115001799006-Mass-Deployment-with-Preconfigured-Settings-for-Mac)
