### PR TITLE
DigiDNA WWDC 2023 (replacement)

### DIFF
--- a/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_max</key>
 	<string>10.12.6</string>
 	<key>pfm_macos_min</key>
@@ -318,6 +318,19 @@ Availability: Available in macOS 10.10 and later.</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>If 'true', and this payload is installed after enrolling with MDM in Setup Assistant, it requests Setup Assistant to enable FileVault at setup time. In this case, the system also ignores all other keys in this payload, except for 'ShowRecoveryKey'.
+To use this, enable the Await Device Configured DEP configuration option, send this profile with this key set, before sending the DeviceConfiguredCommand.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>ForceEnableInSetupAssistant</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -328,6 +341,6 @@ Availability: Available in macOS 10.10 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-09-06T08:17:53Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>
@@ -2704,6 +2704,146 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>Allows the application to access data of other apps.</string>
+					<key>pfm_macos_min</key>
+					<string>14.0</string>
+					<key>pfm_name</key>
+					<string>SystemPolicyAppData</string>
+					<key>pfm_platforms</key>
+					<array>
+						<string>macOS</string>
+					</array>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_name</key>
+							<string>IdentityDict</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_description</key>
+									<string>The bundle ID or installation path of the binary.</string>
+									<key>pfm_name</key>
+									<string>Identifier</string>
+									<key>pfm_require</key>
+									<string>always</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>The type of identifier value. Application bundles must be identified by bundle ID. Nonbundled binaries must be identified by installation path. Helper tools embedded within an application bundle automatically inherit the permissions of their enclosing app bundle.</string>
+									<key>pfm_name</key>
+									<string>IdentifierType</string>
+									<key>pfm_range_list</key>
+									<array>
+										<string>bundleID</string>
+										<string>path</string>
+									</array>
+									<key>pfm_require</key>
+									<string>always</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>Obtained via the command ''codesign -display -r -''.</string>
+									<key>pfm_name</key>
+									<string>CodeRequirement</string>
+									<key>pfm_require</key>
+									<string>always</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>If 'true', statically validate the code requirement. Used only if the process invalidates its dynamic code signature.</string>
+									<key>pfm_name</key>
+									<string>StaticCode</string>
+									<key>pfm_type</key>
+									<string>boolean</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>If 'true', access is granted; otherwise, the process doesn't have access. The user isn't prompted and can't change this value.</string>
+									<key>pfm_name</key>
+									<string>Allowed</string>
+									<key>pfm_require</key>
+									<string>always</string>
+									<key>pfm_type</key>
+									<string>boolean</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>The 'Authorization' key is an optional replacement for the 'Allowed' key. Every payload must specify either 'Authorization' or 'Allowed', but not both.
+'Allow': Equivalent to a 'true' value for the 'Allowed' key.
+'Deny': Equivalent to a 'false' value for the 'Allowed' key.
+'AllowStandardUserToSetSystemService:' allows a standard (non-admin) user to configure the permissions for the specified app in the Privacy preferences for services that otherwise require admin authorization. 'AllowStandardUserToSetSystemService' is only valid for the 'ListenEvent' and 'ScreenCapture' services.
+Available in macOS 11 and later.</string>
+									<key>pfm_macos_min</key>
+									<string>11.0</string>
+									<key>pfm_name</key>
+									<string>Authorization</string>
+									<key>pfm_platforms</key>
+									<array>
+										<string>macOS</string>
+									</array>
+									<key>pfm_range_list</key>
+									<array>
+										<string>Allow</string>
+										<string>Deny</string>
+										<string>AllowStandardUserToSetSystemService</string>
+									</array>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>Not used.</string>
+									<key>pfm_name</key>
+									<string>Comment</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>The identifier of the process receiving an AppleEvent sent by the Identifier process. This identifier is required for AppleEvents service; not valid for other services.</string>
+									<key>pfm_name</key>
+									<string>AEReceiverIdentifier</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>The type of AEReceiverIdentifier value, either 'bundleID' or 'path'. This setting is required for AppleEvents service; not valid for other services.</string>
+									<key>pfm_name</key>
+									<string>AEReceiverIdentifierType</string>
+									<key>pfm_range_list</key>
+									<array>
+										<string>bundleID</string>
+										<string>path</string>
+									</array>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string>The code requirement for the receiving binary. This code requirement is required for AppleEvents service; not valid for other services.</string>
+									<key>pfm_name</key>
+									<string>AEReceiverCodeRequirement</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
+							<key>pfm_type</key>
+							<string>dictionary</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>array</string>
+				</dict>
+				<dict>
 					<key>pfm_macos_min</key>
 					<string>13.0</string>
 					<key>pfm_name</key>
@@ -2842,6 +2982,6 @@
 	<key>pfm_user_approved</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_note</key>
 	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 	<key>pfm_platforms</key>
@@ -238,6 +238,7 @@ The payload organization for a payload need not match the payload organization i
 					<string>allowFindMyFriendsModification</string>
 					<string>allowGlobalBackgroundFetchWhenRoaming</string>
 					<string>allowHostPairing</string>
+					<string>allowiPhoneWidgetsOnMac</string>
 					<string>allowKeyboardShortcuts</string>
 					<string>allowLockScreenControlCenter</string>
 					<string>allowLockScreenNotificationsView</string>
@@ -1602,6 +1603,25 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<true/>
 			<key>pfm_title</key>
 			<string>Allow pairing with non-Configurator hosts</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', disallows iPhone widgets on a Mac that has signed in the same AppleID for iCloud. Supervised only.
+Available on iOS 17 and later.</string>
+			<key>pfm_description_reference</key>
+			<string></string>
+			<key>pfm_ios_min</key>
+			<string>17.0</string>
+			<key>pfm_name</key>
+			<string>allowiPhoneWidgetsOnMac</string>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_title</key>
+			<string>Allow iPhone widget on Mac</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -2990,6 +3010,6 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>8</integer>
+	<integer>9</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-18T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_note</key>
 	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 	<key>pfm_platforms</key>
@@ -135,6 +135,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				<string>iCloud</string>
 				<string>Passwords / Unlock</string>
 				<string>Classroom</string>
+				<string>Siri</string>
 				<string>Updates</string>
 			</array>
 			<key>pfm_require</key>
@@ -163,19 +164,30 @@ A profile can consist of payloads with different version numbers. For example, c
 				</array>
 				<key>General</key>
 				<array>
+					<string>allowAccountModification</string>
 					<string>allowActivityContinuation</string>
 					<string>allowAddingGameCenterFriends</string>
+					<string>allowARDRemoteManagementModification</string>
+					<string>allowBluetoothSharingModification</string>
 					<string>allowCamera</string>
 					<string>allowContentCaching</string>
 					<string>allowDefinitionLookup</string>
 					<string>allowDeprecatedWebKitTLS</string>
