### PR TITLE
MacOSLAPS update

### DIFF
--- a/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
+++ b/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
@@ -411,6 +411,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
+++ b/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-01-11T23:59:09Z</date>
+	<date>2023-02-10T01:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -310,6 +310,95 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>First Password</string>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Specifies the password requirements.</string>
+			<key>pfm_description_reference</key>
+			<string>A dictionary that allows you to specify the password requirements. There are 4 keys Lowercase, Uppercase, Number and Symbol. For each you specify an integer for the amount of each that you would like in your password.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/joshua-d-miller/macOSLAPS/wiki/Configuration-Keys</string>
+			<key>pfm_name</key>
+			<string>PasswordRequirements</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>3.0.2</string>
+					<key>pfm_default</key>
+					<integer>0</integer>
+					<key>pfm_description</key>
+					<string>The minimum number of lowercase letters in a generated password.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://github.com/joshua-d-miller/macOSLAPS/wiki/Configuration-Keys</string>
+					<key>pfm_name</key>
+					<string>Lowercase</string>
+					<key>pfm_range_min</key>
+					<integer>0</integer>
+					<key>pfm_title</key>
+					<string>Minimum Lowercase Letters</string>
+					<key>pfm_type</key>
+					<string>integer</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>3.0.2</string>
+					<key>pfm_default</key>
+					<integer>0</integer>
+					<key>pfm_description</key>
+					<string>The minimum number of uppercase letters in a generated password.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://github.com/joshua-d-miller/macOSLAPS/wiki/Configuration-Keys</string>
+					<key>pfm_name</key>
+					<string>Uppercase</string>
+					<key>pfm_range_min</key>
+					<integer>0</integer>
+					<key>pfm_title</key>
+					<string>Minimum Uppercase Letters</string>
+					<key>pfm_type</key>
+					<string>integer</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>3.0.2</string>
+					<key>pfm_default</key>
+					<integer>0</integer>
+					<key>pfm_description</key>
+					<string>The minimum number of numeric characters in a generated password.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://github.com/joshua-d-miller/macOSLAPS/wiki/Configuration-Keys</string>
+					<key>pfm_name</key>
+					<string>Number</string>
+					<key>pfm_range_min</key>
+					<integer>0</integer>
+					<key>pfm_title</key>
+					<string>Minimum Numeric Characters</string>
+					<key>pfm_type</key>
+					<string>integer</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>3.0.2</string>
+					<key>pfm_default</key>
+					<integer>0</integer>
+					<key>pfm_description</key>
+					<string>The minimum number of non-alphanumeric characters in a generated password.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://github.com/joshua-d-miller/macOSLAPS/wiki/Configuration-Keys</string>
+					<key>pfm_name</key>
+					<string>Symbol</string>
+					<key>pfm_range_min</key>
+					<integer>0</integer>
+					<key>pfm_title</key>
+					<string>Minimum Symbols</string>
+					<key>pfm_type</key>
+					<string>integer</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Password Requirements</string>
+			<key>pfm_type</key>
+			<string>dictionary</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>

--- a/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
+++ b/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
@@ -312,6 +312,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>3.0.2</string>
 			<key>pfm_description</key>
 			<string>Specifies the password requirements.</string>
 			<key>pfm_description_reference</key>


### PR DESCRIPTION
v3.0.2 of MacOSLAPS added a new PasswordRequirements key - this PR adds support for it.