### PR TITLE
Add CrossSiteTrackingPreventionRelaxedDomains

### DIFF
--- a/Manifests/ManifestsApple/com.apple.domains.plist
+++ b/Manifests/ManifestsApple/com.apple.domains.plist
@@ -295,6 +295,6 @@ SafariPasswordAutoFillDomains definitions are cumulative. Patterns defined by al
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.domains.plist
+++ b/Manifests/ManifestsApple/com.apple.domains.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:50Z</date>
+	<date>2023-02-27T08:57:44Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -269,10 +269,6 @@ SafariPasswordAutoFillDomains definitions are cumulative. Patterns defined by al
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
-					<key>pfm_description</key>
-					<string></string>
-					<key>pfm_name</key>
-					<string>CrossSiteTrackingDomain</string>
 					<key>pfm_title</key>
 					<string>Domain</string>
 					<key>pfm_type</key>

--- a/Manifests/ManifestsApple/com.apple.domains.plist
+++ b/Manifests/ManifestsApple/com.apple.domains.plist
@@ -246,6 +246,48 @@ SafariPasswordAutoFillDomains definitions are cumulative. Patterns defined by al
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Up to 10 domains can be added for which Cross-Site Tracking Prevention will be relaxed. Domains should be listed as theacmeinc.com which includes any subdomains (without needing to use *theacmeinc.com)</string>
+			<key>pfm_description_extended</key>
+			<string>As a result, organizations can leave Cross-Site Tracking Prevention turned on and benefit from tracking prevention for general browsing but also allow select domains to give third-party embedded resources the ability to use cookies. This is useful, for example, in education, where learning management systems embed content like videos or images stored by third parties, or learning tools (LTI tools) offered by third parties and presented in iFrames.</string>
+			<key>pfm_description_reference</key>
+			<string>Optional. An array of URL strings; maximum of 10. Supported in iOS 16.2 and later; Supported in macOS 13.1 and later. URLs matching the patterns listed here have relaxed enforcement of cross-site tracking prevention.</string>
+			<key>pfm_ios_min</key>
+			<string>16.2</string>
+			<key>pfm_macos_min</key>
+			<string>13.1</string>
+			<key>pfm_name</key>
+			<string>CrossSiteTrackingPreventionRelaxedDomains</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>iOS</string>
+				<string>macOS</string>
+			</array>
+			<key>pfm_repetition_max</key>
+			<integer>10</integer>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string></string>
+					<key>pfm_name</key>
+					<string>CrossSiteTrackingDomain</string>
+					<key>pfm_title</key>
+					<string>Domain</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>example.com</string>
+				</dict>
+			</array>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_title</key>
+			<string>Safari Relaxed Cross Site Tracking Domains</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>

--- a/Manifests/ManifestsApple/com.apple.domains.plist
+++ b/Manifests/ManifestsApple/com.apple.domains.plist
@@ -259,6 +259,8 @@ SafariPasswordAutoFillDomains definitions are cumulative. Patterns defined by al
 			<string>13.1</string>
 			<key>pfm_name</key>
 			<string>CrossSiteTrackingPreventionRelaxedDomains</string>
+			<key>pfm_note</key>
+			<string>A maximum of 10 URLs is supported</string>
 			<key>pfm_platforms</key>
 			<array>
 				<string>iOS</string>


### PR DESCRIPTION
Adds new keys from 13.1, 16.2

https://developer.apple.com/documentation/devicemanagement/domains