### PR TITLE
support for new Slack settings

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -176,7 +176,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_app_min</key>
 			<string>4.31</string>
 			<key>pfm_description</key>
-			<string>Enables or disable hardware accelerated rendering via GPU.</string>
+			<string>Enable or disable hardware accelerated rendering via GPU.</string>
 			<key>pfm_name</key>
 			<string>HardwareAcceleration</string>
 			<key>pfm_title</key>
@@ -240,7 +240,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_app_min</key>
 			<string>4.31</string>
 			<key>pfm_description</key>
-			<string>Enables or disables auto updates.</string>
+			<string>Enable or disable auto updates.</string>
 			<key>pfm_name</key>
 			<string>AutoUpdate</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -212,7 +212,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_name</key>
 			<string>DefaultSignInTeam</string>
 			<key>pfm_title</key>
-			<string>Default Team/Workspace</string>
+			<string>Default Team / Workspace</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -113,8 +113,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
-
-		<!-- App Keys -->		
 		<dict>
 			<key>pfm_name</key>
 			<string>PFC_SegmentedControl_0</string>
@@ -128,15 +126,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
-				<key>Policy</key>
-				<array>
-					<string>ClientEnvironment</string>
-					<string>HardwareAcceleration</string>
-					<string>DownloadPath</string>
-					<string>DefaultSignInTeam</string>
-					<string>ReleaseChannel</string>
-					<string>AutoUpdate</string>
-				</array>
 				<key>Defaults</key>
 				<array>
 					<string>Defaults</string>
@@ -146,25 +135,28 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>SlackNoAutoUpdates</string>
 					<string>SlackDefaultSignInWorkspace</string>
 				</array>
+				<key>Policy</key>
+				<array>
+					<string>ClientEnvironment</string>
+					<string>HardwareAcceleration</string>
+					<string>DownloadPath</string>
+					<string>DefaultSignInTeam</string>
+					<string>ReleaseChannel</string>
+					<string>AutoUpdate</string>
+				</array>
 			</dict>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
-		
-		<!-- Policies -->
 		<dict>
-			<key>pfm_name</key>
-			<string>ClientEnvironment</string>
-			<key>pfm_title</key>
-			<string>Client Environment</string>
-			<key>pfm_type</key>
-			<string>integer</string>
 			<key>pfm_app_min</key>
 			<string>4.31</string>
 			<key>pfm_description</key>
 			<string>Configures the client to run in either commercial mode or government compliance mode (GovSlack).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://slack.com/solutions/govslack</string>
+			<key>pfm_name</key>
+			<string>ClientEnvironment</string>
 			<key>pfm_range_list</key>
 			<array>
 				<integer>1000</integer>
@@ -175,60 +167,60 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>Commercial</string>
 				<string>GovSlack</string>
 			</array>
+			<key>pfm_title</key>
+			<string>Client Environment</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>4.31</string>
+			<key>pfm_description</key>
+			<string>Enables or disable hardware accelerated rendering via GPU.</string>
 			<key>pfm_name</key>
 			<string>HardwareAcceleration</string>
 			<key>pfm_title</key>
 			<string>Hardware Acceleration</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-			<key>pfm_app_min</key>
-			<string>4.31</string>
-			<key>pfm_description</key>
-			<string>Enables or disable hardware accelerated rendering via GPU.</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>4.31y</string>
+			<key>pfm_description</key>
+			<string>Defines the download location for documents from Slack. This must be a valid user accessible path.</string>
+			<key>pfm_format</key>
+			<string>^/|//|(/[\w-]+)+$</string>
 			<key>pfm_name</key>
 			<string>DownloadPath</string>
 			<key>pfm_title</key>
 			<string>Download Path</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_format</key>
-			<string>^/|//|(/[\w-]+)+$</string>
-			<key>pfm_app_min</key>
-			<string>4.31y</string>
-			<key>pfm_description</key>
-			<string>Defines the download location for documents from Slack. This must be a valid user accessible path.</string>
 		</dict>
 		<dict>
