### PR TITLE
Add InstallDefender to com.microsoft.office.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -472,7 +472,7 @@
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>16.24</string>
+			<string>16.75</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -136,6 +136,7 @@
 				</array>
 				<key>Installation</key>
 				<array>
+					<string>InstallDefender</string>
 					<string>InstallAutoUpdate</string>
 					<string>InstallExcel</string>
 					<string>InstallOneDrive</string>
@@ -450,6 +451,24 @@
 			<string>Theme</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.24</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Defender Shim. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing Defender Shim. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/shim/</string>
+			<key>pfm_name</key>
+			<string>InstallDefender</string>
+			<key>pfm_title</key>
+			<string>Install Defender Shim</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -136,8 +136,8 @@
 				</array>
 				<key>Installation</key>
 				<array>
-					<string>InstallDefender</string>
 					<string>InstallAutoUpdate</string>
+					<string>InstallDefender</string>
 					<string>InstallExcel</string>
 					<string>InstallOneDrive</string>
 					<string>InstallOneNote</string>
@@ -458,24 +458,6 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Defender Shim. (Not needed if you want to use default value of TRUE.)</string>
-			<key>pfm_description_reference</key>
-			<string>Disable the Office Suite installer from installing Defender Shim. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
-			<key>pfm_documentation_url</key>
-			<string>https://macadmins.software/shim/</string>
-			<key>pfm_name</key>
-			<string>InstallDefender</string>
-			<key>pfm_title</key>
-			<string>Install Defender Shim</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_app_min</key>
-			<string>16.24</string>
-			<key>pfm_default</key>
-			<true/>
-			<key>pfm_description</key>
 			<string>Uncheck (FALSE) to prevent the Office suite installer from installing AutoUpdate. (Not needed if you want to use default value of TRUE.)</string>
 			<key>pfm_description_reference</key>
 			<string>Disable the Office Suite installer from installing AutoUpdate. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
@@ -485,6 +467,24 @@
 			<string>InstallAutoUpdate</string>
 			<key>pfm_title</key>
 			<string>Install AutoUpdate (MAU)</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>16.24</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Uncheck (FALSE) to prevent the Office suite installer from installing Defender Shim. (Not needed if you want to use default value of TRUE.)</string>
+			<key>pfm_description_reference</key>
+			<string>Disable the Office Suite installer from installing Defender Shim. Only valid if set with a configuration profile or if written to /Library/Managed Preferences/com.microsoft.office.plist</string>
+			<key>pfm_documentation_url</key>
+			<string>https://macadmins.software/shim/</string>
+			<key>pfm_name</key>
+			<string>InstallDefender</string>
+			<key>pfm_title</key>
+			<string>Install Defender Shim</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>


### PR DESCRIPTION
Adds support for the new InstallDefender key as per https://learn.microsoft.com/en-au/deployoffice/mac/preferences-office#app-installation and https://macadmins.software/shim/.