### PR TITLE
Remove redundant platform tags

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
+++ b/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-29T16:46:29Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -158,11 +158,6 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>OPPrefBiometryAllowed</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>iOS</string>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Allow Biometric Unlock (Face ID &amp; Touch ID)</string>
 			<key>pfm_type</key>
@@ -215,11 +210,6 @@
 			<string>NOTE: values '0' and '-1' are availabe on iOS only.
 
 To set the Master Password timeout to "Never", set the value to -1 (this will be going away in a future release). To set the Master Password timeout to "After restart", set the value to 0</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>iOS</string>
-				<string>macOS</string>
-			</array>
 			<key>pfm_range_min</key>
 			<integer>-1</integer>
 			<key>pfm_title</key>
@@ -474,11 +464,6 @@ To set the Master Password timeout to "Never", set the value to -1 (this will be
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>OPPreferencesNotifyCompromisedWebsites</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>iOS</string>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Check for Compromised Websites (Watchtower) Notification</string>
 			<key>pfm_type</key>
@@ -491,11 +476,6 @@ To set the Master Password timeout to "Never", set the value to -1 (this will be
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>OPPreferencesNotifyVaultAddedRemoved</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>iOS</string>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Vault Access Added/Removed Notification</string>
 			<key>pfm_type</key>
@@ -508,11 +488,6 @@ To set the Master Password timeout to "Never", set the value to -1 (this will be
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>OPPreferencesNotifyOfTOTPCopy</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>iOS</string>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>One-Time Password Copied to Clipboard Notification</string>
 			<key>pfm_type</key>

--- a/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-29T16:46:29Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>
@@ -2710,10 +2710,6 @@
 					<string>14.0</string>
 					<key>pfm_name</key>
 					<string>SystemPolicyAppData</string>
-					<key>pfm_platforms</key>
-					<array>
-						<string>macOS</string>
-					</array>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
@@ -2785,10 +2781,6 @@ Available in macOS 11 and later.</string>
 									<string>11.0</string>
 									<key>pfm_name</key>
 									<string>Authorization</string>
-									<key>pfm_platforms</key>
-									<array>
-										<string>macOS</string>
-									</array>
 									<key>pfm_range_list</key>
 									<array>
 										<string>Allow</string>

--- a/Manifests/ManifestsApple/com.apple.ews.account.plist
+++ b/Manifests/ManifestsApple/com.apple.ews.account.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-29T08:33:42Z</date>
+	<date>2023-11-29T16:46:29Z</date>
 	<key>pfm_note</key>
 	<string>As with VPN and Wi-Fi configurations, it is possible to associate an SCEP credential with an Exchange configu- ration via the PayloadCertificateUUID key.</string>
 	<key>pfm_platforms</key>
@@ -245,10 +245,6 @@ In macOS, this key is required.</string>
 			<string>The UUID of the Identification Payload to use as the source for user values.</string>
 			<key>pfm_name</key>
 			<string>IdentificationUUID</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>macOS</string>
-			</array>
 			<key>pfm_title</key>
 			<string>IdentificationUUID</string>
 			<key>pfm_type</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-29T16:46:29Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -1160,12 +1160,6 @@
 					<string>10.8</string>
 					<key>pfm_name</key>
 					<string>OneTimeUserPassword</string>
-					<key>pfm_platforms</key>
-					<array>
-						<string>iOS</string>
-						<string>macOS</string>
-						<string>tvOS</string>
-					</array>
 					<key>pfm_title</key>
 					<string>Per-Connection Password</string>
 					<key>pfm_type</key>


### PR DESCRIPTION
This PR removes `pfm_platforms` tags in a handful of places where they state the same platforms already specified for the domain itself, thus adding no new information.