-			<key>pfm_name</key>
-			<string>DefaultSignInTeam</string>
-			<key>pfm_title</key>
-			<string>Default Team/Workspace</string>
-			<key>pfm_type</key>
-			<string>string</string>
-			<key>pfm_format</key>
-			<string>^(E|T)[A-Z0-9]{8,50}$</string>
 			<key>pfm_app_min</key>
 			<string>4.31</string>
 			<key>pfm_description</key>
 			<string>Sets the default team/workspace for Slack sign-ins.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://slack.com/help/articles/360041725993-Share-a-default-sign-in-file-with-members</string>
-		</dict>
-		<dict>
+			<key>pfm_format</key>
+			<string>^(E|T)[A-Z0-9]{8,50}$</string>
 			<key>pfm_name</key>
-			<string>ReleaseChannel</string>
+			<string>DefaultSignInTeam</string>
 			<key>pfm_title</key>
-			<string>Release Channel</string>
+			<string>Default Team/Workspace</string>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>4.31</string>
 			<key>pfm_description</key>
 			<string>Configure the client to receive updates from either the production or beta channel.</string>
+			<key>pfm_name</key>
+			<string>ReleaseChannel</string>
 			<key>pfm_range_list</key>
 			<array>
 				<string>prod</string>
@@ -239,21 +231,23 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>Production</string>
 				<string>Beta</string>
 			</array>
+			<key>pfm_title</key>
+			<string>Release Channel</string>
+			<key>pfm_type</key>
+			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>4.31</string>
+			<key>pfm_description</key>
+			<string>Enables or disables auto updates.</string>
 			<key>pfm_name</key>
 			<string>AutoUpdate</string>
 			<key>pfm_title</key>
 			<string>Auto Update</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
-			<key>pfm_app_min</key>
-			<string>4.31</string>
-			<key>pfm_description</key>
-			<string>Enables or disables auto updates.</string>
 		</dict>
-
-		<!-- Defaults -->
 		<dict>
 			<key>pfm_description</key>
 			<string>List of default values.</string>
@@ -262,18 +256,14 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
-					<key>pfm_name</key>
-					<string>ClientEnvironment</string>
-					<key>pfm_title</key>
-					<string>Client Environment (Default)</string>
-					<key>pfm_type</key>
-					<string>integer</string>
 					<key>pfm_app_min</key>
 					<string>4.31</string>
 					<key>pfm_description</key>
 					<string>Configures the client to run in either commercial mode or government compliance mode (GovSlack) by default. The user can still change this setting.</string>
 					<key>pfm_documentation_url</key>
 					<string>https://slack.com/solutions/govslack</string>
+					<key>pfm_name</key>
+					<string>ClientEnvironment</string>
 					<key>pfm_range_list</key>
 					<array>
 						<integer>1000</integer>
@@ -284,61 +274,63 @@ A profile can consist of payloads with different version numbers. For example, c
 						<string>Commercial</string>
 						<string>GovSlack</string>
 					</array>
+					<key>pfm_title</key>
+					<string>Client Environment (Default)</string>
+					<key>pfm_type</key>
+					<string>integer</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>4.31</string>
+					<key>pfm_description</key>
+					<string>Enables or disable hardware accelerated rendering via GPU. The user can still change this setting.</string>
 					<key>pfm_name</key>
 					<string>HardwareAcceleration</string>
 					<key>pfm_title</key>
 					<string>Hardware Acceleration (Default)</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
+				</dict>
+				<dict>
 					<key>pfm_app_min</key>
 					<string>4.31</string>
 					<key>pfm_description</key>
-					<string>Enables or disable hardware accelerated rendering via GPU. The user can still change this setting.</string>
-				</dict>
-				<dict>
+					<string>Defines the download location for documents from Slack. This must be a valid user accesible path. The user can still change this setting.</string>
+					<key>pfm_format</key>
+					<string>^/|//|(/[\w-]+)+$</string>
 					<key>pfm_name</key>
 					<string>DownloadPath</string>
 					<key>pfm_title</key>
 					<string>Download Path (Default)</string>
 					<key>pfm_type</key>
 					<string>string</string>
-					<key>pfm_format</key>
-					<string>^/|//|(/[\w-]+)+$</string>
+				</dict>
+				<dict>
 					<key>pfm_app_min</key>
 					<string>4.31</string>
 					<key>pfm_description</key>