+					<string>allowDeviceNameModification</string>
 					<string>allowEraseContentAndSettings</string>
+					<string>allowFileSharingModification</string>
 					<string>allowGameCenter</string>
+					<string>allowInternetSharingModification</string>
+					<string>allowLocalUserCreation</string>
 					<string>allowMailPrivacyProtection</string>
+					<string>allowPrinterSharingModification</string>
 					<string>allowUniversalControl</string>
 					<string>allowMusicService</string>
+					<string>allowRemoteAppleEventsModification</string>
 					<string>allowRemoteScreenObservation</string>
 					<string>allowScreenShot</string>
+					<string>allowStartupDiskModification</string>
+					<string>allowTimeMachineBackup</string>
 					<string>allowUIConfigurationProfileInstallation</string>
 					<string>allowSpotlightInternetResults</string>
 					<string>allowiTunesFileSharing</string>
@@ -185,10 +197,15 @@ A profile can consist of payloads with different version numbers. For example, c
 				<array>
 					<string>allowAutoUnlock</string>
 					<string>allowFingerprintForUnlock</string>
+					<string>allowFingerprintModification</string>
 					<string>allowPasswordAutoFill</string>
 					<string>allowPasswordProximityRequests</string>
 					<string>allowPasswordSharing</string>
 					<string>enforcedFingerprintTimeout</string>
+				</array>
+				<key>Siri</key>
+				<array>
+					<string>allowAssistant</string>
 				</array>
 				<key>Updates</key>
 				<array>
@@ -211,6 +228,7 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>allowCloudDesktopAndDocuments</string>
 					<string>allowCloudDocumentSync</string>
 					<string>allowCloudFMM</string>
+					<string>allowCloudFreeform</string>
 					<string>allowCloudKeychainSync</string>
 					<string>allowCloudMail</string>
 					<string>allowCloudNotes</string>
@@ -336,6 +354,21 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
+			<string>If 'false', prevents modifying Printer Sharing setting in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowPrinterSharingModification</string>
+			<key>pfm_title</key>
+			<string>Allow modifying Printer Sharing setting</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
 			<string>Set to false to prevent sharing mouse and keyboard between a Mac and an iPad</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
@@ -359,6 +392,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>allowiTunesFileSharing</string>
 			<key>pfm_title</key>
 			<string>Allow iTunes File Sharing</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', disables account modification. iOS requires a supervised device. Available in iOS 7 and later, and macOS 14.0 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowAccountModification</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -409,6 +454,23 @@ A profile can consist of payloads with different version numbers. For example, c
 			<true/>
 			<key>pfm_title</key>
 			<string>Allow Apple Music</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents modifying Remote Apple Events Sharing setting in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_description_reference</key>
+			<string></string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowRemoteAppleEventsModification</string>
+			<key>pfm_title</key>
+			<string>Allow modifying Remote Apple Events Sharing setting</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -523,6 +585,22 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>allowCloudFMM</string>
 			<key>pfm_title</key>
 			<string>Allow iCloud Find My Mac</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_description_reference</key>
+			<string>If 'false', disallows iCloud Freeform services. Available in macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowCloudFreeform</string>
+			<key>pfm_title</key>
+			<string>Allow Cloud Freeform</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -662,6 +740,22 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_description_reference</key>
+			<string>Supervised only. If set to false, disables the "Erase All Content And Settings" option in the Reset UI.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowFileSharingModification</string>
+			<key>pfm_title</key>
+			<string>Allow modifying File Sharing setting</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_description_reference</key>
 			<string>Optional. If false, prevents Touch ID from unlocking a device. Availability: Available in iOS 7 and later and in macOS 10.12.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12.4</string>
@@ -669,6 +763,20 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>allowFingerprintForUnlock</string>
 			<key>pfm_title</key>
 			<string>Allow Touch ID / Face ID to unlock device</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents the user from modifying Touch ID or Face ID. Requires a supervised device. Available in iOS 8.3 and later, and macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowFingerprintModification</string>
+			<key>pfm_title</key>
+			<string>Allow Modifying Touch ID Fingerprints</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -710,6 +818,21 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
+			<string>If 'false', prevents the user from changing the device name. Requires a supervised device.
+Available in iOS 9 and later, macOS 14 and later, and tvOS 11.0 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowDeviceNameModification</string>
+			<key>pfm_title</key>
+			<string>Allow Modifying Device Name</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
@@ -726,6 +849,36 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
+			<string>If 'false', prevents modifying Internet Sharing setting in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowInternetSharingModification</string>
+			<key>pfm_title</key>
+			<string>Allow modifying Internet Sharing setting</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents creating new users in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowLocalUserCreation</string>
+			<key>pfm_title</key>
+			<string>Allow creating users in System Settings</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
 			<string></string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
@@ -735,6 +888,36 @@ A profile can consist of payloads with different version numbers. For example, c
 			<true/>
 			<key>pfm_title</key>
 			<string>Allow adding Game Center friends</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents modifying the Remote Management Sharing setting in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowARDRemoteManagementModification</string>
+			<key>pfm_title</key>
+			<string>Allow modifying Remote Management Sharing setting</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents modifying the Remote Management Sharing setting in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowBluetoothSharingModification</string>
+			<key>pfm_title</key>
+			<string>Allow modifying Bluetooth Sharing setting</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -809,6 +992,40 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>allowScreenShot</string>
 			<key>pfm_title</key>
 			<string>Allow screenshots and screen recording</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents modification of Startup Disk setting in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_description_reference</key>
+			<string></string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowStartupDiskModification</string>
+			<key>pfm_title</key>
+			<string>Allow modifying Startup Disk settings</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents modification of Time Machine settings in System Settings.
+Available in macOS 14 and later.</string>
+			<key>pfm_description_reference</key>
+			<string></string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowTimeMachineBackup</string>
+			<key>pfm_title</key>
+			<string>Allow modifying Time Machine settings</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -981,6 +1198,20 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<true/>
 			<key>pfm_title</key>
 			<string>Allow USB Restricted Mode</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', disables Siri or Siri settings. Available in iOS 5 and later, and macOS 14.0 and later. Also available on iOS for user enrollment.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>allowAssistant</string>
+			<key>pfm_title</key>
+			<string>Allow Siri</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -1260,6 +1491,6 @@ Available in macOS 11 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>12</integer>
+	<integer>13</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-18T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_note</key>
 	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 	<key>pfm_platforms</key>
@@ -168,6 +168,7 @@ The payload organization for a payload need not match the payload organization i
 				<key>General</key>
 				<array>
 					<string>allowAutomaticScreenSaver</string>
