### PR TITLE
Brave-specific Preference Fix

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-23T00:31:31Z</date>
+	<date>2022-10-31T23:14:14Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -434,6 +434,9 @@
 					<string>WebRtcLocalIpsAllowedUrls</string>
 					<string>WebRtcUdpPortRange</string>
 					<string>TorDisabled</string>
+					<string>IPFSEnabled</string>
+					<string>BraveRewardsDisabled</string>
+					<string>BraveWalletDisabled</string>
 				</array>
 				<key>Native Messaging</key>
 				<array>
@@ -5781,10 +5784,10 @@ Managed bookmarks are not synced to the user account and can't be modified by ex
 			<string>array</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<integer>32</integer>
 			<key>pfm_app_min</key>
 			<string>14</string>
+			<key>pfm_default</key>
+			<integer>32</integer>
 			<key>pfm_description</key>
 			<string>Specifies the maximal number of simultaneous connections to the proxy server.</string>
 			<key>pfm_description_reference</key>
@@ -9632,13 +9635,15 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<integer>0</integer>
+			<false/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>TorDisabled</string>
 			<key>pfm_range_list</key>
 			<array>
-				<integer>0</integer>
-				<integer>1</integer>
+				<false/>
+				<true/>
 			</array>
 			<key>pfm_range_list_titles</key>
 			<array>
@@ -9648,7 +9653,73 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 			<key>pfm_title</key>
 			<string>Disable Tor</string>
 			<key>pfm_type</key>
-			<string>integer</string>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
+			<key>pfm_name</key>
+			<string>IPFSEnabled</string>
+			<key>pfm_range_list</key>
+			<array>
+				<false/>
+				<true/>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>IPFS Disabled</string>
+				<string>IPFS Enabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Enable IPFS</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
+			<key>pfm_name</key>
+			<string>BraveRewardsDisabled</string>
+			<key>pfm_range_list</key>
+			<array>
+				<false/>
+				<true/>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Brave Rewards Enabled</string>
+				<string>Brave Rewards Disabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Disable Brave Rewards</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
+			<key>pfm_name</key>
+			<string>BraveWalletDisabled</string>
+			<key>pfm_range_list</key>
+			<array>
+				<false/>
+				<true/>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Brave Wallet Enabled</string>
+				<string>Brave Wallet Disabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Disable Brave Wallet</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-10-31T23:14:14Z</date>
+	<date>2022-11-02T00:25:52Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -9636,20 +9636,12 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>false = Tor Enabled; true = Tor Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>TorDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Tor Enabled</string>
-				<string>Tor Disabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Tor</string>
 			<key>pfm_type</key>
@@ -9658,20 +9650,12 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>false = IPFS Disabled; true = IPFS Enabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>IPFSEnabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>IPFS Disabled</string>
-				<string>IPFS Enabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Enable IPFS</string>
 			<key>pfm_type</key>
@@ -9680,20 +9664,12 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>false = Brave Rewards Enabled; true = Brave Rewards Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveRewardsDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Brave Rewards Enabled</string>
-				<string>Brave Rewards Disabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Brave Rewards</string>
 			<key>pfm_type</key>
@@ -9702,20 +9678,12 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>false = Brave Wallet Enabled; true = Brave Wallet Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveWalletDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Brave Wallet Enabled</string>
-				<string>Brave Wallet Disabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Brave Wallet</string>
 			<key>pfm_type</key>

--- a/Resources/ChromeToBrave/com.brave.Browser-specific.plist
+++ b/Resources/ChromeToBrave/com.brave.Browser-specific.plist
@@ -7,20 +7,12 @@
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>false = Tor Enabled; true = Tor Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>TorDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Tor Enabled</string>
-				<string>Tor Disabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Tor</string>
 			<key>pfm_type</key>
@@ -29,20 +21,12 @@
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>false = IPFS Disabled; true = IPFS Enabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>IPFSEnabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>IPFS Disabled</string>
-				<string>IPFS Enabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Enable IPFS</string>
 			<key>pfm_type</key>
@@ -51,20 +35,12 @@
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>false = Brave Rewards Enabled; true = Brave Rewards Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveRewardsDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Brave Rewards Enabled</string>
-				<string>Brave Rewards Disabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Brave Rewards</string>
 			<key>pfm_type</key>
@@ -73,20 +49,12 @@
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>false = Brave Wallet Enabled; true = Brave Wallet Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveWalletDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<false/>
-				<true/>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Brave Wallet Enabled</string>
-				<string>Brave Wallet Disabled</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Brave Wallet</string>
 			<key>pfm_type</key>

--- a/Resources/ChromeToBrave/com.brave.Browser-specific.plist
+++ b/Resources/ChromeToBrave/com.brave.Browser-specific.plist
@@ -6,13 +6,15 @@
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<integer>0</integer>
+			<false/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>TorDisabled</string>
 			<key>pfm_range_list</key>
 			<array>
-				<integer>0</integer>
-				<integer>1</integer>
+				<false/>
+				<true/>
 			</array>
 			<key>pfm_range_list_titles</key>
 			<array>
@@ -22,7 +24,73 @@
 			<key>pfm_title</key>
 			<string>Disable Tor</string>
 			<key>pfm_type</key>
-			<string>integer</string>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
+			<key>pfm_name</key>
+			<string>IPFSEnabled</string>
+			<key>pfm_range_list</key>
+			<array>
+				<false/>
+				<true/>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>IPFS Disabled</string>
+				<string>IPFS Enabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Enable IPFS</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
+			<key>pfm_name</key>
+			<string>BraveRewardsDisabled</string>
+			<key>pfm_range_list</key>
+			<array>
+				<false/>
+				<true/>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Brave Rewards Enabled</string>
+				<string>Brave Rewards Disabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Disable Brave Rewards</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_documentation_url</key>
+			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
+			<key>pfm_name</key>
+			<string>BraveWalletDisabled</string>
+			<key>pfm_range_list</key>
+			<array>
+				<false/>
+				<true/>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Brave Wallet Enabled</string>
+				<string>Brave Wallet Disabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Disable Brave Wallet</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 	</array>
 	<key>Updates</key>


### PR DESCRIPTION
Originally communicated in Jamf manifest mirror by @dustinjlandgraf: https://github.com/Jamf-Custom-Profile-Schemas/ProfileManifestsMirror/pull/14

Admittedly, could only confirm 3 of the 4 listed prefs on https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy are boolean as `BraveWalletDisabled` wouldn't display in brave://policy, even after quitting Brave and running `sudo killall cfprefsd`.

<img width="1200" alt="Screen Shot 2022-10-31 at 7 19 12 PM" src="https://user-images.githubusercontent.com/11789931/199128062-f76f030c-a96f-40a8-b2b9-7b0faae4b504.png">

It is annoying that we keep getting these preferences which have 'disabled' or 'enabled' in the key name, rather than a standard use of one of these so that we can always know that `false` = disabled or that `true` = enabled. ¯\_ (ツ)_/¯