-					<string>Defines the download location for documents from Slack. This must be a valid user accesible path. The user can still change this setting.</string>
+					<string>Configure the client to receive updates from either the production or beta channel. The user can still change this setting.</string>
+					<key>pfm_name</key>
+					<string>ReleaseChannel</string>
+					<key>pfm_range_list</key>
+					<array>
+						<string>prod</string>
+						<string>beta</string>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>Production</string>
+						<string>Beta</string>
+					</array>
+					<key>pfm_title</key>
+					<string>Release Channel (Default)</string>
+					<key>pfm_type</key>
+					<string>string</string>
 				</dict>
-					<dict>
-						<key>pfm_name</key>
-						<string>ReleaseChannel</string>
-						<key>pfm_title</key>
-						<string>Release Channel (Default)</string>
-						<key>pfm_type</key>
-						<string>string</string>
-						<key>pfm_app_min</key>
-						<string>4.31</string>
-						<key>pfm_description</key>
-						<string>Configure the client to receive updates from either the production or beta channel. The user can still change this setting.</string>
-						<key>pfm_range_list</key>
-						<array>
-							<string>prod</string>
-							<string>beta</string>
-						</array>
-						<key>pfm_range_list_titles</key>
-						<array>
-							<string>Production</string>
-							<string>Beta</string>
-						</array>
-					</dict>
 			</array>
 			<key>pfm_type</key>
 			<string>dictionary</string>
 		</dict>
-
-		<!-- Legacy Settings -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>4.0</string>

--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -6,6 +6,8 @@
 	<string>https://slack.com/downloads/mac</string>
 	<key>pfm_description</key>
 	<string>Slack Client Management</string>
+	<key>pfm_documentation_url</key>
+	<string>https://slack.com/help/articles/11906214948755-Manage-desktop-app-configurations</string>
 	<key>pfm_domain</key>
 	<string>com.tinyspeck.slackmacgap</string>
 	<key>pfm_format_version</key>

--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -5,7 +5,7 @@
 	<key>pfm_app_url</key>
 	<string>https://slack.com/downloads/mac</string>
 	<key>pfm_description</key>
-	<string>Slack settings</string>
+	<string>Slack Client Management</string>
 	<key>pfm_domain</key>
 	<string>com.tinyspeck.slackmacgap</string>
 	<key>pfm_format_version</key>
@@ -113,11 +113,235 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>integer</string>
 		</dict>
