### PR TITLE
Enhance 1Password 8 manifest with iOS keys

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_app_min</key>
-	<string>8.0</string>
+	<string>8.9</string>
 	<key>pfm_app_url</key>
 	<string>https://1password.com</string>
 	<key>pfm_description</key>
@@ -19,6 +19,7 @@
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
+		<string>iOS</string>
 	</array>
 	<key>pfm_subkeys</key>
 	<array>
@@ -111,23 +112,20 @@
 			<string>PFC_SegmentedControl_0</string>
 			<key>pfm_range_list_titles</key>
 			<array>
-				<string>Privacy</string>
 				<string>Security</string>
-				<string>Updates</string>
+				<string>Privacy</string>
+				<string>Advanced</string>
+				<string>Notifications</string>
 			</array>
 			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
-				<key>Privacy</key>
-				<array>
-					<string>privacy.downloadRichIcons</string>
-					<string>privacy.checkHibp</string>
-				</array>
 				<key>Security</key>
 				<array>
-					<string>security.authenticatedUnlock.appleTouchId</string>
 					<string>security.authenticatedUnlock.appleWatchUnlock</string>
+					<string>security.authenticatedUnlock.appleTouchId</string>
+					<string>security.authenticatedUnlock.appleFaceId</string>
 					<string>security.revealPasswords</string>
 					<string>security.autolock.onDeviceLock</string>
 					<string>security.autolock.onWindowClose</string>
@@ -135,182 +133,276 @@
 					<string>security.clipboard.clearAfter</string>
 					<string>security.deviceClipboardSharing</string>
 				</array>
-				<key>Updates</key>
+				<key>Privacy</key>
+				<array>
+					<string>privacy.checkHibp</string>
+					<string>privacy.downloadRichIcons</string>
+				</array>
+				<key>Advanced</key>
 				<array>
 					<string>updates.autoUpdate</string>
 					<string>updates.updateChannel</string>
+				</array>
+				<key>Notifications</key>
+				<array>
+					<string>app.notifyCopyTotpToClipboard</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>If present enforces whether biometric unlock is allowed (Preferences > Security > Unlock).</string>
+			<string>If present enforces whether biometric unlock is allowed using Touch ID (Preferences &gt; Security &gt; Unlock using ...).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.authenticatedUnlock.appleTouchId</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
 			<key>pfm_title</key>
-			<string>Allow Biometric Unlock (Face ID &amp; Touch ID)</string>
+			<string>Allow Touch ID Unlock</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>If present enforces whether Apple Watch unlock is allowed (Preferences > Security > Unlock).</string>
+			<string>If present enforces whether biometric unlock is allowed using Face ID (Preferences &gt; Security &gt; Unlock using ...).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.authenticatedUnlock.appleFaceId</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow Face ID Unlock</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>If present enforces whether biometric unlock is allowed using Apple Watch</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.authenticatedUnlock.appleWatchUnlock</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
 			<key>pfm_title</key>
 			<string>Allow Apple Watch Unlock</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Enforces showing passwords and full credit card numbers (Preferences > Security > Conceal Fields).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.revealPasswords</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
 			<key>pfm_title</key>
-			<string>Allow revealing passwords</string>
+			<string>Always show passwords and full credit card numbers</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>Enforces the configured locked on sleep,screensaver, or switching users (Preferences > Security > Auto-lock).</string>
+			<string>Enforces the configured lock on sleep setting (Preferences &gt; Security &gt; Lock on sleep, screensaver, or switching users).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.onDeviceLock</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
 			<key>pfm_title</key>
-			<string>Lock on sleep, screensaver, or switching users</string>
+			<string>Lock on Sleep, Screensaver or Switching Users</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>Enforces the configured lock on app exit preference</string>
+			<string>Enforces locking when the main window closes.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.onWindowClose</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
 			<key>pfm_title</key>
 			<string>Lock when main window is closed</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
