### PR TITLE
feat: Add manifest for 1Password 8 on macOS and iOS.

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_app_min</key>
+	<string>8.9.8</string>
+	<key>pfm_app_url</key>
+	<string>https://1password.com</string>
+	<key>pfm_description</key>
+	<string>1Password settings</string>
+	<key>pfm_documentation_url</key>
+	<string>https://support.1password.com/mobile-device-management/</string>
+	<key>pfm_domain</key>
+	<string>com.1password.1password</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_last_modified</key>
+	<date>2022-11-14T11:25:00Z</date>
+	<key>pfm_platforms</key>
+	<array>
+		<string>macOS</string>
+		<string>iOS</string>
+	</array>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Configures 1Password settings</string>
+			<key>pfm_description</key>
+			<string>Description of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>1Password 8</string>
+			<key>pfm_description</key>
+			<string>Name of the payload</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.1password.1password</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.1password.1password</string>
+			<key>pfm_description</key>
+			<string>The type of the payload, a reverse dns string</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string></string>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_OP8</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Security</string>
+				<string>Privacy</string>
+				<string>Advanced</string>
+				<string>Notifications</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>Security</key>
+				<array>
+					<string>security.authenticatedUnlock.appleWatchUnlock</string>
+					<string>security.authenticatedUnlock.appleTouchId</string>
+					<string>security.authenticatedUnlock.appleFaceId</string>
+					<string>security.revealPasswords</string>
+					<string>security.autolock.onDeviceLock</string>
+					<string>security.autolock.onWindowClose</string>
+					<string>security.autolock.minutes</string>
+					<string>security.clipboard.clearAfter</string>
+					<string>security.deviceClipboardSharing</string>
+				</array>
+				<key>Privacy</key>
+				<array>
+					<string>privacy.checkHibp</string>
+					<string>privacy.downloadRichIcons</string>
+				</array>
+				<key>Advanced</key>
+				<array>
+					<string>updates.autoUpdate</string>
+					<string>updates.updateChannel</string>
+				</array>
+				<key>Notifications</key>
+				<array>
+					<string>app.notifyCopyTotpToClipboard</string>
+				</array>
+			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>If present enforces whether biometric unlock is allowed using Touch ID (Preferences &gt; Security &gt; Unlock using ...).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.authenticatedUnlock.appleTouchId</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow Touch ID Unlock</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>If present enforces whether biometric unlock is allowed using Face ID (Preferences &gt; Security &gt; Unlock using ...).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.authenticatedUnlock.appleFaceId</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow Face ID Unlock</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>If present enforces whether biometric unlock is allowed using Apple Watch</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.authenticatedUnlock.appleWatchUnlock</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow Apple Watch Unlock</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enforces the configured conceal passwords setting (Preferences &gt; Security &gt; Always show passwords and full credit card numbers).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.revealPasswords</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Always show passwords and full credit card numbers</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enforces the configured lock on sleep setting (Preferences &gt; Security &gt; Lock on sleep, screensaver, or switching users).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.autolock.onDeviceLock</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Lock on Sleep, Screensaver or Switching Users</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enforces locking when the main window closes.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.autolock.onWindowClose</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Lock on Window Close</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+                            <string>security.autolock.minutes</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
+			<key>pfm_description</key>
+			<string>Lock on idle on macOS (1-1440 minutes) or time in background on iOS (0-480 minutes)</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.autolock.minutes</string>
+			<key>pfm_range_min</key>
+			<integer>0</integer>
+			<key>pfm_range_max</key>
+			<integer>1440</integer>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+            <string>Lock after the computer is idle for...(macOS)/Auto-lock on exit (iOS)</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+			<key>pfm_value_unit</key>
+			<string>minutes</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enforces whether Universal Clipboard is allowed for copying to other devices.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.deviceClipboardSharing</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Use Universal Clipboard to copy to other devices</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Enforces whether the clear clipboard preference is enabled or disabled (Preferences &gt; Security &gt; Clear clipboard contents).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.clipboard.clearAfter</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Remove copied information and authentication codes after 90 seconds</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>If enabled, creates a user notification when a vault item&apos;s OTP code is copied to the clipboard.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>app.notifyCopyTotpToClipboard</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Notify me whem One-Time Passwords are copied to the clipboard</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Checks for vulnerable passwords.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>privacy.checkHibp</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Check for vulnerable passwords</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Download Rich Icons.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>privacy.downloadRichIcons</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Show app and website icons</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Enforces whether to automatically check for available updates.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>updates.autoUpdate</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Install updates automatically</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Controls which update channel to use.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>updates.updateChannel</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Release channel</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>PRODUCTION</string>
+				<string>BETA</string>
+				<string>NIGHTLY</string>
+			</array>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+	</array>
+	<key>pfm_targets</key>
+	<array>
+		<string>system</string>
+	</array>
+	<key>pfm_title</key>
+	<string>1Password 8</string>
+	<key>pfm_unique</key>
+	<true/>
+	<key>pfm_version</key>
+	<integer>3</integer>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds manifests for the new MDM support in 1Password for macOS and iOS.