+					<string>allowCamera</string>
 					<string>allowCloudPrivateRelay</string>
 					<string>allowDeviceNameModification</string>
 					<string>allowInAppPurchases</string>
@@ -245,6 +246,20 @@ The payload organization for a payload need not match the payload organization i
 			<string>Allow Automatic Screen Saver</string>
 			<key>pfm_tvos_min</key>
 			<string>15.4</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', disables the camera, and its icon is removed from the Home screen. Users are unable to take photographs. This restriction is deprecated on unsupervised devices and will be supervised only in a future release.  Available in iOS 4 and later, and macOS 10.11 and later.</string>
+			<key>pfm_name</key>
+			<string>allowCamera</string>
+			<key>pfm_title</key>
+			<string>Allow Camera</string>
+			<key>pfm_tvos_min</key>
+			<string>17.0</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -807,6 +822,6 @@ The payload organization for a payload need not match the payload organization i
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.associated-domains.plist
+++ b/Manifests/ManifestsApple/com.apple.associated-domains.plist
@@ -3,18 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Parental Controls: Dashboard settings</string>
-	<key>pfm_description_reference</key>
-	<string>The Parental Control Dashboard payload is designated by specifying com.apple.dashboard as the PayloadType value.
-It is used to define a white list of dashboard widgets.</string>
+	<string>Use this section to define settings for Associated Domains to be used with features such as Extensible AppSSO, universal links and Password AutoFill.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/associateddomains</string>
 	<key>pfm_domain</key>
-	<string>com.apple.dashboard</string>
+	<string>com.apple.associated-domains</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
-	<key>pfm_interaction</key>
-	<string>exclusive</string>
 	<key>pfm_last_modified</key>
 	<date>2023-11-23T13:57:28Z</date>
+	<key>pfm_macos_min</key>
+	<string>10.15</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -23,7 +22,7 @@ It is used to define a white list of dashboard widgets.</string>
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Parental Controls: Dashboard settings</string>
+			<string>Use this section to define settings for Associated Domains to be used with features such as Extensible AppSSO, universal links and Password AutoFill.</string>
 			<key>pfm_description</key>
 			<string>Description of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -37,7 +36,7 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>Parental Controls: Dashboard</string>
+			<string>Associated Domains</string>
 			<key>pfm_description</key>
 			<string>Name of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -53,9 +52,9 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.dashboard</string>
+			<string>com.apple.associated-domains</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
 			<key>pfm_description_reference</key>
 			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
 			<key>pfm_name</key>
@@ -69,7 +68,7 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.dashboard</string>
+			<string>com.apple.associated-domains</string>
 			<key>pfm_description</key>
 			<string>The type of the payload, a reverse dns string.</string>
 			<key>pfm_description_reference</key>
@@ -84,10 +83,8 @@ It is used to define a white list of dashboard widgets.</string>
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
 			<key>pfm_description_reference</key>
 			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
 			<key>pfm_format</key>
@@ -107,8 +104,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_description</key>
 			<string>The version of the whole configuration profile.</string>
 			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +116,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -133,79 +126,59 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to true to enable the widget white list items.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Set to true to enable the widget white list items.</string>
+			<string>A dictionary that maps apps to their associated domains.</string>
 			<key>pfm_name</key>
-			<string>whiteListEnabled</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Enable dashboard widget allowlist</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_allowed_file_types</key>
-			<array>
-				<string>com.apple.dashboard-widget</string>
-			</array>
-			<key>pfm_description</key>
-			<string>List that defines Dashboard widgets.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. List that defines Dashboard widgets.</string>
-			<key>pfm_name</key>
-			<string>WhiteList</string>
+			<string>Configuration</string>
 			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_name</key>
-					<string>WhiteListItem</string>
+					<string>ConfigurationItem</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
-							<key>pfm_default</key>
-							<string>bundleID</string>
 							<key>pfm_description</key>
-							<string>Set to "bundleID" to use a widget's bundle ID as its ID.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. Set to bundleID to use a widget's bundle ID as its ID.</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
+							<string>The app identifier to associate the domains with.</string>
 							<key>pfm_name</key>
-							<string>Type</string>
-							<key>pfm_range_list</key>
-							<array>
-								<string>bundleID</string>
-							</array>
-							<key>pfm_range_list_titles</key>
-							<array>
-								<string>Bundle ID</string>
-							</array>
+							<string>ApplicationIdentifier</string>
 							<key>pfm_require</key>
 							<string>always</string>
-							<key>pfm_title</key>
-							<string>Entry Type</string>
 							<key>pfm_type</key>
 							<string>string</string>
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The bundle ID of a widget.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. The bundle ID of a widget.</string>
+							<string>The domains to be associated with the app. Each string is in the form of ''service:domain''. Domains should be fully qualified hostnames, like 'www.example.com'.
+See Supporting Associated Domains for more information.</string>
 							<key>pfm_name</key>
-							<string>ID</string>
+							<string>AssociatedDomains</string>
 							<key>pfm_require</key>
 							<string>always</string>
-							<key>pfm_title</key>
-							<string>Bundle ID</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>AssociatedDomain</string>
+									<key>pfm_require</key>
+									<string>always</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
 							<key>pfm_type</key>
-							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>com.apple.widget.name</string>
+							<string>array</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>If 'true', data for this domain should be downloaded directly instead of through a CDN. The entitlement value for this domain must be set to 'service:domain?mode=managed' or this value will be ignored. Available in macOS 11 and later.</string>
+							<key>pfm_macos_min</key>
+							<string>11.0</string>
+							<key>pfm_name</key>
+							<string>EnableDirectDownloads</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
 						</dict>
 					</array>
 					<key>pfm_type</key>
@@ -213,11 +186,9 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_title</key>
-			<string>Dashboard widget allowlist</string>
+			<string>Configuration</string>
 			<key>pfm_type</key>
 			<string>array</string>
-			<key>pfm_value_import_processor</key>
-			<string>com.apple.dashboard.whiteList</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>
@@ -226,10 +197,10 @@ The payload organization for a payload need not match the payload organization i
 		<string>user</string>
 	</array>
 	<key>pfm_title</key>
-	<string>Parental Controls: Dashboard</string>
+	<string>Associated Domains</string>
 	<key>pfm_unique</key>
-	<true/>
+	<false/>
 	<key>pfm_version</key>
-	<integer>9</integer>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.cellularprivatenetwork.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.cellularprivatenetwork.managed.plist
@@ -3,27 +3,26 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Parental Controls: Dashboard settings</string>
-	<key>pfm_description_reference</key>
-	<string>The Parental Control Dashboard payload is designated by specifying com.apple.dashboard as the PayloadType value.
-It is used to define a white list of dashboard widgets.</string>
+	<string>Cellular Private Network Settings and Device Configuration</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/cellularprivatenetwork</string>
 	<key>pfm_domain</key>