+
+		<!-- App Keys -->		
+		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_0</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Policy</string>
+				<string>Defaults</string>
+				<string>Legacy</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>Policy</key>
+				<array>
+					<string>ClientEnvironment</string>
+					<string>HardwareAcceleration</string>
+					<string>DownloadPath</string>
+					<string>DefaultSignInTeam</string>
+					<string>ReleaseChannel</string>
+					<string>AutoUpdate</string>
+				</array>
+				<key>Defaults</key>
+				<array>
+					<string>Defaults</string>
+				</array>
+				<key>Legacy</key>
+				<array>
+					<string>SlackNoAutoUpdates</string>
+					<string>SlackDefaultSignInWorkspace</string>
+				</array>
+			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		
+		<!-- Policies -->
+		<dict>
+			<key>pfm_name</key>
+			<string>ClientEnvironment</string>
+			<key>pfm_title</key>
+			<string>Client Environment</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+			<key>pfm_app_min</key>
+			<string>4.31</string>
+			<key>pfm_description</key>
+			<string>Configures the client to run in either commercial mode or government compliance mode (GovSlack).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://slack.com/solutions/govslack</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1000</integer>
+				<integer>1001</integer>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Commercial</string>
+				<string>GovSlack</string>
+			</array>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>HardwareAcceleration</string>
+			<key>pfm_title</key>
+			<string>Hardware Acceleration</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+			<key>pfm_app_min</key>
+			<string>4.31</string>
+			<key>pfm_description</key>
+			<string>Enables or disable hardware accelerated rendering via GPU.</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>DownloadPath</string>
+			<key>pfm_title</key>
+			<string>Download Path</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_format</key>
+			<string>^/|//|(/[\w-]+)+$</string>
+			<key>pfm_app_min</key>
+			<string>4.31y</string>
+			<key>pfm_description</key>
+			<string>Defines the download location for documents from Slack. This must be a valid user accessible path.</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>DefaultSignInTeam</string>
+			<key>pfm_title</key>
+			<string>Default Team/Workspace</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_format</key>
+			<string>^(E|T)[A-Z0-9]{8,50}$</string>
+			<key>pfm_app_min</key>
+			<string>4.31</string>
+			<key>pfm_description</key>
+			<string>Sets the default team/workspace for Slack sign-ins.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://slack.com/help/articles/360041725993-Share-a-default-sign-in-file-with-members</string>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>ReleaseChannel</string>
+			<key>pfm_title</key>
+			<string>Release Channel</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>4.31</string>
+			<key>pfm_description</key>
+			<string>Configure the client to receive updates from either the production or beta channel.</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>prod</string>
+				<string>beta</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Production</string>
+				<string>Beta</string>
+			</array>
+		</dict>
+		<dict>
+			<key>pfm_name</key>
+			<string>AutoUpdate</string>
+			<key>pfm_title</key>
+			<string>Auto Update</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+			<key>pfm_app_min</key>
+			<string>4.31</string>
+			<key>pfm_description</key>
+			<string>Enables or disables auto updates.</string>
+		</dict>
+
+		<!-- Defaults -->
+		<dict>
+			<key>pfm_description</key>
+			<string>List of default values.</string>
+			<key>pfm_name</key>
+			<string>Defaults</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>ClientEnvironment</string>
+					<key>pfm_title</key>
+					<string>Client Environment (Default)</string>
+					<key>pfm_type</key>
+					<string>integer</string>
+					<key>pfm_app_min</key>
+					<string>4.31</string>
+					<key>pfm_description</key>
+					<string>Configures the client to run in either commercial mode or government compliance mode (GovSlack) by default. The user can still change this setting.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://slack.com/solutions/govslack</string>
+					<key>pfm_range_list</key>
+					<array>
+						<integer>1000</integer>
+						<integer>1001</integer>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>Commercial</string>
+						<string>GovSlack</string>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>HardwareAcceleration</string>
+					<key>pfm_title</key>
+					<string>Hardware Acceleration (Default)</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+					<key>pfm_app_min</key>
+					<string>4.31</string>
+					<key>pfm_description</key>
+					<string>Enables or disable hardware accelerated rendering via GPU. The user can still change this setting.</string>
+				</dict>
+				<dict>
+					<key>pfm_name</key>
+					<string>DownloadPath</string>
+					<key>pfm_title</key>
+					<string>Download Path (Default)</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_format</key>
+					<string>^/|//|(/[\w-]+)+$</string>
+					<key>pfm_app_min</key>
+					<string>4.31</string>
+					<key>pfm_description</key>
+					<string>Defines the download location for documents from Slack. This must be a valid user accesible path. The user can still change this setting.</string>
+				</dict>
+					<dict>
+						<key>pfm_name</key>
+						<string>ReleaseChannel</string>
+						<key>pfm_title</key>
+						<string>Release Channel (Default)</string>
+						<key>pfm_type</key>
+						<string>string</string>
+						<key>pfm_app_min</key>
+						<string>4.31</string>
+						<key>pfm_description</key>
+						<string>Configure the client to receive updates from either the production or beta channel. The user can still change this setting.</string>
+						<key>pfm_range_list</key>
+						<array>
+							<string>prod</string>
+							<string>beta</string>
+						</array>
+						<key>pfm_range_list_titles</key>
+						<array>
+							<string>Production</string>
+							<string>Beta</string>
+						</array>
+					</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
+
+		<!-- Legacy Settings -->
 		<dict>
 			<key>pfm_app_min</key>
 			<string>4.0</string>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
 			<string>When true, disables Slack's built-in automatic update mechanism. Useful if you update Slack using a tool like Munki.</string>
 			<key>pfm_documentation_url</key>
@@ -152,8 +376,8 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_title</key>
 	<string>Slack</string>
 	<key>pfm_unique</key>
-	<false/>
+	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-15T17:17:24Z</date>
+	<date>2023-04-09T15:57:47Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -370,6 +370,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
A new set of supported settings for Slack version 4.31.  See https://slack.com/help/articles/11906214948755-Manage-desktop-app-configurations for details