### PR TITLE
Update 1Password 8 Manifest

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-11-10T23:29:11Z</date>
+	<date>2022-11-13T23:26:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -7,7 +7,7 @@
 	<key>pfm_app_url</key>
 	<string>https://1password.com</string>
 	<key>pfm_description</key>
-	<string>1Password 8 settings</string>
+	<string>1Password settings</string>
 	<key>pfm_documentation_url</key>
 	<string>https://support.1password.com/mobile-device-management/</string>
 	<key>pfm_domain</key>
@@ -24,7 +24,7 @@
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Configure 1Password 8 settings</string>
+			<string>Configure 1Password settings</string>
 			<key>pfm_description</key>
 			<string>Settings to configure 1Password using your MDM solution</string>
 			<key>pfm_name</key>
@@ -36,7 +36,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>1Password 8</string>
+			<string>1Password</string>
 			<key>pfm_description</key>
 			<string>Name of the payload</string>
 			<key>pfm_name</key>
@@ -382,7 +382,7 @@
 		<string>system</string>
 	</array>
 	<key>pfm_title</key>
-	<string>1Password 8</string>
+	<string>1Password</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -111,8 +111,8 @@
 			<string>PFC_SegmentedControl_0</string>
 			<key>pfm_range_list_titles</key>
 			<array>
-				<string>Security</string>
 				<string>Privacy</string>
+				<string>Security</string>
 				<string>Updates</string>
 			</array>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -265,10 +265,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.clipboard.clearAfter</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Clear clipboard after timeout</string>
 			<key>pfm_type</key>
@@ -283,10 +279,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.deviceClipboardSharing</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Allow Universal Clipboard</string>
 			<key>pfm_type</key>
@@ -301,10 +293,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>privacy.downloadRichIcons</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Show app and website icons</string>
 			<key>pfm_type</key>
@@ -319,10 +307,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>privacy.checkHibp</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Check for vulnerable passwords</string>
 			<key>pfm_type</key>
@@ -337,10 +321,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>updates.autoUpdate</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Automatically check for updates</string>
 			<key>pfm_type</key>
@@ -355,10 +335,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>updates.updateChannel</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_range_list</key>
 			<array>
 				<string>PRODUCTION</string>
@@ -382,7 +358,7 @@
 		<string>system</string>
 	</array>
 	<key>pfm_title</key>
-	<string>1Password</string>
+	<string>1Password 8 (and later)</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -7,7 +7,7 @@
 	<key>pfm_app_url</key>
 	<string>https://1password.com</string>
 	<key>pfm_description</key>
-	<string>1Password settings</string>
+	<string>1Password 8 settings</string>
 	<key>pfm_documentation_url</key>
 	<string>https://support.1password.com/mobile-device-management/</string>
 	<key>pfm_domain</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -334,7 +334,7 @@
 		<string>system</string>
 	</array>
 	<key>pfm_title</key>
-	<string>1Password 8 (and later)</string>
+	<string>1Password 8</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -153,10 +153,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.authenticatedUnlock.appleTouchId</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Allow Biometric Unlock (Face ID &amp; Touch ID)</string>
 			<key>pfm_type</key>
@@ -169,10 +165,6 @@
 			<string>If present enforces whether Apple Watch unlock is allowed (Preferences > Security > Unlock).</string>
 			<key>pfm_name</key>
 			<string>security.authenticatedUnlock.appleWatchUnlock</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Allow Apple Watch Unlock</string>
 			<key>pfm_type</key>
@@ -187,10 +179,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.revealPasswords</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Allow revealing passwords</string>
 			<key>pfm_type</key>
@@ -205,10 +193,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.onDeviceLock</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Lock on sleep, screensaver, or switching users</string>
 			<key>pfm_type</key>
@@ -223,10 +207,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.onWindowClose</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Lock when main window is closed</string>
 			<key>pfm_type</key>
@@ -241,10 +221,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.minutes</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_range_max</key>
 			<integer>1440</integer>
 			<key>pfm_range_min</key>
@@ -260,7 +236,7 @@
 			<key>pfm_app_min</key>
 			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>Clear Clipboard Timeout</string>
+			<string>The amount of time after copying a 1Password item that it is cleared from the clipboard (Preferences > Security > Clipboard).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
Per @apizz [comment](https://github.com/ProfileCreator/ProfileManifests/pull/577#discussion_r1019827300), I forgot to commit this change in this [PR](https://github.com/ProfileCreator/ProfileManifests/pull/577) that the 1Password 8 title and description in the preference domain has been standardized to not be version specific, we remove the version number.

- Remove 1Password version number from manifest
- Tested on ProfileCreator 0.3.3