-	<string>com.apple.dashboard</string>
+	<string>com.apple.cellularprivatenetwork.managed</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
-	<key>pfm_interaction</key>
-	<string>exclusive</string>
+	<key>pfm_ios_min</key>
+	<string>17.0</string>
 	<key>pfm_last_modified</key>
 	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_platforms</key>
 	<array>
-		<string>macOS</string>
+		<string>iOS</string>
 	</array>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Parental Controls: Dashboard settings</string>
+			<string>Cellular Private Network Settings and Device Configuration</string>
 			<key>pfm_description</key>
 			<string>Description of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -37,7 +36,7 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>Parental Controls: Dashboard</string>
+			<string>Cellular Private Network</string>
 			<key>pfm_description</key>
 			<string>Name of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -53,9 +52,9 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.dashboard</string>
+			<string>com.apple.cellularprivatenetwork.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
 			<key>pfm_description_reference</key>
 			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
 			<key>pfm_name</key>
@@ -69,7 +68,7 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.dashboard</string>
+			<string>com.apple.cellularprivatenetwork.managed</string>
 			<key>pfm_description</key>
 			<string>The type of the payload, a reverse dns string.</string>
 			<key>pfm_description_reference</key>
@@ -84,10 +83,8 @@ It is used to define a white list of dashboard widgets.</string>
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
 			<key>pfm_description_reference</key>
 			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
 			<key>pfm_format</key>
@@ -107,8 +104,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_description</key>
 			<string>The version of the whole configuration profile.</string>
 			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +116,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -133,103 +126,122 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to true to enable the widget white list items.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Set to true to enable the widget white list items.</string>
+			<string>List of up to 1000 geofences for private networks. Geofencing is only used on iPhones.</string>
 			<key>pfm_name</key>
-			<string>whiteListEnabled</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Enable dashboard widget allowlist</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_allowed_file_types</key>
-			<array>
-				<string>com.apple.dashboard-widget</string>
-			</array>
-			<key>pfm_description</key>
-			<string>List that defines Dashboard widgets.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. List that defines Dashboard widgets.</string>
-			<key>pfm_name</key>
-			<string>WhiteList</string>
-			<key>pfm_require</key>
-			<string>always</string>
+			<string>Geofences</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_name</key>
-					<string>WhiteListItem</string>
+					<string>GeofenceItem</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
-							<key>pfm_default</key>
-							<string>bundleID</string>
 							<key>pfm_description</key>
-							<string>Set to "bundleID" to use a widget's bundle ID as its ID.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. Set to bundleID to use a widget's bundle ID as its ID.</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
+							<string>Signed decimal value of longitude from -180 to 180</string>
 							<key>pfm_name</key>
-							<string>Type</string>
-							<key>pfm_range_list</key>
-							<array>
-								<string>bundleID</string>
-							</array>
-							<key>pfm_range_list_titles</key>
-							<array>
-								<string>Bundle ID</string>
-							</array>
+							<string>Longitude</string>
+							<key>pfm_range_max</key>
+							<real>180</real>
+							<key>pfm_range_min</key>
+							<real>-180</real>
 							<key>pfm_require</key>
 							<string>always</string>
-							<key>pfm_title</key>
-							<string>Entry Type</string>
 							<key>pfm_type</key>
-							<string>string</string>
+							<string>real</string>
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The bundle ID of a widget.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. The bundle ID of a widget.</string>
+							<string>Signed decimal value of latitude from -90 to 90</string>
 							<key>pfm_name</key>
-							<string>ID</string>
+							<string>Latitude</string>
+							<key>pfm_range_max</key>
+							<real>90</real>
+							<key>pfm_range_min</key>
+							<real>-90</real>
 							<key>pfm_require</key>
 							<string>always</string>
-							<key>pfm_title</key>
-							<string>Bundle ID</string>
+							<key>pfm_type</key>
+							<string>real</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Specifies the radius of the geofence in meters. Should be set slightly greater than the private cellular network coverage area. Supported values 100 to 6500</string>
+							<key>pfm_name</key>
+							<string>Radius</string>
+							<key>pfm_range_max</key>
+							<real>6500</real>
+							<key>pfm_range_min</key>
+							<real>100</real>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_type</key>
+							<string>real</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>ID of geofence, must be unique amongst list</string>
+							<key>pfm_name</key>
+							<string>GeofenceId</string>
+							<key>pfm_require</key>
+							<string>always</string>
 							<key>pfm_type</key>
 							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>com.apple.widget.name</string>
 						</dict>
 					</array>
 					<key>pfm_type</key>
 					<string>dictionary</string>
 				</dict>
 			</array>
-			<key>pfm_title</key>
-			<string>Dashboard widget allowlist</string>
 			<key>pfm_type</key>
 			<string>array</string>
-			<key>pfm_value_import_processor</key>
-			<string>com.apple.dashboard.whiteList</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Name for private network configuration dataset</string>
+			<key>pfm_name</key>
+			<string>DataSetName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>The version number of this dataset. Used to track updates</string>
+			<key>pfm_name</key>
+			<string>VersionNumber</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Set to true if this private network should be preferred over wifi</string>
+			<key>pfm_name</key>
+			<string>CellularDataPreferred</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Set to true if this private network is NR Standalone</string>
+			<key>pfm_name</key>
+			<string>EnableNRStandalone</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
 		<string>system</string>
-		<string>user</string>
 	</array>
 	<key>pfm_title</key>
-	<string>Parental Controls: Dashboard</string>
+	<string>Cellular Private Network</string>
 	<key>pfm_unique</key>
-	<true/>
+	<false/>
 	<key>pfm_version</key>
-	<integer>9</integer>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.declarations.plist
+++ b/Manifests/ManifestsApple/com.apple.declarations.plist
@@ -3,27 +3,30 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Parental Controls: Dashboard settings</string>
-	<key>pfm_description_reference</key>
-	<string>The Parental Control Dashboard payload is designated by specifying com.apple.dashboard as the PayloadType value.
-It is used to define a white list of dashboard widgets.</string>
+	<string>Declarations</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/declarations-t8t</string>
 	<key>pfm_domain</key>
-	<string>com.apple.dashboard</string>
+	<string>com.apple.declarations</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
-	<key>pfm_interaction</key>
-	<string>exclusive</string>
+	<key>pfm_ios_min</key>
+	<string>17.0</string>
 	<key>pfm_last_modified</key>
 	<date>2023-11-23T13:57:28Z</date>
+	<key>pfm_macos_min</key>
+	<string>14.0</string>
 	<key>pfm_platforms</key>
 	<array>
