### PR TITLE
Also update indexes for branch named "main"

### DIFF
--- a/.github/workflows/updateIndexes.yml
+++ b/.github/workflows/updateIndexes.yml
@@ -3,6 +3,7 @@ name: Update indexes
 on:
   push:
     branches:
+      - main
       - master
 
 jobs:


### PR DESCRIPTION
This PR will enable indexes to be rebuilt automatically should the default branch ever be switched to `main` from `master` in the future.

This is a lightweight version of the changes in https://github.com/ProfileCreator/ProfileManifests/pull/540, but does not require changing the default branch in GitHub.