### PR TITLE
Fix Printing Manifest UserPrinterList

### DIFF
--- a/Manifests/ManifestsApple/com.apple.mcxprinting.plist
+++ b/Manifests/ManifestsApple/com.apple.mcxprinting.plist
@@ -15,7 +15,7 @@
 		<key>pfm_interaction</key>
 		<string>exlusive</string>
 		<key>pfm_last_modified</key>
-		<date>2022-10-10T08:08:05Z</date>
+		<date>2022-12-04T04:14:48Z</date>
 		<key>pfm_macos_min</key>
 		<string>10.7</string>
 		<key>pfm_platforms</key>
@@ -152,9 +152,23 @@ The payload organization for a payload need not match the payload organization i
 			</dict>
 			<dict>
 				<key>pfm_description</key>
-				<string>The default printer for the user.</string>
+				<string>The default printer for the user. This information should match one of the printers in the Printer List.</string>
 				<key>pfm_documentation_url</key>
 				<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
+				<key>pfm_exclude</key>
+				<array>
+					<dict>
+						<key>pfm_target_conditions</key>
+						<array>
+							<dict>
+								<key>pfm_present</key>
+								<false/>
+								<key>pfm_target</key>
+								<string>UserPrinterList</string>
+							</dict>
+						</array>
+					</dict>
+				</array>
 				<key>pfm_macos_min</key>
 				<string>10.7</string>
 				<key>pfm_name</key>
@@ -163,7 +177,7 @@ The payload organization for a payload need not match the payload organization i
 				<array>
 					<dict>
 						<key>pfm_description</key>
-						<string>The display name.</string>
+						<string>The printer display name. This should match one of the printers in the Printer List.</string>
 						<key>pfm_documentation_url</key>
 						<string>https://developer.apple.com/documentation/devicemanagement/printing/defaultprinter</string>
 						<key>pfm_macos_min</key>
@@ -181,7 +195,7 @@ The payload organization for a payload need not match the payload organization i
 					</dict>
 					<dict>
 						<key>pfm_description</key>
-						<string>The device URI.</string>
+						<string>The device URI. This should match one of the printers in the Printer List.</string>
 						<key>pfm_documentation_url</key>
 						<string>https://developer.apple.com/documentation/devicemanagement/printing/defaultprinter</string>
 						<key>pfm_macos_min</key>
@@ -325,6 +339,8 @@ The payload organization for a payload need not match the payload organization i
 					<dict>
 						<key>pfm_description</key>
 						<string>A printer item in the printer list</string>
+						<key>pfm_hidden</key>
+						<string>container</string>
 						<key>pfm_name</key>
 						<string>Printer</string>
 						<key>pfm_require</key>
@@ -333,7 +349,7 @@ The payload organization for a payload need not match the payload organization i
 						<array>
 							<dict>
 								<key>pfm_description</key>
-								<string>The display name.</string>
+								<string>The printer display name.</string>
 								<key>pfm_name</key>
 								<string>DisplayName</string>
 								<key>pfm_require</key>
@@ -421,7 +437,7 @@ The payload organization for a payload need not match the payload organization i
 				<key>pfm_title</key>
 				<string>User Printer List</string>
 				<key>pfm_type</key>
-				<string>dictionary</string>
+				<string>array</string>
 			</dict>
 		</array>
 		<key>pfm_targets</key>


### PR DESCRIPTION
Resolves #584 

Was not correctly setup to be an array of dictionaries.  Changes correctly show this in the UI.

<img width="801" alt="Screenshot 2022-12-03 at 11 25 00 PM" src="https://user-images.githubusercontent.com/11789931/205474434-b06e69ef-aa07-4b72-b27b-58ed111ce995.png">

Also:
- Add a `pfm_exclude` for `DefaultPrinter` since this needs to be in the UserPrinterList
- Update some descriptions for clarity