+		<string>iOS</string>
+		<string>tvOS</string>
 		<string>macOS</string>
 	</array>
 	<key>pfm_subkeys</key>
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Parental Controls: Dashboard settings</string>
+			<string>Declarations</string>
 			<key>pfm_description</key>
 			<string>Description of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -37,7 +40,7 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>Parental Controls: Dashboard</string>
+			<string>Declarations</string>
 			<key>pfm_description</key>
 			<string>Name of the payload.</string>
 			<key>pfm_description_reference</key>
@@ -53,9 +56,9 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.dashboard</string>
+			<string>com.apple.declarations</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
 			<key>pfm_description_reference</key>
 			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
 			<key>pfm_name</key>
@@ -69,7 +72,7 @@ It is used to define a white list of dashboard widgets.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>com.apple.dashboard</string>
+			<string>com.apple.declarations</string>
 			<key>pfm_description</key>
 			<string>The type of the payload, a reverse dns string.</string>
 			<key>pfm_description_reference</key>
@@ -84,10 +87,8 @@ It is used to define a white list of dashboard widgets.</string>
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_default</key>
-			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
 			<key>pfm_description_reference</key>
 			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
 			<key>pfm_format</key>
@@ -107,8 +108,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_description</key>
 			<string>The version of the whole configuration profile.</string>
 			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +120,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -133,103 +130,42 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to true to enable the widget white list items.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Set to true to enable the widget white list items.</string>
+			<string>The set of declarations to apply. The items in this array are &lt;data&gt; (base64-encoded) representations
+of the declaration JSON data.</string>
 			<key>pfm_name</key>
-			<string>whiteListEnabled</string>
-			<key>pfm_require</key>
-			<string>always</string>
-			<key>pfm_title</key>
-			<string>Enable dashboard widget allowlist</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_allowed_file_types</key>
-			<array>
-				<string>com.apple.dashboard-widget</string>
-			</array>
-			<key>pfm_description</key>
-			<string>List that defines Dashboard widgets.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. List that defines Dashboard widgets.</string>
-			<key>pfm_name</key>
-			<string>WhiteList</string>
+			<string>Declarations</string>
 			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_description</key>
+					<string>An item in the declarations list</string>
 					<key>pfm_name</key>
-					<string>WhiteListItem</string>
-					<key>pfm_subkeys</key>
-					<array>
-						<dict>
-							<key>pfm_default</key>
-							<string>bundleID</string>
-							<key>pfm_description</key>
-							<string>Set to "bundleID" to use a widget's bundle ID as its ID.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. Set to bundleID to use a widget's bundle ID as its ID.</string>
-							<key>pfm_hidden</key>
-							<string>all</string>
-							<key>pfm_name</key>
-							<string>Type</string>
-							<key>pfm_range_list</key>
-							<array>
-								<string>bundleID</string>
-							</array>
-							<key>pfm_range_list_titles</key>
-							<array>
-								<string>Bundle ID</string>
-							</array>
-							<key>pfm_require</key>
-							<string>always</string>
-							<key>pfm_title</key>
-							<string>Entry Type</string>
-							<key>pfm_type</key>
-							<string>string</string>
-						</dict>
-						<dict>
-							<key>pfm_description</key>
-							<string>The bundle ID of a widget.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. The bundle ID of a widget.</string>
-							<key>pfm_name</key>
-							<string>ID</string>
-							<key>pfm_require</key>
-							<string>always</string>
-							<key>pfm_title</key>
-							<string>Bundle ID</string>
-							<key>pfm_type</key>
-							<string>string</string>
-							<key>pfm_value_placeholder</key>
-							<string>com.apple.widget.name</string>
-						</dict>
-					</array>
+					<string>DeclarationsItem</string>
+					<key>pfm_require</key>
+					<string>always</string>
+					<key>pfm_title</key>
+					<string>Declarations Content Item</string>
 					<key>pfm_type</key>
-					<string>dictionary</string>
+					<string>data</string>
 				</dict>
 			</array>
 			<key>pfm_title</key>
-			<string>Dashboard widget allowlist</string>
+			<string>Declarations</string>
 			<key>pfm_type</key>
 			<string>array</string>
-			<key>pfm_value_import_processor</key>
-			<string>com.apple.dashboard.whiteList</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
 		<string>system</string>
-		<string>user</string>
 	</array>
 	<key>pfm_title</key>
-	<string>Parental Controls: Dashboard</string>
-	<key>pfm_unique</key>
-	<true/>
+	<string>Declarations</string>
+	<key>pfm_tvos_min</key>
+	<string>17.0</string>
 	<key>pfm_version</key>
-	<integer>9</integer>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>14.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_platforms</key>
@@ -488,6 +488,20 @@ Matching with a single wildcard is supported. For example, 17.* matches any DNS 
 			<key>pfm_user_approved</key>
 			<true/>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>UUID pointing to an identity certificate payload. This identity will be used to authenticate the user to the DNS resolver.</string>
+			<key>pfm_ios_min</key>
+			<string>16.0</string>
+			<key>pfm_macos_min</key>
+			<string>13.0</string>
+			<key>pfm_name</key>
+			<string>PayloadCertificateUUID</string>
+			<key>pfm_title</key>
+			<string>Certificate UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -498,6 +512,6 @@ Matching with a single wildcard is supported. For example, 17.* matches any DNS 
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.extensiblesso.plist
+++ b/Manifests/ManifestsApple/com.apple.extensiblesso.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>13.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-17T11:47:33Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -1797,6 +1797,8 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 		<dict>
 			<key>pfm_description</key>
 			<string>Platform SSO authentication method supported and used by the configured SSO extension.</string>
