### PR TITLE
Fix pfm_format_version in com.vpntracker.365mac-config.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
+++ b/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-11-11T09:00:00Z</date>
+	<date>2023-11-19T21:41:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -234,6 +234,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
+++ b/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
@@ -234,6 +234,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
+++ b/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
@@ -9,7 +9,7 @@
 	<key>pfm_domain</key>
 	<string>com.vpntracker.365mac</string>
 	<key>pfm_format_version</key>
-	<integer>6</integer>
+	<integer>1</integer>
 	<key>pfm_last_modified</key>
 	<date>2022-11-11T09:00:00Z</date>
 	<key>pfm_platforms</key>


### PR DESCRIPTION
The only currently valid value for `pfm_format_version` is `<integer>1</integer>`.