### PR TITLE
Automatic pre-commit checks on pull requests and pushes to master branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: Pre-commit checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/homebysix/pre-commit-macadmin
     # Please use commit hash instead of tag
-    rev: c668a2da8236a983ffaa0761fbbe31f90c0f5822
+    rev: 26bd4322b87b2136701aed0c77a60c7e931f3781
     hooks:
       - id: check-preference-manifests
         exclude: "^Resources/|^Manifests/ManagedPreferencesDeveloper/"


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that runs `pre-commit` on any files included in a pull request or push to master. This should provide useful signal to contributors if their pull request does not align with community preference manifest standards, even if the contributor doesn't have `pre-commit` installed or configured on their local system.

https://github.com/ProfileCreator/ProfileManifests/pull/641 should be merged before this PR, in order for this failure to be resolved:
```
Check Apple Preference Manifests.........................................Failed
- hook id: check-preference-manifests
- exit code: 1

Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist: pfm_format_version should be 1, not 6 (https://github.com/ProfileCreator/ProfileManifests/wiki/Manifest-Format-Versions)
```