+			<key>pfm_macos_deprecated</key>
+			<string>14.0</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -1850,6 +1852,223 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>This is the dictionary used to configure PlatformSSO.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>PlatformSSO</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>The Platform SSO authentication method to be used with the extension. Requires that the SSO Extension also support the method.</string>
+					<key>pfm_name</key>
+					<string>AuthenticationMethod</string>
+					<key>pfm_range_list</key>
+					<array>
+						<string>Password</string>
+						<string>UserSecureEnclaveKey</string>
+						<string>SmartCard</string>
+					</array>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<false/>
+					<key>pfm_description</key>
+					<string>If set to true, Platform SSO will use the same signing and encryption keys for all users.</string>
+					<key>pfm_name</key>
+					<string>UseSharedDeviceKeys</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>The display name for the account in notifications and authentication requests.</string>
+					<key>pfm_name</key>
+					<string>AccountDisplayName</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<integer>64800</integer>
+					<key>pfm_description</key>
+					<string>The frequency where a full login is required instead of a refresh. Default is 18 hours. Must be &gt; 1 hour.</string>
+					<key>pfm_name</key>
+					<string>LoginFrequency</string>
+					<key>pfm_range_min</key>
+					<integer>3600</integer>
+					<key>pfm_type</key>
+					<string>integer</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<false/>
+					<key>pfm_description</key>
+					<string>Enables creating new users at the login window with either Passwords or SmartCards. Requires 'UseSharedDeviceKeys' is true.</string>
+					<key>pfm_name</key>
+					<string>EnableCreateUserAtLogin</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_default</key>
+					<false/>
+					<key>pfm_description</key>
+					<string>Enables using identity provider accounts at authorization prompts. Requires 'UseSharedDeviceKeys' is true. The account will be assigned groups using the 'AdministratorGroups', 'AdditionalGroups', or 'AuthorizationGroups'.</string>
+					<key>pfm_name</key>
+					<string>EnableAuthorization</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>The attribute mapping used when creating new users or for authorization.</string>
+					<key>pfm_name</key>
+					<string>TokenToUserMapping</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The claim name to use for the user's account name.</string>
+							<key>pfm_name</key>
+							<string>AccountName</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The claim name to use for the user's full name.</string>
+							<key>pfm_name</key>
+							<string>FullName</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>This setting affects the permissions for accounts created at login by Platform SSO. It is only used when the account is created. Use of the following:
+* Standard
+    The account will be a standard user.
+* Admin
+    The account will be added to the local administrators group.
+* Groups
+    The account will be assigned groups using the 'AdministratorGroups', 'AdditionalGroups', or 'AuthorizationGroups'.</string>
+					<key>pfm_name</key>
+					<string>NewUserAuthorizationMode</string>
+					<key>pfm_range_list</key>
+					<array>
+						<string>Standard</string>
+						<string>Admin</string>
+						<string>Groups</string>
+					</array>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>This setting affects the permissions after authentication by Platform SSO. It is applied each time user authenticates. Use of the following:
+* Standard
+    The account will be a standard user. It will be removed from the 'admin' group.
+* Admin
+    The account will be added to the local administrators group.
+* Groups
+    The account will be assigned groups using the 'AdministratorGroups', 'AdditionalGroups', or 'AuthorizationGroups'.</string>
+					<key>pfm_name</key>
+					<string>UserAuthorizationMode</string>
+					<key>pfm_range_list</key>
+					<array>
+						<string>Standard</string>
+						<string>Admin</string>
+						<string>Groups</string>
+					</array>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>The list of groups that are used for administrator access. Membership will be requested during authentication.</string>
+					<key>pfm_name</key>
+					<string>AdministratorGroups</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The group name.</string>
+							<key>pfm_name</key>
+							<string>Group</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>array</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>The list of groups that are created and do not have administrator access.</string>
+					<key>pfm_name</key>
+					<string>AdditionalGroups</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The group name.</string>
+							<key>pfm_name</key>
+							<string>Group</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>array</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>The pairing of Authorization Rights to group names. The Authorization Right will be updated to use the group when used.</string>
+					<key>pfm_name</key>
+					<string>AuthorizationGroups</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The Authorization Right to update.</string>
+							<key>pfm_name</key>
+							<string>Authorization Right</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The group to use for the Authorization Right.</string>
+							<key>pfm_name</key>
+							<string>Group</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -1863,6 +2082,6 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 	<key>pfm_user_approved</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
@@ -12,13 +12,17 @@
 	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
+	<key>pfm_ios_min</key>
+	<string>17.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
 	<array>
+		<string>iOS</string>
 		<string>macOS</string>
+		<string>tvOS</string>
 	</array>
 	<key>pfm_subkeys</key>
 	<array>
@@ -794,6 +798,8 @@ If false, the authentication fails if the certificate isn't already trusted.</st
 	</array>
 	<key>pfm_title</key>
 	<string>802.1X Ethernet: Global</string>
+	<key>pfm_tvos_min</key>
+	<string>17.0</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -16,7 +16,7 @@ window payloads may be installed together.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -160,6 +160,8 @@ The payload organization for a payload need not match the payload organization i
 				<key>Options</key>
 				<array>
 					<string>com.apple.login.mcx.DisableAutoLoginClient</string>
+					<string>AutologinUsername</string>
+					<string>AutologinPassword</string>
 					<string>DisableFDEAutoLogin</string>
 					<string>DisableConsoleAccess</string>
 					<string>EnableExternalAccounts</string>
@@ -548,6 +550,26 @@ Availability: Available in macOS 10.13 and later.</string>
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>Sets up auto login with the specified short user name.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>AutologinUsername</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Optional user password when setting up auto login.  If this key does not exist, and a user name was specified, auto login will be set up the next time the specified user logs in to the client.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>AutologinPassword</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
@@ -852,6 +874,6 @@ Availability: Available in macOS 10.13 and later.</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>6</integer>
+	<integer>7</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.mdm.plist
+++ b/Manifests/ManifestsApple/com.apple.mdm.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-23T13:58:21Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -157,10 +157,13 @@
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_name</key>
+					<string>ServerCapabilitiesItems</string>
 					<key>pfm_range_list</key>
 					<array>
 						<string>com.apple.mdm.per-user-connections</string>
 						<string>com.apple.mdm.bootstraptoken</string>
+						<string>com.apple.mdm.token</string>
 					</array>
 					<key>pfm_type</key>
 					<string>string</string>
@@ -201,9 +204,13 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The user's managed Apple ID.</string>
+			<string>The Managed Apple ID of the user. Available in iOS 13.1 and later, and macOS 10.15 and later. This is only used with the profile-driven BYOD enrollment flow, and must not be present in the BYOD and ADDE account-driven enrollment flows. As of iOS 17 and macOS 14, profile-driven user enrollments are deprecated and will be removed in a future release.</string>
+			<key>pfm_ios_deprecated</key>
+			<string>17.0</string>
 			<key>pfm_ios_min</key>
 			<string>13.1</string>
+			<key>pfm_macos_deprecated</key>
+			<string>14.0</string>
 			<key>pfm_macos_min</key>
 			<string>10.15</string>
 			<key>pfm_name</key>
@@ -380,7 +387,7 @@
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_macos_min</key>
-			<string>12.0</string>
+			<string>14.0</string>
 			<key>pfm_name</key>
 			<string>AssignedManagedAppleID</string>
 			<key>pfm_title</key>
@@ -396,7 +403,7 @@
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_macos_min</key>
-			<string>12.0</string>
+			<string>14.0</string>
 			<key>pfm_name</key>
 			<string>EnrollmentMode</string>
 			<key>pfm_note</key>
@@ -404,6 +411,7 @@
 			<key>pfm_range_list</key>
 			<array>
 				<string>BYOD</string>
