### PR TITLE
Fix 'github-actions[bot]' to point to correct GitHub App

### DIFF
--- a/.github/workflows/updateIndexes.yml
+++ b/.github/workflows/updateIndexes.yml
@@ -20,8 +20,8 @@ jobs:
         working-directory: clone
         run: |
           ./updateIndexes.py
-          git config user.name git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -am "Update indexes" || true
           git push --set-upstream origin master || true

--- a/.github/workflows/updateIndexes.yml
+++ b/.github/workflows/updateIndexes.yml
@@ -20,8 +20,8 @@ jobs:
         working-directory: clone
         run: |
           ./updateIndexes.py
-          git config user.name github-actions
-          git config user.email github-actions@github.com
+          git config user.name git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -am "Update indexes" || true
           git push --set-upstream origin master || true


### PR DESCRIPTION
Simple change to make commits match up to the official 'github-actions' app in GitHub, rather than an unmatched user.