+			<key>pfm_conditionals</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<true/>
+							</array>
+							<key>pfm_target</key>
+                            <string>security.autolock.minutes</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_description</key>
-			<string>Enforces the lock on idle time preference (Preferences > Security > Lock).</string>
+			<string>Lock on idle on macOS (1-1440 minutes) or time in background on iOS (0-480 minutes)</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.minutes</string>
+			<key>pfm_range_min</key>
+			<integer>0</integer>
 			<key>pfm_range_max</key>
 			<integer>1440</integer>
-			<key>pfm_range_min</key>
-			<integer>1</integer>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
 			<key>pfm_title</key>
-			<string>Set auto-lock timeout</string>
+            <string>Lock after the computer is idle for...(macOS)/Auto-lock on exit (iOS)</string>
 			<key>pfm_type</key>
 			<string>integer</string>
 			<key>pfm_value_unit</key>
 			<string>minutes</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>The amount of time after copying a 1Password item that it is cleared from the clipboard (Preferences > Security > Clipboard).</string>
-			<key>pfm_documentation_url</key>
-			<string>https://support.1password.com/mobile-device-management/</string>
-			<key>pfm_name</key>
-			<string>security.clipboard.clearAfter</string>
-			<key>pfm_title</key>
-			<string>Clear clipboard after timeout</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
-			<key>pfm_description</key>
-			<string>Enforces whether the clear clipboard preference is enabled or disabled (Preferences > Security > Clear clipboard contents).</string>
+			<string>Enforces whether Universal Clipboard is allowed for copying to other devices.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.deviceClipboardSharing</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
 			<key>pfm_title</key>
-			<string>Allow Universal Clipboard</string>
+			<string>Use Universal Clipboard to copy to other devices</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>Show app and website icons</string>
+			<string>Enforces whether the clear clipboard preference is enabled or disabled (Preferences &gt; Security &gt; Clear clipboard contents).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
-			<string>privacy.downloadRichIcons</string>
+			<string>security.clipboard.clearAfter</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
 			<key>pfm_title</key>
-			<string>Show app and website icons</string>
+			<string>Remove copied information and authentication codes after 90 seconds</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>Check for vulnerable passwords</string>
+			<string>If enabled, creates a user notification when a vault item&apos;s TOTP code is copied to the clipboard.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>app.notifyCopyTotpToClipboard</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Notify me whem One-Time Passwords are copied to the clipboard</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Checks for vulnerable passwords.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>privacy.checkHibp</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
 			<key>pfm_title</key>
 			<string>Check for vulnerable passwords</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>Automatically check for updates</string>
+			<string>Download Rich Icons.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>privacy.downloadRichIcons</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+				<string>iOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Show app and website icons</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Enforces whether to automatically check for available updates.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>updates.autoUpdate</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
 			<key>pfm_title</key>
 			<string>Automatically check for updates</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
-			<string>Set release channel</string>
+			<string>Controls which release channel to use.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>updates.updateChannel</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Release channel</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>PRODUCTION</string>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -121,6 +121,20 @@
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
+				<key>Advanced</key>
+				<array>
+					<string>updates.autoUpdate</string>
+					<string>updates.updateChannel</string>
+				</array>
+				<key>Notifications</key>
+				<array>
+					<string>app.notifyCopyTotpToClipboard</string>
+				</array>
+				<key>Privacy</key>
+				<array>
+					<string>privacy.checkHibp</string>
+					<string>privacy.downloadRichIcons</string>
+				</array>
 				<key>Security</key>
 				<array>
 					<string>security.authenticatedUnlock.appleWatchUnlock</string>
@@ -132,20 +146,6 @@
 					<string>security.autolock.minutes</string>
 					<string>security.clipboard.clearAfter</string>
 					<string>security.deviceClipboardSharing</string>
-				</array>
-				<key>Privacy</key>
-				<array>
-					<string>privacy.checkHibp</string>
-					<string>privacy.downloadRichIcons</string>
-				</array>
-				<key>Advanced</key>
-				<array>
-					<string>updates.autoUpdate</string>
-					<string>updates.updateChannel</string>
-				</array>
-				<key>Notifications</key>
-				<array>
-					<string>app.notifyCopyTotpToClipboard</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
@@ -160,8 +160,8 @@
 			<string>security.authenticatedUnlock.appleTouchId</string>
 			<key>pfm_platforms</key>
 			<array>