+				<string>ADDE</string>
 			</array>
 			<key>pfm_title</key>
 			<string>EnrollmentMode</string>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-01-27T01:33:49Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -335,6 +335,61 @@
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Specifies a regular expression, and its description, used to enforce password compliance. Use the simpler passcode restrictions whenever possible, and rely on regular expression matching only when necessary. Mistakes in regular expressions can lead to frustrating user experiences, such as unsatisfiable passcode policies, or policy descriptions that don't match the enforced policy.
+Available in macOS 14 and later.</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>customRegex</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>macOS</string>
+			</array>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>A regular expression string that they system matches against the password to determine whether it complies with a policy. The regular expression uses the ICU syntax (&lt;https://unicode-org.github.io/icu/userguide/strings/regexp.html&gt;). The string must not exceed 2048 characters in length.</string>
+					<key>pfm_name</key>
+					<string>passwordContentRegex</string>
+					<key>pfm_require</key>
+					<string>always</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>Contains a dictionary of keys for supported OS language IDs (for example, “en-US”), and whose values represent a localized description of the policy enforced by the regular expression. Use the special 'default' key can for languages that aren't contained in the dictionary.</string>
+					<key>pfm_name</key>
+					<string>passwordContentDescription</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string></string>
+							<key>pfm_name</key>
+							<string>{{key}}</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string></string>
+							<key>pfm_name</key>
+							<string>{{value}}</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -346,6 +401,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.proxy.http.global.plist
+++ b/Manifests/ManifestsApple/com.apple.proxy.http.global.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>6.0</string>
 	<key>pfm_last_modified</key>
-	<date>2022-12-14T02:29:16Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -157,7 +157,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The proxy server's network address.</string>
+			<string>The proxy server's network address. This is required if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -203,7 +203,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The port on which to connect to the proxy server.</string>
+			<string>The proxy server's port number. This is required if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -229,7 +229,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The user name for the proxy server.</string>
+			<string>The user name used to authenticate to the proxy server. This setting is only used if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -255,7 +255,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The authentication password for the proxy server.</string>
+			<string>The password used to authenticate to the proxy server. This setting is only used if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -303,7 +303,7 @@
 			<key>pfm_name</key>
 			<string>ProxyPACURL</string>
 			<key>pfm_note</key>
-			<string>Beginning with iOS 13 and macOS 10.15, URLs must be prefixed by http:// or https://. This property is a required on platforms earlier than iOS 14.5, macOS 11.3, and tvOS 14.5.</string>
+			<string>The URL of the PAC file that defines the proxy configuration. Starting in iOS 13 and macOS 10.15, only URLs that begin with 'http://' or 'https://' are allowed. This setting is only used if the ProxyType is set to Automatic, and is ignored if the ProxyType is set to Manual.</string>
 			<key>pfm_title</key>
 			<string>Proxy PAC URL</string>
 			<key>pfm_type</key>

--- a/Manifests/ManifestsApple/com.apple.relay.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.relay.managed.plist
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>pfm_description</key>
+	<string>Use this section to define settings for network relays.</string>
+	<key>pfm_domain</key>
+	<string>com.apple.relay.managed</string>
+	<key>pfm_format_version</key>
+	<integer>1</integer>
+	<key>pfm_ios_min</key>
+	<string>17.0</string>
+	<key>pfm_last_modified</key>
+	<date>2023-11-23T13:57:28Z</date>
+	<key>pfm_macos_min</key>
+	<string>14.0</string>
+	<key>pfm_platforms</key>
+	<array>
+		<string>iOS</string>
+		<string>macOS</string>
+	</array>
+	<key>pfm_subkeys</key>
+	<array>
+		<dict>
+			<key>pfm_default</key>
+			<string>Use this section to define settings for network relays.</string>
+			<key>pfm_description</key>
+			<string>Description of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<key>pfm_name</key>
+			<string>PayloadDescription</string>
+			<key>pfm_title</key>
+			<string>Payload Description</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>Relay</string>
+			<key>pfm_description</key>
+			<string>Name of the payload.</string>
+			<key>pfm_description_reference</key>
+			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<key>pfm_name</key>
+			<string>PayloadDisplayName</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Display Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.apple.relay.managed</string>
+			<key>pfm_description</key>
+			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<key>pfm_description_reference</key>
+			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<key>pfm_name</key>
+			<string>PayloadIdentifier</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Identifier</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>com.apple.relay.managed</string>
+			<key>pfm_description</key>
+			<string>The type of the payload, a reverse dns string.</string>
+			<key>pfm_description_reference</key>
+			<string>The payload type.</string>
+			<key>pfm_name</key>
+			<string>PayloadType</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Type</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<key>pfm_description_reference</key>
+			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<key>pfm_format</key>
+			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
+			<key>pfm_name</key>
+			<string>PayloadUUID</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<integer>1</integer>
+			<key>pfm_description</key>
+			<string>The version of the whole configuration profile.</string>
+			<key>pfm_description_reference</key>
+			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<key>pfm_name</key>
+			<string>PayloadVersion</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_title</key>
+			<string>Payload Version</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<key>pfm_name</key>
+			<string>PayloadOrganization</string>
+			<key>pfm_title</key>
+			<string>Payload Organization</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>An array of dictionaries that describes one or more relay servers that can be chained together.</string>
+			<key>pfm_name</key>
+			<string>Relays</string>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>Relay</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The URL or URI template (such as defined in RFC 9298) of a relay server that is reachable using HTTP/3 and supports proxying TCP and UDP using the CONNECT method. Each relay must have at least one URL, for either HTTP/3 or HTTP/2, and may support both.</string>
+							<key>pfm_name</key>
+							<string>HTTP3RelayURL</string>
+							<key>pfm_title</key>
+							<string>HTTP/3 Relay URL</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The URL or URI template (such as defined in RFC 9298) of a relay server that is reachable using HTTP/2 and supports proxying TCP and UDP using the CONNECT method. Each relay must have at least one URL, for either HTTP/3 or HTTP/2, and may support both.</string>
+							<key>pfm_name</key>
+							<string>HTTP2RelayURL</string>
+							<key>pfm_title</key>
+							<string>HTTP/2 Relay URL</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>A dictionary of custom HTTP header keys and values to add to each request to the relay. The dictionary key name represents the HTTP header field name to use, and the dictionary value is the string to use as the HTTP header field value.</string>
+							<key>pfm_name</key>
+							<string>AdditionalHTTPHeaderFields</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_description</key>
+									<string></string>
+									<key>pfm_name</key>
+									<string>{{key}}</string>
+									<key>pfm_repetition_min</key>
+									<integer>1</integer>
+									<key>pfm_type</key>
+									<string>string</string>
+									<key>pfm_value_unique</key>
+									<true/>
+								</dict>
+								<dict>
+									<key>pfm_description</key>
+									<string></string>
+									<key>pfm_name</key>
+									<string>{{value}}</string>
+									<key>pfm_repetition_min</key>
+									<integer>1</integer>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
+							<key>pfm_title</key>
+							<string>Additional HTTP Header Fields</string>
+							<key>pfm_type</key>
+							<string>dictionary</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>UUID pointing to an identity certificate payload. This identity will be used to authenticate the user to the relay server.</string>
+							<key>pfm_name</key>
+							<string>PayloadCertificateUUID</string>
+							<key>pfm_title</key>
+							<string>Certificate UUID</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>An array of raw public keys used to authenticate the server during a TLS handshake. The server must use one of the keys in the handshake in order to authenticate. If no keys are specified, default TLS trust evaluation is used.</string>
+							<key>pfm_name</key>
+							<string>RawPublicKeys</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_name</key>
+									<string>RawPublicKeysElement</string>
+									<key>pfm_title</key>
+									<string>Raw Public Key Element</string>
+									<key>pfm_type</key>
+									<string>data</string>
+								</dict>
+							</array>
+							<key>pfm_title</key>
+							<string>Raw Public Keys</string>
+							<key>pfm_type</key>
+							<string>array</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Network Relay</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Relays</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>A list of domain strings used to determine which connection should be routed through the servers contained in Relays. Any connection that matches the domain exactly or is a subdomain of the listed domain will use the relay servers, unless they match an excluded domain. If no domains are listed, traffic to all domains, except those matching an excluded domain, will be routed to the relay servers.</string>
+			<key>pfm_name</key>
+			<string>MatchDomains</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>MatchDomainsElement</string>
+					<key>pfm_title</key>
+					<string>Match Domains Element</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Match Domains</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>A list of domain strings that should not be routed through the servers contained in Relays. Any connection that matches the domain exactly or is a subdomain of the listed domain will not use the relay server.</string>
+			<key>pfm_name</key>
+			<string>ExcludedDomains</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>ExcludedDomainsElement</string>
+					<key>pfm_title</key>
+					<string>Excluded Domains Element</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Excluded Domains</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>A globally-unique identifier for this relay configuration. This UUID is used to route managed apps through the servers contained in Relays.</string>
+			<key>pfm_name</key>
+			<string>RelayUUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+	</array>
+	<key>pfm_targets</key>
+	<array>
+		<string>system</string>
+		<string>system</string>
+	</array>
+	<key>pfm_title</key>
+	<string>Relay</string>
+	<key>pfm_version</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/Manifests/ManifestsApple/com.apple.security.acme.plist
+++ b/Manifests/ManifestsApple/com.apple.security.acme.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>16.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-04-18T11:08:07Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>13.1</string>
 	<key>pfm_platforms</key>
@@ -213,19 +213,19 @@ Dotted numbers can represent OIDs , with shortcuts for country (C), locality (L)
 			<array>
 				<dict>
 					<key>pfm_name</key>
-					<string>SCEPSubjectArrayInnerArray</string>
+					<string>ACMESubjectArrayInnerArray</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
 							<key>pfm_name</key>
-							<string>SCEPSubjectArrayPair</string>
+							<string>ACMESubjectArrayPair</string>
 							<key>pfm_subkeys</key>
 							<array>
 								<dict>
 									<key>pfm_name</key>
-									<string>SCEPSubjectArrayPairItem</string>
+									<string>ACMESubjectArrayPairItem</string>
 									<key>pfm_title</key>
-									<string>SCEP Subject Array Pair Item</string>
+									<string>ACME Subject Array Pair Item</string>
 									<key>pfm_type</key>
 									<string>string</string>
 								</dict>
@@ -237,7 +237,7 @@ Dotted numbers can represent OIDs , with shortcuts for country (C), locality (L)
 						</dict>
 					</array>
 					<key>pfm_title</key>
-					<string>Array Inside SCEP Subject Array</string>
+					<string>Array Inside ACME Subject Array</string>
 					<key>pfm_type</key>
 					<string>array</string>
 				</dict>

--- a/Manifests/ManifestsApple/com.apple.security.firewall.plist
+++ b/Manifests/ManifestsApple/com.apple.security.firewall.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-05-04T08:58:50Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -255,6 +255,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_macos_min</key>
 			<string>12.3</string>
 			<key>pfm_name</key>
@@ -265,6 +267,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_macos_min</key>
 			<string>12.3</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.universalaccess.plist
+++ b/Manifests/ManifestsApple/com.apple.universalaccess.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -224,7 +224,7 @@
 			<key>pfm_default</key>
 			<real>0.0</real>
 			<key>pfm_description</key>
-			<string>The amount of display contrast enhancement in a decimal value between 0 and 1, where 0 is none and 1 is the maximum</string>
+			<string>The contrast value in the Display options.</string>
 			<key>pfm_name</key>
 			<string>contrast</string>
 			<key>pfm_range_max</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-23T13:57:28Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -1154,8 +1154,18 @@
 							</array>
 						</dict>
 					</array>
+					<key>pfm_ios_min</key>
+					<string>8.0</string>
+					<key>pfm_macos_min</key>
+					<string>10.8</string>
 					<key>pfm_name</key>
 					<string>OneTimeUserPassword</string>
+					<key>pfm_platforms</key>
+					<array>
+						<string>iOS</string>
+						<string>macOS</string>
+						<string>tvOS</string>
+					</array>
 					<key>pfm_title</key>
 					<string>Per-Connection Password</string>
 					<key>pfm_type</key>
@@ -1339,6 +1349,7 @@
 						<string>1.0</string>
 						<string>1.1</string>
 						<string>1.2</string>
+						<string>1.3</string>
 					</array>
 					<key>pfm_title</key>
 					<string>TLS Minimum Version</string>
@@ -1377,6 +1388,7 @@
 						<string>1.0</string>
 						<string>1.1</string>
 						<string>1.2</string>
+						<string>1.3</string>
 					</array>
 					<key>pfm_title</key>
 					<string>TLS Maximum Version</string>
@@ -1602,7 +1614,7 @@
 					<key>pfm_ios_min</key>
 					<string>14.5</string>
 					<key>pfm_macos_min</key>
-					<string>11.3</string>
+					<string>14.0</string>
 					<key>pfm_name</key>
 					<string>QoSMarkingAllowListAppIdentifiers</string>
 					<key>pfm_subkeys</key>
@@ -1625,7 +1637,7 @@
 					<key>pfm_ios_deprecated</key>
 					<string>14.5</string>
 					<key>pfm_macos_deprecated</key>
-					<string>11.3</string>
+					<string>14.0</string>
 					<key>pfm_name</key>
 					<string>QoSMarkingWhitelistedAppIdentifiers</string>
 					<key>pfm_subkeys</key>


### PR DESCRIPTION
This PR implements the updates introduced during last WWDC for the 2023 platforms generation.

It replaces #631 which was opened for the same purpose but can no longer be merged without painstaking conflict resolution due to accumulated changes.