-				<string>macOS</string>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Allow Touch ID Unlock</string>
@@ -202,15 +202,15 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enforces showing passwords and full credit card numbers (Preferences > Security > Conceal Fields).</string>
+			<string>Enforces showing passwords and full credit card numbers (Preferences &gt; Security &gt; Conceal Fields).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.revealPasswords</string>
 			<key>pfm_platforms</key>
 			<array>
-				<string>macOS</string>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Always show passwords and full credit card numbers</string>
@@ -261,7 +261,7 @@
 								<true/>
 							</array>
 							<key>pfm_target</key>
-                            <string>security.autolock.minutes</string>
+							<string>security.autolock.minutes</string>
 						</dict>
 					</array>
 				</dict>
@@ -272,17 +272,17 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.minutes</string>
-			<key>pfm_range_min</key>
-			<integer>0</integer>
-			<key>pfm_range_max</key>
-			<integer>1440</integer>
 			<key>pfm_platforms</key>
 			<array>
-				<string>macOS</string>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
+			<key>pfm_range_max</key>
+			<integer>1440</integer>
+			<key>pfm_range_min</key>
+			<integer>0</integer>
 			<key>pfm_title</key>
-            <string>Lock after the computer is idle for...(macOS)/Auto-lock on exit (iOS)</string>
+			<string>Lock after the computer is idle for...(macOS)/Auto-lock on exit (iOS)</string>
 			<key>pfm_type</key>
 			<string>integer</string>
 			<key>pfm_value_unit</key>
@@ -297,8 +297,8 @@
 			<string>security.deviceClipboardSharing</string>
 			<key>pfm_platforms</key>
 			<array>
-				<string>macOS</string>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Use Universal Clipboard to copy to other devices</string>
@@ -314,8 +314,8 @@
 			<string>security.clipboard.clearAfter</string>
 			<key>pfm_platforms</key>
 			<array>
-				<string>macOS</string>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Remove copied information and authentication codes after 90 seconds</string>
@@ -324,7 +324,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If enabled, creates a user notification when a vault item&apos;s TOTP code is copied to the clipboard.</string>
+			<string>If enabled, creates a user notification when a vault item's TOTP code is copied to the clipboard.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
@@ -347,8 +347,8 @@
 			<string>privacy.checkHibp</string>
 			<key>pfm_platforms</key>
 			<array>
-				<string>macOS</string>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Check for vulnerable passwords</string>
@@ -364,8 +364,8 @@
 			<string>privacy.downloadRichIcons</string>
 			<key>pfm_platforms</key>
 			<array>
-				<string>macOS</string>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Show app and website icons</string>
@@ -401,8 +401,6 @@
 			<array>
 				<string>macOS</string>
 			</array>
-			<key>pfm_title</key>
-			<string>Release channel</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>PRODUCTION</string>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_app_min</key>
-	<string>8.9</string>
+	<string>8.0</string>
 	<key>pfm_app_url</key>
 	<string>https://1password.com</string>
 	<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -18,8 +18,8 @@
 	<date>2022-11-13T23:26:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
-		<string>macOS</string>
 		<string>iOS</string>
+		<string>macOS</string>
 	</array>
 	<key>pfm_subkeys</key>
 	<array>


### PR DESCRIPTION
Sorry about the earlier botched PR. This one should be more easily mergeable - it adds information about the keys supported by iOS and clarifies some of the text.

Is it OK to have an overall `pfm_app_min` at the top of the file, rather than having them in each item, given that all of these keys are supported on 8.9 and later on both platforms?

Also, I couldn't figure out how to have a different `pfm_range_min` value for different platforms for the key `security.autolock.minutes`. It should be 1 on macOS and 0 on iOS. I'm happy to adapt this PR if you can advise.