### PR TITLE
Official descriptions rerun

### DIFF
--- a/ManifestExamples/com.github.profilecreator.exampleApplication.plist
+++ b/ManifestExamples/com.github.profilecreator.exampleApplication.plist
@@ -81,9 +81,7 @@
 			<key>pfm_default</key>
 			<string>Configures Example Application configuration preferences</string> <!-- CHANGE THIS VALUE -->
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -98,9 +96,7 @@
 			<key>pfm_default</key>
 			<string>Example Application</string> <!-- CHANGE THIS VALUE -->
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -117,9 +113,7 @@
 			<key>pfm_default</key>
 			<string>com.github.ProfileManifests.exampleApplication</string> <!-- CHANGE THIS VALUE TO THE SAME AS pfm_domain and PayloadType -->
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -136,9 +130,7 @@
 			<key>pfm_default</key>
 			<string>com.github.ProfileManifests.exampleApplication</string> <!-- CHANGE THIS VALUE TO THE SAME AS pfm_domain and PayloadIdentifier -->
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -153,9 +145,7 @@
 		<!-- This is the PayloadUUID and it will be generated automatically. You should NOT edit this. -->
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -174,10 +164,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -192,7 +179,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		<!-- This is the organization of the payload. You should NOT edit this. -->
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.AdLib.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.AdLib.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,9 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Ad Tracking settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,9 +32,7 @@
 			<key>pfm_default</key>
 			<string>Ad Tracking</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,9 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.AdLib</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,9 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.AdLib</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.GlobalPreferences.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Global Preferences settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Global Preferences</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>.GlobalPreferences</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>.GlobalPreferences</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.NetworkBrowser.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.NetworkBrowser.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>macOS AirDrop Preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>AirDrop</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.NetworkBrowser</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.NetworkBrowser</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,10 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Safari Developer preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Safari Developer</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Safari.SandboxBroker</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Safari.SandboxBroker</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-	A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -119,10 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-	The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.Siri.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Siri.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:48Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Siri settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>Siri</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Siri</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Siri</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.Spotlight.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Spotlight.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T15:24:49Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,9 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Spotlight settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,9 +32,7 @@
 			<key>pfm_default</key>
 			<string>Spotlight</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,9 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Spotlight</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,9 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Spotlight</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -115,9 +102,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.TimeMachine.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.TimeMachine.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:48Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Time Machine settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>Time Machine</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.TimeMachine</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.TimeMachine</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.assistant.support.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.assistant.support.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-01-06T11:35:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Assistant (Siri) settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>Assistant</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.assistant.support</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.assistant.support</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.controlcenter.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.controlcenter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exlusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>12.0</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Control Center settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Control Center</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.controlcenter</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.controlcenter</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,10 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.coreservices.uiagent.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.coreservices.uiagent.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures CoreServices UIAgent settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>CoreServices UIAgent</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.coreservices.uiagent</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.coreservices.uiagent</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,10 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.desktopservices.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.desktopservices.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-03-06T08:58:48Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Desktop Services settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>Desktop Services</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.desktopservices</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ManagedClient.preferences</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.finder.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.finder.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Finder settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>Finder</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.finder</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.finder</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.freeform.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.freeform.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,9 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Freeform settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,9 +32,7 @@
 			<key>pfm_default</key>
 			<string>Freeform</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,9 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.freeform</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,9 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.freeform</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.iBooksX.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.iBooksX.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures iBooks configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>iBooks</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iBooksX</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iBooksX</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.iTunes.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.iTunes.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures iTunes configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>iTunes</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iTunes</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iTunes</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.iWork.Keynote.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.iWork.Keynote.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Keynote configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Keynote</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iWork.Keynote</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iWork.Keynote</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.iWork.Numbers.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.iWork.Numbers.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Numbers configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Numbers</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iWork.Numbers</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iWork.Numbers</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.iWork.Pages.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.iWork.Pages.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Pages configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Pages</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iWork.Pages</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iWork.Pages</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.icloud.managed.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.icloud.managed.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures iCloud Find My settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>iCloud Find My</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.icloud.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.icloud.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.mDNSResponder.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.mDNSResponder.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Bonjour settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Bonjour</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mDNSResponder</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mDNSResponder</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,10 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.preferences.sharing.SharingPrefsExtension.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.preferences.sharing.SharingPrefsExtension.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exlusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>12.0</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Media Sharing extension settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Media Sharing</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.preferences.sharing.SharingPrefsExtension</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.preferences.sharing.SharingPrefsExtension</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,10 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.print.add.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures the toolbar of the Add Printer window under Printers and Scanners in System Preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Printing: Toolbar of Add Printer Window</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.print.add</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.print.add</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,9 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -116,9 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.python.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.python.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-13T12:09:45Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,9 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures settings for the version of Python bundled with macOS.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,9 +32,7 @@
 			<key>pfm_default</key>
 			<string>Python</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,9 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.python</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,9 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.python</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,9 +72,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -98,10 +88,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -113,7 +100,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Safari configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Safari</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Safari</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Safari</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-	A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,10 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-	The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.screencapture.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.screencapture.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-09-15T15:46:07Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Screencapture settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>Screencapture</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.screencapture</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.screencapture</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.security.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.security.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:48Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures Security settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>Security</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.sharingd.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.sharingd.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>macOS AirDrop Discoverability Preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>AirDrop</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.sharingd</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.sharingd</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,10 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.systemuiserver.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.systemuiserver.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 			<key>pfm_default</key>
 			<string>Configures SystemUI Server settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -32,7 +32,7 @@
 			<key>pfm_default</key>
 			<string>SystemUI Server</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,7 +46,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systemuiserver</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -60,7 +60,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systemuiserver</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,7 +74,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -90,7 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -102,7 +102,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.timed.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.timed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-04-06T00:23:23Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>macOS Time Synchronization Daemon settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>macOS Time Synchronization Daemon</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.timed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.timed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -115,7 +102,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.touristd.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>"New to Mac" tour notification settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>New to Mac</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.touristd</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.touristd</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -115,7 +102,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
+++ b/Manifests/ManagedPreferencesApplications/ManagedInstalls.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Munki settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Munki</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>ManagedInstalls</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>ManagedInstalls</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/MunkiReport.plist
+++ b/Manifests/ManagedPreferencesApplications/MunkiReport.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:30Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures MunkiReport settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>MunkiReport</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>MunkiReport</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>MunkiReport</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configure 1Password settings</string>
 			<key>pfm_description</key>
-			<string>Settings to configure 1Password using your MDM solution</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>1Password</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.1password.1password</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.1password.1password</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.ThomsonResearchSoft.EndNote.plist
+++ b/Manifests/ManagedPreferencesApplications/com.ThomsonResearchSoft.EndNote.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures EndNote settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>EndNote</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.ThomsonResearchSoft.EndNote</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.ThomsonResearchSoft.EndNote</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
+++ b/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -27,7 +27,7 @@
 			<key>pfm_default</key>
 			<string>Configures 1Password 7 settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,7 +39,7 @@
 			<key>pfm_default</key>
 			<string>1Password 7</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -53,7 +53,7 @@
 			<key>pfm_default</key>
 			<string>com.agilebits.onepassword7</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -67,7 +67,7 @@
 			<key>pfm_default</key>
 			<string>com.agilebits.onepassword7</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -81,7 +81,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -97,7 +97,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.alectrona.patch-agent.plist
+++ b/Manifests/ManagedPreferencesApplications/com.alectrona.patch-agent.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-06-02T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Alectrona Patch Agent configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Alectrona Patch Agent</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.alectrona.patch-agent</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.alectrona.patch-agent</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.alectrona.patch-notifier.plist
+++ b/Manifests/ManagedPreferencesApplications/com.alectrona.patch-notifier.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-06-02T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Alectrona Patch Notifier configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Alectrona Patch Notifier</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.alectrona.patch-notifier</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.alectrona.patch-notifier</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.alectrona.patch.plist
+++ b/Manifests/ManagedPreferencesApplications/com.alectrona.patch.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-06-02T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Alectrona Patch Command Line Tool configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Alectrona Patch Command Line Tool</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.alectrona.patch</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.alectrona.patch</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.Compressor.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.Compressor.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-04-11T16:59:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Compressor configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Compressor</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Compressor</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Compressor</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.Enterprise-Connect.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.Enterprise-Connect.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Enterprise Connect</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Enterprise-Connect</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.Enterprise-Connect</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -88,10 +80,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -105,9 +94,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<string>Enterprise Connect settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.FinalCut.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.FinalCut.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Final Cut Pro configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Final Cut Pro</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.FinalCut</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.FinalCut</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.TextEdit.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.TextEdit.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures TextEdit settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>TextEdit</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.TextEdit</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.TextEdit</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -119,9 +106,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.garageband10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.garageband10.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures GarageBand  preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>GarageBand</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.garageband10</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.garageband10</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -115,7 +102,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.iMovieApp.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.iMovieApp.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures iMovie configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>iMovie</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iMovieApp</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.iMovieApp</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.logic10.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Logic Pro X configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Logic Pro X</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.logic10</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.logic10</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.apple.motionapp.plist
+++ b/Manifests/ManagedPreferencesApplications/com.apple.motionapp.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-09T19:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Motion configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Motion</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.motionapp</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.motionapp</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.barebones.bbedit.plist
+++ b/Manifests/ManagedPreferencesApplications/com.barebones.bbedit.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-17T13:20:39Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures BBEdit settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>BBEdit</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.barebones.bbedit</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.barebones.bbedit</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -554,7 +554,7 @@
 			<key>pfm_name</key>
 			<string>BRIEFStateTimeout</string>
 			<key>pfm_range_min</key>
-			<real>0.1</real>
+			<real>0.10000000000000001</real>
 			<key>pfm_title</key>
 			<string>Brief State Timeout</string>
 			<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-21T16:48:27Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Brave Browser settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Brave Browser</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.brave.Browser</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.brave.Browser</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,9 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,9 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.citrix.receiver.nomas.plist
+++ b/Manifests/ManagedPreferencesApplications/com.citrix.receiver.nomas.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Citrix Receiver settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Citrix Receiver</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.citrix.receiver.nomas</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.citrix.receiver.nomas</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -119,10 +106,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.crowdstrike.falcon.plist
+++ b/Manifests/ManagedPreferencesApplications/com.crowdstrike.falcon.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-07-30T21:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures CrowdStrike Falcon settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>CrowdStrike Falcon</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.crowdstrike.falcon</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.crowdstrike.falcon</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.fxfactory.FxFactory.plist
+++ b/Manifests/ManagedPreferencesApplications/com.fxfactory.FxFactory.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-21T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures FxFactory settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>FxFactory</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.fxfactory.FxFactory</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.fxfactory.FxFactory</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.ants-framework.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.ants-framework.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures the ANTS framework configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>ANTS Framework settings</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.github.ants-framework</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -92,7 +92,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Nudge settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Nudge</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.github.macadmins.Nudge</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.github.macadmins.Nudge</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.mpanighetti.install-or-defer.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-09T09:13:53Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Install or Defer preferences.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Install or Defer</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.github.mpanighetti.install-or-defer</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.github.mpanighetti.install-or-defer</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.github.salopensource.sal.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.salopensource.sal.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Sal settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Sal</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.github.salopensource.sal</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.github.salopensource.sal</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -119,10 +106,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-15T10:06:29Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Google Chrome settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Google Chrome</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.google.Chrome</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.google.Chrome</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,9 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,9 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Google Software Update preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Google Software Update Preferences</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.google.Keystone</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.google.Keystone</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -119,10 +106,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2022-11-29T14:50:44Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Google Drive for desktop preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Google Drive for desktop</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.google.drivefs.settings</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.google.drivefs.settings</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -161,10 +148,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.santa.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.santa.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-08-11T00:20:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Santa settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Santa</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.google.santa</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.google.santa</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,9 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -116,9 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.grahamgilbert.crypt.plist
+++ b/Manifests/ManagedPreferencesApplications/com.grahamgilbert.crypt.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:30Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Crypt settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Crypt</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.grahamgilbert.crypt</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.grahamgilbert.crypt</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.hjuutilainen.MunkiAdmin.plist
+++ b/Manifests/ManagedPreferencesApplications/com.hjuutilainen.MunkiAdmin.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures MunkiAdmin app settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>MunkiAdmin app</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.hjuutilainen.MunkiAdmin</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.hjuutilainen.MunkiAdmin</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,9 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.hjuutilainen.bigsurblocker.plist
+++ b/Manifests/ManagedPreferencesApplications/com.hjuutilainen.bigsurblocker.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2021-07-01T09:56:57Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Big Sur Blocker settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Big Sur Blocker</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.hjuutilainen.bigsurblocker</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.hjuutilainen.bigsurblocker</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-Okta.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-Okta.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Jamf Connect Login configuration settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Jamf Connect Login configuration</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Jamf Connect Login configuration.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.login</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.login</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -119,7 +106,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.login-OpenID.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Jamf Connect Login configuration settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Jamf Connect Login configuration</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Jamf Connect Login configuration.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.login</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.login</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.shares.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Jamf Connect Shares</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.shares</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.shares</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -72,10 +66,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -87,9 +78,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -123,9 +112,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<string>Configures Jamf Connect Shares settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.sync.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Jamf Connect Sync settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Jamf Connect Sync</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.sync</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.sync</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.connect.verify.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.connect.verify.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Jamf Connect Verify configuration settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Jamf Connect Verify configuration</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.verify</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.connect.verify</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.jamf.trust.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jamf.trust.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-02-09T23:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Jamf Trust settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Jamf Trust</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.trust</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.jamf.trust</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,11 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -118,9 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.jelockwood.pinpoint.plist
+++ b/Manifests/ManagedPreferencesApplications/com.jelockwood.pinpoint.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-02-21T17:17:24Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Pinpoint settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Pinpoint</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.jelockwood.pinpoint</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.jelockwood.pinpoint</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.macpaw.site.theunarchiver.plist
+++ b/Manifests/ManagedPreferencesApplications/com.macpaw.site.theunarchiver.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures The Unarchiver (Standalone) settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>The Unarchiver (Standalone)</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.macpaw.site.theunarchiver</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.macpaw.site.theunarchiver</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.mcneel.rhinoceros.plist
+++ b/Manifests/ManagedPreferencesApplications/com.mcneel.rhinoceros.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-06T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Rhinoceros settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Rhinoceros</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.mcneel.rhinoceros</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.mcneel.rhinoceros</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Edge.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-15T10:06:29Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Edge settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Edge</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Edge</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Edge</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,9 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,9 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Excel.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Excel.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Excel settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Excel</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Excel</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Excel</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Office365ServiceV2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Office365ServiceV2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Office 365 Service settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Office 365 Service</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Office365ServiceV2</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Office365ServiceV2</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.OneDrive.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.OneDrive.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T15:29:51Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft OneDrive settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft OneDrive</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.OneDrive</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.OneDrive</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.OneDriveUpdater.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.OneDriveUpdater.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-01-30T20:35:38Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft OneDrive Updater settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft OneDrive Updater</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.OneDriveUpdater</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.OneDriveUpdater</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Outlook.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-01-30T17:38:16Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Outlook settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Outlook</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Outlook</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Outlook</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Powerpoint.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Powerpoint.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft PowerPoint settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft PowerPoint</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Powerpoint</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Powerpoint</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.SkypeForBusiness.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.SkypeForBusiness.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Skype for Business settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Skype for Business</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.SkypeForBusiness</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.SkypeForBusiness</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,9 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -104,10 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -119,9 +106,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.Word.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.Word.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Word settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Word</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Word</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.Word</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate.fba.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate.fba.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft AutoUpdate FBA settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft AutoUpdate FBA</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.autoupdate.fba</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.autoupdate.fba</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_note</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft AutoUpdate</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.autoupdate2</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.autoupdate2</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft AutoUpdate settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.errorreporting.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.errorreporting.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Error Reporting settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Error Reporting</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.errorreporting</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.errorreporting</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.office.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-10-11T08:20:25Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Office</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.office</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.office</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Office settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.onenote.mac.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.onenote.mac.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft OneNote settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft OneNote</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.onenote.mac</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.onenote.mac</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.rdc.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.rdc.macos.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Remote Desktop settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Remote Desktop</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.rdc.macos</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.rdc.macos</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.wdav.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.wdav.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-10-18T01:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Microsoft Defender for Endpoint settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Microsoft Defender for Endpoint</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.wdav</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.microsoft.wdav</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.papercut.printdeploy.client.plist
+++ b/Manifests/ManagedPreferencesApplications/com.papercut.printdeploy.client.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-03-16T14:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures PaperCut Print Deploy Settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>PaperCut Print Deploy</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.papercut.printdeploy.client</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.papercut.printdeploy.client</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,9 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
+++ b/Manifests/ManagedPreferencesApplications/com.pratikkumar.airserver-mac.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures AirServer settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>AirServer</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.pratikkumar.airserver-mac</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.pratikkumar.airserver-mac</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,10 +78,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -101,9 +90,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist
+++ b/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.baseline.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-06-23T00:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Baseline configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Baseline</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.secondsonconsulting.baseline</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.secondsonconsulting.baseline</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.renew.plist
+++ b/Manifests/ManagedPreferencesApplications/com.secondsonconsulting.renew.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-11-25T00:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Renew behavior and dialog window design</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Renew</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.secondsonconsulting.renew</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.secondsonconsulting.renew</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.skype.skype.plist
+++ b/Manifests/ManagedPreferencesApplications/com.skype.skype.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Skype settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Skype</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.skype.skype</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.skype.skype</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.sqwarq.DetectX-Swift.plist
+++ b/Manifests/ManagedPreferencesApplications/com.sqwarq.DetectX-Swift.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures DetectX Swift settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>DetectX Swift</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.sqwarq.DetectX-Swift</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.sqwarq.DetectX-Swift</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,10 +78,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -101,9 +90,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
+++ b/Manifests/ManagedPreferencesApplications/com.tinyspeck.slackmacgap.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-04-09T15:57:47Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Slack settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Slack</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.tinyspeck.slackmacgap</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.tinyspeck.slackmacgap</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
+++ b/Manifests/ManagedPreferencesApplications/com.trusourcelabs.NoMAD.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures NoMAD settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>NoMAD</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.trusourcelabs.NoMAD</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.trusourcelabs.NoMAD</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.twingate.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/com.twingate.macos.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-12-23T02:09:27Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Twingate macOS Client configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Twingate</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.twingate.macos</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.twingate.macos</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
+++ b/Manifests/ManagedPreferencesApplications/com.twocanoes.xcreds.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-10-16T16:50:44Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures XCreds configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>XCreds</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.twocanoes.xcreds</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.twocanoes.xcreds</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.unity3d.UnityEditor5.x.plist
+++ b/Manifests/ManagedPreferencesApplications/com.unity3d.UnityEditor5.x.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-18T17:28:30Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Unity Editor preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>Unity Editor</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.unity3d.UnityEditor5.x</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.unity3d.UnityEditor5.x</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
+++ b/Manifests/ManagedPreferencesApplications/com.vpntracker.365mac-config.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-11-19T21:41:10Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures VPN Tracker preferences for managed onboarding</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>VPN Tracker</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.vpntracker.365mac</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.vpntracker.365mac</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,9 +74,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,10 +90,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -115,7 +102,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
+++ b/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures SAP Privileges app settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>SAP Privileges app</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>corp.sap.privileges</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>corp.sap.privileges</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,9 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/cx.c3.theunarchiver.plist
+++ b/Manifests/ManagedPreferencesApplications/cx.c3.theunarchiver.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures The Unarchiver settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>The Unarchiver (Mac App Store)</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>cx.c3.theunarchiver</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>cx.c3.theunarchiver</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
+++ b/Manifests/ManagedPreferencesApplications/de.fau.rrze.NetworkShareMounter.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>de.fau.rrze.NetworkShareMounter</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>de.fau.rrze.NetworkShareMounter</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -74,10 +68,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/edu.ncsu.confboard.plist
+++ b/Manifests/ManagedPreferencesApplications/edu.ncsu.confboard.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>12.0</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures ConfBoard configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>ConfBoard</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>edu.ncsu.confboard</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>edu.ncsu.confboard</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,7 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
+++ b/Manifests/ManagedPreferencesApplications/edu.psu.macoslaps.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,9 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures macOS LAPS settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,9 +34,7 @@
 			<key>pfm_default</key>
 			<string>macOS LAPS</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,9 +48,7 @@
 			<key>pfm_default</key>
 			<string>edu.psu.macoslaps</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,9 +62,7 @@
 			<key>pfm_default</key>
 			<string>edu.psu.macoslaps</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,9 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/fr.handbrake.HandBrake.plist
+++ b/Manifests/ManagedPreferencesApplications/fr.handbrake.HandBrake.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-05T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Handbrake settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Handbrake</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>fr.handbrake.HandBrake</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>fr.handbrake.HandBrake</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-10-31T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Tailscale (MAS) configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Tailscale (MAS)</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>io.tailscale.ipn.macos</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>io.tailscale.ipn.macos</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-10-31T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Tailscale (Standalone) configuration preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Tailscale (Standalone)</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>io.tailscale.ipn.macsys</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>io.tailscale.ipn.macsys</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,10 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +104,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.NoMADPro.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures NoMAD Pro settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>NoMAD Pro</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.NoMADPro</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.NoMADPro</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.ad.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures NoMAD Login settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>NoMAD Login</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.login.ad</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.login.ad</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.login.okta.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.login.okta.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures NoMAD Login+ settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>NoMAD Login+</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.login.okta</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.login.okta</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
+++ b/Manifests/ManagedPreferencesApplications/menu.nomad.shares.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures NoMAD Shares settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>NoMAD Shares</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.shares</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>menu.nomad.shares</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -86,10 +78,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -101,9 +90,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/net.glencode.Particulars.Widget.plist
+++ b/Manifests/ManagedPreferencesApplications/net.glencode.Particulars.Widget.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Particulars settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Particulars</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>net.glencode.Particulars</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>net.glencode.Particulars</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
+++ b/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-01-15T02:15:59Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0.1</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>SupportApp by Root3</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>nl.root3.support</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>nl.root3.support</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,10 +84,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -109,9 +98,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<string>SupportApp by Root3 settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -20,7 +20,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-01T15:48:15Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -33,7 +33,7 @@
 			<key>pfm_default</key>
 			<string>Configures Firefox settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -45,7 +45,7 @@
 			<key>pfm_default</key>
 			<string>Firefox</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -59,7 +59,7 @@
 			<key>pfm_default</key>
 			<string>org.mozilla.firefox</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -73,7 +73,7 @@
 			<key>pfm_default</key>
 			<string>org.mozilla.firefox</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -85,7 +85,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -101,7 +101,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -113,7 +113,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/org.sveinbjorn.Platypus.plist
+++ b/Manifests/ManagedPreferencesApplications/org.sveinbjorn.Platypus.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Platypus settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Platypus</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>org.sveinbjorn.Platypus</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>org.sveinbjorn.Platypus</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/org.videolan.vlc.plist
+++ b/Manifests/ManagedPreferencesApplications/org.videolan.vlc.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-05T18:36:23Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures VLC settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>VLC</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>org.videolan.VLC</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>org.videolan.VLC</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>

--- a/Manifests/ManagedPreferencesApplications/uk.co.dataJAR.jamJAR.plist
+++ b/Manifests/ManagedPreferencesApplications/uk.co.dataJAR.jamJAR.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures jamJAR preferences</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>jamJAR Preferences</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>uk.co.dataJAR.jamJAR</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>uk.co.dataJAR.jamJAR</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/us.zoom.config.plist
+++ b/Manifests/ManagedPreferencesApplications/us.zoom.config.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-17T13:21:37Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Zoom settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Zoom</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>us.zoom.config</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>us.zoom.config</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/Configuration.plist
+++ b/Manifests/ManifestsApple/Configuration.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -22,9 +22,7 @@
 	<array>
 		<dict>
 			<key>pfm_description</key>
-			<string>Display name of the profile.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable name for the profile. This value is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile. This value is displayed on the Detail screen. It doesn't have to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -36,9 +34,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Description of this profile.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A description of the profile, shown on the Detail screen for the profile. This should be descriptive enough to help the user decide whether to install the profile.</string>
+			<string>The description of the profile, shown on the Detail screen for the profile. This description should be detailed enough to help the user decide whether to install the profile.</string>
 			<key>pfm_enabled</key>
 			<true/>
 			<key>pfm_name</key>
@@ -50,9 +46,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name of the organization for the profile.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.</string>
+			<string>The human-readable string containing the name of the organization that provided the profile.</string>
 			<key>pfm_enabled</key>
 			<true/>
 			<key>pfm_name</key>
@@ -64,9 +58,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A reverse-DNS style identifier (com.example.myprofile, for example) that identifies the profile. This string is used to determine whether a new profile should replace an existing one or should be added.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS style identifier (com.example.myprofile, for example) that identifies the profile. This string is used to determine whether a new profile should replace an existing one or should be added.</string>
+			<string>The reverse-DNS style identifier ('com.example.myprofile', for example) that identifies the profile. This string is used to determine whether a new profile should replace an existing one or should be added.</string>
 			<key>pfm_hidden</key>
 			<string>all</string>
 			<key>pfm_name</key>
@@ -80,9 +72,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A globally unique identifier for the profile.</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the profile. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the profile. The actual content is unimportant. In macOS, you can use 'uuidgen' to generate reasonable UUIDs.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_hidden</key>
@@ -100,9 +90,10 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent manual removal of profiles installed through an MDM. Profiles installed manually can be removed manually, but only by using administrative authority.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>If present and set to 'true', the user can't delete the profile (unless the profile has a removal password and the user provides it).
+On macOS, as of 10.15, this key only affects removal of manually installed profiles. If set to 'true' and no profile removal payload is present, removing the profile requires admin auth.
+On macOS versions prior to 10.15, this key would prevent admins from removing MDM installed profiles but as of macOS 10.15, users can never remove MDM profiles, not even the admin.
+Requires a supervised device.</string>
 			<key>pfm_name</key>
 			<string>PayloadRemovalDisallowed</string>
 			<key>pfm_supervised</key>
@@ -114,9 +105,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The date on which the profile will be automatically removed.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If present and set to true, the user cannot delete the profile (unless the profile has a removal password and the user provides it).</string>
+			<string>The date when the profile is automatically removed.</string>
 			<key>pfm_name</key>
 			<string>RemovalDate</string>
 			<key>pfm_title</key>
@@ -126,9 +115,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Number of seconds until the profile is automatically removed. If RemovalDate key is present, its value is used instead.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Number of seconds until the profile is automatically removed. If the RemovalDate keys is present, whichever field yields the earliest date will be used.</string>
+			<string>The number of seconds until the profile is automatically removed. If the 'RemovalDate' key is present, whichever field yields the earliest date is used.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -156,13 +143,13 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Dictionary specifying localized consent text that will be displayed as a warning during profile installation.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A dictionary containing these keys and values:
-• For each language in which a consent or license agreement is available, a key consisting of the IETF BCP 47 identifier for that language (for example, en or jp) and a value consisting of the agreement localized to that language. The agreement is displayed in a dialog to which the user must agree before installing the profile.
-• The optional key default with its value consisting of the unlocalized agreement (usually in en).
-The system chooses a localized version in the order of preference specified by the user (macOS) or based on the user's current language setting (iOS). If no exact match is found, the default localization is used. If there is no default localization, the en localization is used. If there is no en localization, then the first available localization is used.
-You should provide a default value if possible. No warning will be displayed if the user's locale does not match any localization in the ConsentText dictionary.</string>
+			<string>A dictionary containing a key that consists of the IETF BCP 47 identifier for a language (for example, en or jp) and a value consisting of the agreement localized to that language. The agreement is displayed in a dialog, and the user must agree before installing the profile.
+
+The dictionary can also contain an optional key, 'default', with its value consisting of the unlocalized (usually in en) agreement.
+
+The system chooses a localized version in the order of preference specified by the user (macOS) or based on the user's current language setting (iOS). If no exact match is found, the default localization is used. If there is no default localization, the en localization is used. If there is no en localization, the first available localization is used.
+
+Provide a default value, if possible. No warning is displayed if the user's locale doesn't match any localization in the 'ConsentText' dictionary.</string>
 			<key>pfm_name</key>
 			<string>ConsentText</string>
 			<key>pfm_subkeys</key>
@@ -215,9 +202,7 @@ You should provide a default value if possible. No warning will be displayed if 
 			<key>pfm_default</key>
 			<string>Configuration</string>
 			<key>pfm_description</key>
-			<string>Payload Type.</string>
-			<key>pfm_description_reference</key>
-			<string>The only supported value is Configuration.</string>
+			<string>The type of payload. The only supported value is 'Configuration'.</string>
 			<key>pfm_hidden</key>
 			<string>all</string>
 			<key>pfm_name</key>
@@ -233,10 +218,7 @@ You should provide a default value if possible. No warning will be displayed if 
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version number of the profile format. This describes the version of the configuration profile as a whole, not of the individual profiles within it.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the profile format. This describes the version of the configuration profile as a whole, not of the individual profiles within it.
-Currently, this value should be 1.</string>
+			<string>The version number of the profile format. This number represents the version of the configuration profile as a whole, not of the individual profiles within it. The value should be 1.</string>
 			<key>pfm_hidden</key>
 			<string>all</string>
 			<key>pfm_name</key>
@@ -252,9 +234,7 @@ Currently, this value should be 1.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Specifes if there is a removal passcode for the profile.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>Set to 'true' if there is a removal passcode.</string>
 			<key>pfm_hidden</key>
 			<string>all</string>
 			<key>pfm_name</key>
@@ -266,9 +246,7 @@ Currently, this value should be 1.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If provided, will show an OTA-delivered profile as "expired" on a specific date. Users will be offered an "Update" button when the profile has expired.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A date on which a profile is considered to have expired and can be updated over the air. This key is only used if the profile is delivered via over-the-air profile delivery.</string>
+			<string>The date when a profile is no longer valid and an update button is presented to the user.</string>
 			<key>pfm_hidden</key>
 			<string>all</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.ADCertificate.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.ADCertificate.managed.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Active Directory Certificate settings</string>
+	<string>Active Directory Certificate</string>
 	<key>pfm_domain</key>
 	<string>com.apple.ADCertificate.managed</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Requests an Active Directory certificate</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>AD Certificate</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ADCertificate.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ADCertificate.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The description of the certificate request as shown in the certificate selector of other payloads such as VPN and Network</string>
+			<string>A user-friendly description of the certification identity.</string>
 			<key>pfm_name</key>
 			<string>Description</string>
 			<key>pfm_require</key>
@@ -126,7 +126,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Fully qualified host name of the Active Directory issuing CA.</string>
+			<string>The fully qualified host name of the CA.</string>
 			<key>pfm_name</key>
 			<string>CertServer</string>
 			<key>pfm_require</key>
@@ -138,7 +138,15 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name of the CA. This value is determined from the Common Name (CN) of the Active Directory entry: CN=(your CA name), CN='Certification Authorities', CN='Public Key Services', CN='Services', or CN='Configuration', (your base Domain Name).</string>
+			<string>The name of the certificate authority (CA). This value is determined from the common name (CN) of the Active Directory entry. Available in macOS 10.8 and later.
+
+Valid values:
+* CN=&lt;your CA Name&gt;
+* CN='Certification Authorities'
+* CN='Public Key Services'
+* ''CN='Services'
+* ''CN='Configuration'
+* ''CN=&lt;your base Domain Name&gt;</string>
 			<key>pfm_name</key>
 			<string>CertificateAuthority</string>
 			<key>pfm_require</key>
@@ -152,7 +160,7 @@
 			<key>pfm_default</key>
 			<string>User</string>
 			<key>pfm_description</key>
-			<string>The name of the certificate template as it appears in the General tab of the template's object in the Certificate Templates' Microsoft Management Console snap-in component. Usually Machine or User</string>
+			<string>The certificate template for your environment. The default user certificate value is `User`. The default computer certificate value is `Machine`.</string>
 			<key>pfm_name</key>
 			<string>CertTemplate</string>
 			<key>pfm_require</key>
@@ -164,7 +172,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Most commonly RPC. If using Web enrollment, HTTP.</string>
+			<string>This value is most commonly 'RPC'; if using web enrollment, use 'HTTP'. Available in macOS 10.8 and later.</string>
 			<key>pfm_name</key>
 			<string>CertificateAcquisitionMechanism</string>
 			<key>pfm_range_list</key>
@@ -181,7 +189,7 @@
 			<key>pfm_default</key>
 			<integer>14</integer>
 			<key>pfm_description</key>
-			<string>The number of days before the certificate expires at which to start showing the expiration notification</string>
+			<string>The number of days in advance of certificate expiration that the notification center notifies the user.</string>
 			<key>pfm_name</key>
 			<string>CertificateRenewalTimeInterval</string>
 			<key>pfm_require</key>
@@ -195,7 +203,7 @@
 			<key>pfm_default</key>
 			<integer>2048</integer>
 			<key>pfm_description</key>
-			<string>The RSA key size for the Certificate Signing Request (CSR).</string>
+			<string>The RSA key size for the certificate signing request (CSR). Available in macOS 10.11 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -211,7 +219,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prompt the user for credentials.  This setting is not supported for pushed profiles</string>
+			<string>If 'true', the user is prompted for credentials when the profile is installed. This key applies only to user certificates with the Manual Download profile delivery method. Omit this key for computer certificates. Available in macOS 10.8 and later.</string>
 			<key>pfm_name</key>
 			<string>PromptForCredentials</string>
 			<key>pfm_title</key>
@@ -243,7 +251,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow all apps to access the certificate in the keychain</string>
+			<string>If 'true', gives apps access to the private key. Available in macOS 10.10 and later.</string>
 			<key>pfm_name</key>
 			<string>AllowAllAppsAccess</string>
 			<key>pfm_title</key>
@@ -255,7 +263,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow admin to export private key from the keychain</string>
+			<string>If 'true', allows exporting the private key. Available in macOS 10.10 and later.</string>
 			<key>pfm_name</key>
 			<string>KeyIsExtractable</string>
 			<key>pfm_title</key>
@@ -267,7 +275,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allows the certificate to attempt an auto-renewal from the server.</string>
+			<string>If 'true', the certificate obtained with this payload attempts auto-renewal. Auto-renewal can only be used with device Active Directory certificate payloads. Available in macOS 10.13.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.4</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.AIM.account.plist
+++ b/Manifests/ManifestsApple/com.apple.AIM.account.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Messages: AIM settings</string>
+	<string>Use this section to define settings for configuration access to AIM servers.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.AIM.account</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-17T16:39:02Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Messages: AIM settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Messages: AIM</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.AIM.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mobiledevice.passwordpolicy</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The display name for the account.</string>
+			<string>The description of the account.</string>
 			<key>pfm_name</key>
 			<string>AIMAccountDescription</string>
 			<key>pfm_require</key>
@@ -126,7 +126,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The chat name of the user.</string>
+			<string>The user's login name.</string>
 			<key>pfm_name</key>
 			<string>AIMUserName</string>
 			<key>pfm_title</key>
@@ -136,7 +136,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for the account.</string>
+			<string>The user's password.</string>
 			<key>pfm_name</key>
 			<string>AIMPassword</string>
 			<key>pfm_sensitive</key>
@@ -148,7 +148,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The authentication method for the server.</string>
+			<string>The authentication method for the account.</string>
 			<key>pfm_name</key>
 			<string>AIMAuthentication</string>
 			<key>pfm_range_list</key>
@@ -170,7 +170,7 @@
 			<key>pfm_default</key>
 			<string>slogin.oscar.aol.com</string>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the server.</string>
+			<string>The server address.</string>
 			<key>pfm_name</key>
 			<string>AIMHostName</string>
 			<key>pfm_require</key>
@@ -184,7 +184,7 @@
 			<key>pfm_default</key>
 			<integer>5190</integer>
 			<key>pfm_description</key>
-			<string>The port on which to connect to the server.</string>
+			<string>The connection port for the server.</string>
 			<key>pfm_name</key>
 			<string>AIMPort</string>
 			<key>pfm_range_max</key>
@@ -202,7 +202,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enable Secure Socket Layer for this connection.</string>
+			<string>If 'true', enables SSL.</string>
 			<key>pfm_name</key>
 			<string>AIMUseSSL</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.4</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Content Caching settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>Content Caching</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.AssetCache.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.AssetCache.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,10 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -136,10 +120,8 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Users can't turn off the content caching service.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, automatically activate the Content Cache when possible and prevent disabling of the Content Cache. Default is false.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', automatically activates the content cache when possible and prevents it from being disabled. If the 'allowContentCaching' restriction is set to 'false', 'AutoActivation' is also 'false'.
+Removing a profile that set 'AutoActivation' to 'true' does not deactivate the Content Cache.</string>
 			<key>pfm_name</key>
 			<string>AutoActivation</string>
 			<key>pfm_title</key>
@@ -151,10 +133,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>The maximum number of bytes of disk space that will be used for the content cache. The value of zero allows unlimited space.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Defines the maximum number of bytes of disk space that will be used for the Content Cache. A CacheLimit of 0 means unlimited disk space. Default is 0.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>The maximum number of bytes of disk space that will be used for the content cache. A value of 0 means unlimited disk space.</string>
 			<key>pfm_name</key>
 			<string>CacheLimit</string>
 			<key>pfm_title</key>
@@ -182,10 +161,9 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Clients may take some time (hours, days) to react to changes to this setting; it does not have an immediate effect. At least one of the AllowPersonalCaching or AllowSharedCaching keys must be true. Data includes documents and photos, among others.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, caches the userʼs iCloud data. Clients may take some time (hours, days) to react to changes to this setting; it does not have an immediate effect. Default is true. At least one of the AllowPersonalCaching or AllowSharedCaching keys must be true.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', caches the user's iCloud data. Clients may take some time (hours or days) to react to changes to this setting; it doesn't have an immediate effect.
+
+At least one of the 'AllowPersonalCaching' or 'AllowSharedCaching' keys must be 'true'.</string>
 			<key>pfm_name</key>
 			<string>AllowPersonalCaching</string>
 			<key>pfm_title</key>
@@ -213,11 +191,9 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Clients may take some time (hours, days) to react to changes to this setting; it does not have an immediate effect. At least one of the AllowPersonalCaching or AllowSharedCaching keys must be true. Data includes apps and software updates.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, caches non-iCloud content, such as apps and software updates. Clients may take some time (hours, days) to react to changes to this setting; it does not have an immediate effect. Default is true.
-At least one of the AllowPersonalCaching or AllowSharedCaching keys must be true.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', caches non-iCloud content, such as apps and software updates. Clients may take some time (hours, days) to react to changes to this setting; it does not have an immediate effect.
+
+At least one of the 'AllowPersonalCaching' or 'AllowSharedCaching' keys must be 'true'.</string>
 			<key>pfm_name</key>
 			<string>AllowSharedCaching</string>
 			<key>pfm_title</key>
@@ -227,7 +203,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Requires you to allow sharing the computer's Internet connection and cached content with iOS devices connected using USB.</string>
+			<string>Automatically enable Internet connection sharing when possible and prevent disabling Internet connection sharing. 'DenyTetheredCaching' overrides 'AutoEnableTetheredCaching'. Tethered caching requires Content Caching.
+Available in macOS 10.15.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.15.4</string>
 			<key>pfm_name</key>
@@ -241,10 +218,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>TCP port on which the content caching service accepts requests for uploads or downloads. Set to 0 to pick a random port.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The TCP port number on which the Content Cache accepts requests for uploads or downloads. Port set to 0 picks a random, available port. Default is 0.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>The TCP port number on which the content cache accepts requests for uploads or downloads. Set the port to 0 to pick a random, available port.</string>
 			<key>pfm_name</key>
 			<string>Port</string>
 			<key>pfm_range_max</key>
@@ -260,12 +234,9 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<string>/Library/Application Support/Apple/AssetCache/Data</string>
 			<key>pfm_description</key>
-			<string>The path to the directory used to store cached content. Changing this setting manually doesn't automatically move cached content from the old to the new location. To move content automatically, use Content Caching preferences. You can also set this value in Content Caching preferences.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The path to the directory used to store Cached Content. Changing this setting manually does not automatically move cached content from the old to the new location. To move content automatically, use the Sharing preferenceʼs Content Caching pane.
-The value must be, or end with, /Library/Application Support/Apple/AssetCache/Data. A directory (and its intermediates) will be created for the given DataPath if it does not already exist. The directory will be owned by _assetcache:_assetcache and have mode 0750. Its immediate parent directory (.../Library/Application Support/Apple/AssetCache) will be owned by _assetcache:_assetcache and have mode 0755.
-Default is /Library/Application Support/Apple/AssetCache/Data.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>The path to the directory used to store cached content. Changing this setting manually doesn't automatically move cached content from the old location to the new one. To move content automatically, use the Sharing preference's Content Caching pane. The value must be (or end with) '/Library/Application Support/Apple/AssetCache/Data'.
+
+A directory and its intermediates are created for the given data path if it doesn't already exist. The directory is owned by '_assetcache:_assetcache' and has mode 0750. Its immediate parent directory ('.../Library/Application Support/Apple/AssetCache') is owned by '_assetcache:_assetcache' and has mode '0755'.</string>
 			<key>pfm_name</key>
 			<string>DataPath</string>
 			<key>pfm_title</key>
@@ -277,10 +248,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Share this computer's Internet connection and cached content with iOS devices connected using USB.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, tethered caching is disabled. Default is false.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', disables tethered caching.</string>
 			<key>pfm_name</key>
 			<string>DenyTetheredCaching</string>
 			<key>pfm_title</key>
@@ -294,10 +262,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Log the IP address and port number of clients that request content.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Content Cache will log the IP address and port number of the clients that request content. Default is false.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', the Content Cache logs the IP address and port number of the clients that request content.</string>
 			<key>pfm_name</key>
 			<string>LogClientIdentity</string>
 			<key>pfm_title</key>
@@ -307,11 +272,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A list of the local IP addresses of other content caches from which this cache should download or upload content instead of downloading from or uploading to Apple directly.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Array of the local IP addresses of other Content Caches that this cache should download from or upload to, instead of downloading from or uploading to Apple directly. Invalid addresses and addresses of computers that are not Content Caches are ignored.
-Parent caches that become unavailable are skipped. If all parent Content Caches become unavailable, the Content Cache will download from or upload to Apple directly until a parent Content Cache becomes available again.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>An array of the local IP addresses of other content caches that this cache should download from or upload to, instead of downloading from or uploading to Apple directly. Invalid addresses and addresses of computers that aren't content caches are ignored. Parent caches that become unavailable are skipped. If all parent content caches become unavailable, the content cache downloads from or uploads to Apple directly, until a parent content cache becomes available again.</string>
 			<key>pfm_name</key>
 			<string>Parents</string>
 			<key>pfm_subkeys</key>
@@ -338,16 +299,17 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<string>round-robin</string>
 			<key>pfm_description</key>
-			<string>The policy to use when choosing among more than one configured parent content cache.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The policy to use when choosing among more than one configured parent Content Cache. With every policy, parent caches that are temporarily unavailable are skipped.
-• first-available: Always use the first parent in the Parents list that is available. This is useful for designating permanent primary, secondary, and subsequent parents.
-• url-path-hash: Hash the path part of the requested URL so that the same parent is always used for the same URL. This is useful for maximizing the size of the combined caches of the parents.
-• random: Choose a parent at random. This is useful for load balancing.
-• round-robin: Rotate through the parents in order. This is useful for load balancing.
-• sticky-available: Starting with the first parent in the Parents list, always use the first parent that is available. Use that parent until it becomes unavailable, then advance to the next one. This is useful for designating floating primary, secondary, and subsequent parents.
-Default is round-robin.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>The policy to implement when choosing among more than one configured parent content cache. With every policy, parent caches that are temporarily unavailable are skipped.
+
+'first-available': Always use the first available parent in the Parents list. Use this policy to designate permanent primary, secondary, and subsequent parents.
+
+'url-path-hash': Hash the path part of the requested URL so that the same parent is always used for the same URL. This is useful for maximizing the size of the combined caches of the parents.
+
+'random': Choose a parent at random. Use this policy for load balancing.
+
+'round-robin': Rotate through the parents in order. Use this policy for load balancing.
+
+'sticky-available': Use the first available parent that is available in the Parents list until it becomes unavailable, then advance to the next one. Use this policy for designating floating primary, secondary, and subsequent parents.</string>
 			<key>pfm_name</key>
 			<string>ParentSelectionPolicy</string>
 			<key>pfm_range_list</key>
@@ -373,10 +335,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A range of public IP addresses that the cloud servers should use for matching clients to Content Caches.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Array of dictionaries describing a range of public IP addresses that the cloud servers should use for matching clients to Content Caches.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>An array of dictionaries describing a range of public IP addresses that the cloud servers should use for matching clients to content caches.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -471,7 +430,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Automatically remove content from the cache when the system needs disk space for other apps.</string>
+			<string>Allow the system to purge content from the cache automatically when it needs disk space for other apps (i.e. when free disk space runs low on the computer). Customers who want Content Caching to be as effective as possible should turn this setting off.
+Available in macOS 10.15 and later.</string>
 			<key>pfm_name</key>
 			<string>AllowCacheDelete</string>
 			<key>pfm_title</key>
@@ -483,7 +443,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Display Content Caching alerts as notifications.</string>
+			<string>If 'true', Content Caching displays exceptional conditions (alerts) as system notifications in the upper corner of the screen. Alerts were automatically displayed starting in macOS 10.13. In macOS 10.15 the alerts are off by default, but still available via this setting.
+Available in macOS 10.15 and later.</string>
 			<key>pfm_name</key>
 			<string>DisplayAlerts</string>
 			<key>pfm_title</key>
@@ -495,7 +456,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent the computer from sleeping while caching is on.</string>
+			<string>If 'true', prevents the computer from sleeping as long as Content Caching is on (System Preferences &gt; Sharing &gt; Content Caching is on). Customers who want Content Caching to be as available as much as possible should turn this setting on.
+Available in macOS 10.15 and later.</string>
 			<key>pfm_name</key>
 			<string>KeepAwake</string>
 			<key>pfm_title</key>
@@ -685,7 +647,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<real>0.2</real>
+			<real>0.20000000000000001</real>
 			<key>pfm_description_reference</key>
 			<string>The percentage of attenuation added to the upload time. Clamped minimum is 0% attenuation. Values too large will exceed the ImportTimeout and cause failures.</string>
 			<key>pfm_documentation_url</key>
@@ -781,10 +743,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		<dict>
 			<key>pfm_default</key>
 			<true/>
-			<key>pfm_description_reference</key>
-			<string>Indicates whether content caching registers with the union of the ListenRanges, PeerListenRanges, and Parents keys, or only with the ListenRanges key.
-
-Note that ListenRanges could be automatically generated from LocalSubnetsOnly, and PeerListenRanges could be automatically generated from PeerLocalSubnetsOnly.</string>
+			<key>pfm_description</key>
+			<string>If 'true', the content cache provides content to the clients in the union of the 'ListenRanges', 'PeerListenRanges' and 'Parents'.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.apple.com/guide/mac-help/configure-advanced-content-caching-settings-mchl91e7141a/10.15/mac/10.15</string>
 			<key>pfm_name</key>
@@ -1159,11 +1119,7 @@ Clamped between 1-60 seconds, inclusive.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Content Cache offers content to clients only on the same immediate local network.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Content Cache offers content to clients only on the same immediate local network as the Content Cache. No content would be offered to clients on other networks reachable by the Content Cache. Default is true.
-If LocalSubnetsOnly is set to true, ListenRanges will be ignored.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', the content cache offers content to clients only on the same immediate local network only. No content is offered to clients on other networks reachable by the content cache. If 'LocalSubnetsOnly' is set to 'true', 'ListenRanges' will be ignored.</string>
 			<key>pfm_name</key>
 			<string>LocalSubnetsOnly</string>
 			<key>pfm_title</key>
@@ -1175,10 +1131,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Provide content only to the clients specified by the listen ranges.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Content Cache provides content only to clients in the ranges specified by the ListenRanges key. To use the ListenRangesOnly key, the ListenRanges key must also be specified. Default is false.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', the content cache provides content to the clients in the 'ListenRanges'.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1215,10 +1168,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A range of IPv4 and IPv6 addresses to restrict clients to.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Array of dictionaries describing a range of client IP addresses to serve.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>An array of dictionaries describing a range of client IP addresses to serve.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1327,12 +1277,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Content Cache will only peer with other Content Caches on the same immediate local network, rather than with Content Caches that use the same public IP address as the device.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Content Cache will only peer with other Content Caches on the same immediate local network, rather than with Content Caches that use the same public IP address as the device. When PeerLocalSubnetsOnly is true, it overrides the configuration of PeerFilterRanges and PeerListenRanges. If the network changes, the local network peering restrictions update appropriately.
-If set to false, the Content Cache defers to PeerFilterRanges and PeerListenRanges for configuring the peering restrictions.
-Default is true.
-Availability: Available in macOS 10.13.4 and later.</string>
+			<string>If 'true', the content cache only peers with other content caches on the same immediate local network, rather than with content caches that use the same public IP address as the device. When 'PeerLocalSubnetsOnly' is 'true', it overrides the configuration of 'PeerFilterRanges' and 'PeerListenRanges'. If the network changes, the local network peering restrictions update appropriately. If 'false', the content cache defers to 'PeerFilterRanges' and 'PeerListenRanges' for configuring the peering restrictions.</string>
 			<key>pfm_name</key>
 			<string>PeerLocalSubnetsOnly</string>
 			<key>pfm_title</key>
@@ -1342,9 +1287,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A range of peer IP addresses that the Content Cache will use to filter its list of peers to query for content.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Array of dictionaries describing a range of peer IP addresses that the Content Cache will use to filter its list of peers to query for content. The Content Cache only queries peers that are in the PeerFilterRanges. When PeerFilterRanges is an empty array the Content Cache will not query any peers. Availability: Available in macOS 10.13.4 and later.</string>
+			<string>An array of dictionaries describing a range of peer IP addresses that the content cache uses to filter its list of peers to query for content. The content cache only queries peers in 'PeerFilterRanges'. When 'PeerFilterRanges' is an empty array, the content cache doesn't query any peers.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1437,9 +1380,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A range of peer IP addresses the Content Cache will respond to peer cache queries from.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Array of dictionaries describing a range of peer IP addresses the Content Cache will respond to peer cache queries from. When PeerListenRanges is an empty array, the Content Cache will respond with an error to all cache queries. Availability: Available in macOS 10.13.4 and later.</string>
+			<string>An array of dictionaries describing a range of peer IP addresses the content cache responds to. When 'PeerListenRanges' is an empty array, the content cache responds with an error to all cache queries.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.Dictionary.plist
+++ b/Manifests/ManifestsApple/com.apple.Dictionary.plist
@@ -14,7 +14,7 @@ It enables the restrictions defined in the deviceʼs Parental Controls Dictionar
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-17T16:39:02Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -25,9 +25,7 @@ It enables the restrictions defined in the deviceʼs Parental Controls Dictionar
 			<key>pfm_default</key>
 			<string>Configures Parental Controls: Dictionary settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,9 +37,7 @@ It enables the restrictions defined in the deviceʼs Parental Controls Dictionar
 			<key>pfm_default</key>
 			<string>Parental Controls: Dictionary</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,9 +51,7 @@ It enables the restrictions defined in the deviceʼs Parental Controls Dictionar
 			<key>pfm_default</key>
 			<string>com.apple.Dictionary</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -71,9 +65,7 @@ It enables the restrictions defined in the deviceʼs Parental Controls Dictionar
 			<key>pfm_default</key>
 			<string>com.apple.Dictionary</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -87,9 +79,7 @@ It enables the restrictions defined in the deviceʼs Parental Controls Dictionar
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -105,10 +95,7 @@ It enables the restrictions defined in the deviceʼs Parental Controls Dictionar
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +107,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -133,9 +117,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enable parental controls dictionary restrictions.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Set to true to enable parental controls dictionary restrictions.</string>
+			<string>If 'true', enables parental controls dictionary restrictions.</string>
 			<key>pfm_name</key>
 			<string>parentalControl</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Active Directory settings</string>
+	<string>Directory Service</string>
 	<key>pfm_description_reference</key>
 	<string>In macOS 10.9 and later, a configuration profile can be used to configure macOS to join an Active Directory (AD) domain. Advanced AD options available via Directory Utility or the dsconfigad command line tool can also be set using a configuration profile, following this procedure:
 1. StartwithamacOSDirectorypayload,createdinProfileManager. 
@@ -18,7 +18,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-03-06T10:55:33Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -31,9 +31,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 			<key>pfm_default</key>
 			<string>Configures Active Directory settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -45,9 +43,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 			<key>pfm_default</key>
 			<string>Active Directory</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -61,9 +57,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 			<key>pfm_default</key>
 			<string>com.apple.DirectoryService.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -77,9 +71,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 			<key>pfm_default</key>
 			<string>com.apple.DirectoryService.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -93,9 +85,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -111,10 +101,7 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -126,10 +113,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -139,8 +123,6 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The hostname of the directory server.</string>
-			<key>pfm_description_reference</key>
 			<string>The Active Directory domain to join.</string>
 			<key>pfm_name</key>
 			<string>HostName</string>
@@ -153,9 +135,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>User name of the account used to join the domain.</string>
-			<key>pfm_description_reference</key>
-			<string>User name of the account used to join the domain.</string>
+			<string>The user name of the account for the domain.</string>
 			<key>pfm_name</key>
 			<string>UserName</string>
 			<key>pfm_title</key>
@@ -165,9 +145,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Password of the account used to join the domain.</string>
-			<key>pfm_description_reference</key>
-			<string>Password of the account used to join the domain.</string>
+			<string>The password of the account for the domain.</string>
 			<key>pfm_name</key>
 			<string>Password</string>
 			<key>pfm_title</key>
@@ -177,9 +155,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The directory server client ID.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>The client's identifier.</string>
 			<key>pfm_documentation_source</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -191,9 +167,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The organizational unit (OU) where the joining computer object is added.</string>
-			<key>pfm_description_reference</key>
-			<string>The organizational unit (OU) where the joining computer object is added.</string>
+			<string>The organizational unit where the joining computer object is added.</string>
 			<key>pfm_name</key>
 			<string>ADOrganizationalUnit</string>
 			<key>pfm_title</key>
@@ -205,9 +179,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADCreateMobileAccountAtLogin Flag.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADCreateMobileAccountAtLogin key.</string>
+			<string>If 'true', enables the 'ADCreateMobileAccountAtLogin' key.</string>
 			<key>pfm_name</key>
 			<string>ADCreateMobileAccountAtLoginFlag</string>
 			<key>pfm_title</key>
@@ -237,9 +209,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Create mobile account at login.</string>
-			<key>pfm_description_reference</key>
-			<string>Create mobile account at login.</string>
+			<string>If 'true', creates a mobile account at login.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -267,9 +237,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADWarnUserBeforeCreatingMA Flag.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADWarnUserBeforeCreatingMA key.</string>
+			<string>If 'true', enables the 'ADWarnUserBeforeCreatingMA' key.</string>
 			<key>pfm_name</key>
 			<string>ADWarnUserBeforeCreatingMAFlag</string>
 			<key>pfm_title</key>
@@ -299,9 +267,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Require confirmation before creating mobile account.</string>
-			<key>pfm_description_reference</key>
-			<string>Warn user before creating a Mobile Account.</string>
+			<string>If 'true', enables the warning before creating the mobile account.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -329,9 +295,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADForceHomeLocal Flag.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADForceHomeLocal key.</string>
+			<string>If 'true', enables the 'ADForceHomeLocal' key.</string>
 			<key>pfm_name</key>
 			<string>ADForceHomeLocalFlag</string>
 			<key>pfm_title</key>
@@ -361,9 +325,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Force local home directory on startup disk.</string>
-			<key>pfm_description_reference</key>
-			<string>Force local home directory.</string>
+			<string>If 'true', forces a local home directory.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -391,9 +353,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADUseWindowsUNCPath Flag.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADUseWindowsUNCPath key.</string>
+			<string>If 'true', enables the 'ADUseWindowsUNCPath' key.</string>
 			<key>pfm_name</key>
 			<string>ADUseWindowsUNCPathFlag</string>
 			<key>pfm_title</key>
@@ -423,9 +383,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Use UNC path from Active Directory to derive network home location</string>
-			<key>pfm_description_reference</key>
-			<string>Use UNC path from Active Directory to derive network home location.</string>
+			<string>If 'true', uses the UNC path from Active Directory to derive the network home location.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -453,9 +411,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>smb</string>
 			<key>pfm_description</key>
-			<string>Network protocol to be used to mount home directory.</string>
-			<key>pfm_description_reference</key>
-			<string>Network home protocol to use: "afp" or "smb".</string>
+			<string>The network home protocol to use: 'afp' or 'smb'.</string>
 			<key>pfm_name</key>
 			<string>ADMountStyle</string>
 			<key>pfm_range_list</key>
@@ -477,9 +433,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADDefaultUserShell Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADDefaultUserShell key.</string>
+			<string>If 'true', enables the 'ADDefaultUserShell' key.</string>
 			<key>pfm_name</key>
 			<string>ADDefaultUserShellFlag</string>
 			<key>pfm_title</key>
@@ -509,9 +463,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>/bin/bash</string>
 			<key>pfm_description</key>
-			<string>Default user shell.</string>
-			<key>pfm_description_reference</key>
-			<string>Default user shell; e.g. /bin/bash.</string>
+			<string>The default user shell.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -539,9 +491,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADMapUIDAttribute Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADMapUIDAttribute key.</string>
+			<string>If 'true', enables the 'ADMapUIDAttribute' key.</string>
 			<key>pfm_name</key>
 			<string>ADMapUIDAttributeFlag</string>
 			<key>pfm_title</key>
@@ -569,9 +519,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Map UID to attribute.</string>
-			<key>pfm_description_reference</key>
-			<string>Map UID to attribute.</string>
+			<string>The map UID to attribute.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -599,9 +547,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADMapGIDAttribute Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADMapGIDAttribute key.</string>
+			<string>If 'true', enables the 'ADMapGIDAttribute' key.</string>
 			<key>pfm_name</key>
 			<string>ADMapGIDAttributeFlag</string>
 			<key>pfm_title</key>
@@ -629,9 +575,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Map user GID to attribute.</string>
-			<key>pfm_description_reference</key>
-			<string>Map user GID to attribute.</string>
+			<string>The map GID to attribute.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -659,9 +603,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADMapGGIDAttribute Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADMapGGIDAttributeFlag key.</string>
+			<string>If 'true', enables the 'ADMapGGIDAttributeFlag' key.</string>
 			<key>pfm_name</key>
 			<string>ADMapGGIDAttributeFlag</string>
 			<key>pfm_title</key>
@@ -689,9 +631,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Map group GID to attribute.</string>
-			<key>pfm_description_reference</key>
-			<string>Map group GID to attribute.</string>
+			<string>The map group GID to attribute.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -719,9 +659,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADPreferredDCServer Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADPreferredDCServer key.</string>
+			<string>If 'true', enables the 'ADPreferredDCServer' key.</string>
 			<key>pfm_name</key>
 			<string>ADPreferredDCServerFlag</string>
 			<key>pfm_title</key>
@@ -749,9 +687,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Preferred domain server.</string>
-			<key>pfm_description_reference</key>
-			<string>Prefer this domain server.</string>
+			<string>The preferred domain server.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -779,9 +715,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADDomainAdminGroupList Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADDomainAdminGroupList key.</string>
+			<string>If 'true', enables the 'ADDomainAdminGroupList' key.</string>
 			<key>pfm_name</key>
 			<string>ADDomainAdminGroupListFlag</string>
 			<key>pfm_title</key>
@@ -809,9 +743,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Allow administration by specified Active Directory groups.</string>
-			<key>pfm_description_reference</key>
-			<string>Allow administration by specified Active Directory groups.</string>
+			<string>The list of Active Directory groups that are granted admin access.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -854,9 +786,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADAllowMultiDomainAuth Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADAllowMultiDomainAuth key.</string>
+			<string>If 'true', enables the 'ADAllowMultiDomainAuth' key.</string>
 			<key>pfm_name</key>
 			<string>ADAllowMultiDomainAuthFlag</string>
 			<key>pfm_title</key>
@@ -886,9 +816,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow authentication from any domain in the forest.</string>
-			<key>pfm_description_reference</key>
-			<string>Allow authentication from any domain in the forest.</string>
+			<string>If 'true', allows authentication from any domain in the namespace.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -916,9 +844,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADNamespace Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADNamespace key.</string>
+			<string>If 'true', enables the 'ADNamespace' key.</string>
 			<key>pfm_name</key>
 			<string>ADNamespaceFlag</string>
 			<key>pfm_title</key>
@@ -948,9 +874,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>domain</string>
 			<key>pfm_description</key>
-			<string>Set primary user account naming convention: "forest" or "domain".</string>
-			<key>pfm_description_reference</key>
-			<string>Set primary user account naming convention: "forest" or "domain"; "domain" is default.</string>
+			<string>The primary user account naming convention; either 'forest' or 'domain'.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -983,9 +907,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADPacketSign Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADPacketSign key.</string>
+			<string>If 'true', enables the 'ADPacketSign' key.</string>
 			<key>pfm_name</key>
 			<string>ADPacketSignFlag</string>
 			<key>pfm_title</key>
@@ -1015,9 +937,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>allow</string>
 			<key>pfm_description</key>
-			<string>Packet signing.</string>
-			<key>pfm_description_reference</key>
-			<string>Packet signing: "allow", "disable" or "require"; "allow" is default.</string>
+			<string>The packet signing policy.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1051,9 +971,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADPacketEncrypt Key</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADPacketEncrypt key.</string>
+			<string>If 'true', enables the 'ADPacketEncrypt' key.</string>
 			<key>pfm_name</key>
 			<string>ADPacketEncryptFlag</string>
 			<key>pfm_title</key>
@@ -1083,9 +1001,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>allow</string>
 			<key>pfm_description</key>
-			<string>Packet encryption.</string>
-			<key>pfm_description_reference</key>
-			<string>Packet encryption: "allow", "disable", "require" or "ssl"; "allow" is default.</string>
+			<string>The packet encryption policy.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1120,9 +1036,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADRestrictDDNS Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADRestrictDDNS key.</string>
+			<string>If 'true', enables the 'ADRestrictDDNS' key.</string>
 			<key>pfm_name</key>
 			<string>ADRestrictDDNSFlag</string>
 			<key>pfm_title</key>
@@ -1150,9 +1064,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Restrict Dynamic DNS updates to the specified interfaces (e.g. en0, en1, etc).</string>
-			<key>pfm_description_reference</key>
-			<string>Restrict Dynamic DNS updates to the specified interfaces (e.g. en0, en1, etc).</string>
+			<string>An array of strings representing the interfaces that are allowed for dynamic DNS updates (for example, en0, en1, and so on).</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1195,9 +1107,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable ADTrustChangePassIntervalDays Key.</string>
-			<key>pfm_description_reference</key>
-			<string>Enable or disable the ADTrustChangePassIntervalDays key.</string>
+			<string>If true, enables the 'ADTrustChangePassIntervalDays 'key.</string>
 			<key>pfm_name</key>
 			<string>ADTrustChangePassIntervalDaysFlag</string>
 			<key>pfm_title</key>
@@ -1227,9 +1137,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>14</integer>
 			<key>pfm_description</key>
-			<string>How often to change computer trust account password in days.</string>
-			<key>pfm_description_reference</key>
-			<string>How often to require change of the computer trust account password in days; "0" is disabled.</string>
+			<string>The number of days before requiring a change of the computer trust account password. '0' disables the feature.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.DiscRecording.plist
+++ b/Manifests/ManifestsApple/com.apple.DiscRecording.plist
@@ -14,7 +14,7 @@ The Disc Burning payload is designated by specifying com.apple.DiscRecording as 
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:49Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -25,9 +25,7 @@ The Disc Burning payload is designated by specifying com.apple.DiscRecording as 
 			<key>pfm_default</key>
 			<string>Configures Disc Burning settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,9 +37,7 @@ The Disc Burning payload is designated by specifying com.apple.DiscRecording as 
 			<key>pfm_default</key>
 			<string>Disc Burning</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,9 +51,7 @@ The Disc Burning payload is designated by specifying com.apple.DiscRecording as 
 			<key>pfm_default</key>
 			<string>com.apple.DiscRecording</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -71,9 +65,7 @@ The Disc Burning payload is designated by specifying com.apple.DiscRecording as 
 			<key>pfm_default</key>
 			<string>com.apple.DiscRecording</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -87,9 +79,7 @@ The Disc Burning payload is designated by specifying com.apple.DiscRecording as 
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -105,10 +95,7 @@ The Disc Burning payload is designated by specifying com.apple.DiscRecording as 
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +107,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -153,9 +137,11 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>• Set to off to disable disc burning.\n• Set to on for normal default operation.\n• Set to authenticate to require authentication.\nSetting this key to on will not enable disc burn support if it has already been disabled by other mechanisms or preferences.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Set to off to disable disc burning. Set to on for normal default operation. Set to authenticate to require authentication. Setting this key to on will not enable disc burn support if it has already been disabled by other mechanisms or preferences.</string>
+			<string>If 'off', disables disc burning.
+
+If 'on', allows normal default operation. Setting this key to 'on' doesn't enable disc burn support if it has already been disabled by other mechanisms or preferences. It also must be enabled with the Finder profile.
+
+If 'authenticate', requires authentication.</string>
 			<key>pfm_name</key>
 			<string>BurnSupport</string>
 			<key>pfm_range_list</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-EnergySaver.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-EnergySaver.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Energy Saver settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Energy Saver</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-FileVaultOptions.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-FileVaultOptions.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-04-15T17:37:13Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures FileVault Options</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>FileVault Options</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-GuestAccount.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-GuestAccount.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures the guest account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>Guest Account</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-MobileAccounts.plist
@@ -16,7 +16,7 @@ This payload allows controls the authentication UI during mobile account creatio
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -31,9 +31,7 @@ This payload allows controls the authentication UI during mobile account creatio
 			<key>pfm_default</key>
 			<string>Configures Mobile Accounts settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -45,9 +43,7 @@ This payload allows controls the authentication UI during mobile account creatio
 			<key>pfm_default</key>
 			<string>Mobile Accounts</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -61,9 +57,7 @@ This payload allows controls the authentication UI during mobile account creatio
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -77,9 +71,7 @@ This payload allows controls the authentication UI during mobile account creatio
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -93,9 +85,7 @@ This payload allows controls the authentication UI during mobile account creatio
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -111,10 +101,7 @@ This payload allows controls the authentication UI during mobile account creatio
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -126,10 +113,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-TimeServer.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-TimeServer.plist
@@ -16,7 +16,7 @@ This payload allows devices to connect to custom time servers.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12.4</string>
 	<key>pfm_platforms</key>
@@ -31,9 +31,7 @@ This payload allows devices to connect to custom time servers.</string>
 			<key>pfm_default</key>
 			<string>Configures Time Server settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -45,9 +43,7 @@ This payload allows devices to connect to custom time servers.</string>
 			<key>pfm_default</key>
 			<string>Time Server</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -61,9 +57,7 @@ This payload allows devices to connect to custom time servers.</string>
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -77,9 +71,7 @@ This payload allows devices to connect to custom time servers.</string>
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -93,9 +85,7 @@ This payload allows devices to connect to custom time servers.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -111,10 +101,7 @@ This payload allows devices to connect to custom time servers.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -126,10 +113,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.MCX-WiFiManagedSettings.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX-WiFiManagedSettings.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-02-14T03:34:53Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures managed Wi-Fi settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Wi-Fi Managed Settings</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX.FileVault2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_max</key>
 	<string>10.12.6</string>
 	<key>pfm_macos_min</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures FileVault 2 settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>FileVault 2</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX.FileVault2</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX.FileVault2</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -136,9 +120,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to 'On' to enable FileVault. Set to 'Off' to disable FileVault.</string>
-			<key>pfm_description_reference</key>
-			<string>Set to ʼOnʼ to enable FileVault. Set to ʼOffʼ to disable FileVault. This value is required.</string>
+			<string>If 'true', enables FileVault.</string>
 			<key>pfm_name</key>
 			<string>Enable</string>
 			<key>pfm_range_list</key>
@@ -157,9 +139,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Defer enabling FileVault until the designated user logs out. For details, see fdesetup(8). The person enabling FileVault must be either a local user or a mobile account user.</string>
-			<key>pfm_description_reference</key>
-			<string>Set to true to defer enabling FileVault until the designated user logs out. For details, see fdesetup(8). The person enabling FileVault must be either a local user or a mobile account user.</string>
+			<string>If 'true', defers enabling FileVault until the designated user logs out. For details, see 'fdesetup(8)'. The person enabling FileVault must be either a local user or a mobile account user.</string>
 			<key>pfm_name</key>
 			<string>Defer</string>
 			<key>pfm_title</key>
@@ -171,9 +151,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to true for manual profile installs to prompt for missing user name or password fields.</string>
-			<key>pfm_description_reference</key>
-			<string>Set to true for manual profile installs to prompt for missing user name or password fields.</string>
+			<string>If 'true', enables a prompt for missing user name or password fields.</string>
 			<key>pfm_name</key>
 			<string>UserEntersMissingInfo</string>
 			<key>pfm_title</key>
@@ -185,9 +163,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to true to create a personal recovery key.</string>
-			<key>pfm_description_reference</key>
-			<string>Set to true to create a personal recovery key. Defaults to true.</string>
+			<string>If 'true', creates a personal recovery key and displays it to the user.</string>
 			<key>pfm_name</key>
 			<string>UseRecoveryKey</string>
 			<key>pfm_title</key>
@@ -199,9 +175,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to not display the personal recovery key to the user after FileVault is enabled.</string>
-			<key>pfm_description_reference</key>
-			<string>Set to false to not display the personal recovery key to the user after FileVault is enabled. Defaults to true.</string>
+			<string>If 'false', prevents display of the personal recovery key to the user after FileVault is enabled.</string>
 			<key>pfm_name</key>
 			<string>ShowRecoveryKey</string>
 			<key>pfm_title</key>
@@ -211,9 +185,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Path to the location where the recovery key and computer information plist will be stored.</string>
-			<key>pfm_description_reference</key>
-			<string>Path to the location where the recovery key and computer information plist will be stored.</string>
+			<string>The path to the location where the recovery key and computer information property list are stored.</string>
 			<key>pfm_name</key>
 			<string>OutputPath</string>
 			<key>pfm_title</key>
@@ -227,9 +199,7 @@ The payload organization for a payload need not match the payload organization i
 				<string>public.x509-certificate</string>
 			</array>
 			<key>pfm_description</key>
-			<string>DER-encoded certificate data if an institutional recovery key will be added.</string>
-			<key>pfm_description_reference</key>
-			<string>DER-encoded certificate data if an institutional recovery key will be added.</string>
+			<string>The DER-encoded certificate data if 'UseRecoveryKey' is enabled.</string>
 			<key>pfm_name</key>
 			<string>Certificate</string>
 			<key>pfm_title</key>
@@ -239,9 +209,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>UUID of the payload containing the asymmetric recovery key certificate payload.</string>
-			<key>pfm_description_reference</key>
-			<string>UUID of the payload containing the asymmetric recovery key certificate payload.</string>
+			<string>The UUID of the payload within the same profile containing the asymmetric recovery key certificate payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadCertificateUUID</string>
 			<key>pfm_title</key>
@@ -251,9 +219,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>User name of the Open Directory user that will be added to FileVault.</string>
-			<key>pfm_description_reference</key>
-			<string>User name of the Open Directory user that will be added to FileVault.</string>
+			<string>The user name of the Open Directory user to be added to FileVault.</string>
 			<key>pfm_name</key>
 			<string>Username</string>
 			<key>pfm_title</key>
@@ -263,9 +229,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>User password of the Open Directory user that will be added to FileVault. Use the UserEntersMissingInfo key if you want to prompt for this information.</string>
-			<key>pfm_description_reference</key>
-			<string>User password of the Open Directory user that will be added to FileVault. Use the UserEntersMissingInfo key if you want to prompt for this information.</string>
+			<string>The password of the Open Directory user to be added to FileVault. Use the 'UserEntersMissingInfo' key if you want to prompt for this information.</string>
 			<key>pfm_name</key>
 			<string>Password</string>
 			<key>pfm_title</key>
@@ -277,9 +241,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true and no certificate information is provided in this payload, the keychain already created at /Library/Keychains/FileVaultMaster.keychain will be used when the institutional recovery key is added.</string>
-			<key>pfm_description_reference</key>
-			<string>If set to true and no certificate information is provided in this payload, the keychain already created at /Library/Keychains/FileVaultMaster.keychain will be used when the institutional recovery key is added.</string>
+			<string>If 'true' and no certificate information is provided in this payload, the keychain created at '/Library/Keychains/FileVaultMaster.keychain' is used when the institutional recovery key is added.</string>
 			<key>pfm_name</key>
 			<string>UseKeychain</string>
 			<key>pfm_title</key>
@@ -289,10 +251,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>When using the Defer option you can optionally set this key to the maximum number of times the user can bypass enabling FileVault before it will require that it be enabled before the user can log in. If set to 0, it will always prompt to enable FileVault until it is enabled, though it will allow you to bypass enabling it. Setting this key to –1 will disable this feature.</string>
-			<key>pfm_description_reference</key>
-			<string>When using the Defer option you can optionally set this key to the maximum number of times the user can bypass enabling FileVault before it will require that it be enabled before the user can log in. If set to 0, it will always prompt to enable FileVault until it is enabled, though it will allow you to bypass enabling it. Setting this key to –1 will disable this feature.
-Availability: Available in macOS 10.10 and later.</string>
+			<string>The maximum number of times users can bypass enabling FileVault before being required to enable it to log in. If the value is '0', the user will be required to enabled FileVault the next time they attempt to log in. Setting this key to '–1' disables the feature.</string>
 			<key>pfm_macos_min</key>
 			<string>10.10.0</string>
 			<key>pfm_name</key>
@@ -306,9 +265,7 @@ Availability: Available in macOS 10.10 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When using the Defer option, set this key to true to not request enabling FileVault at user logout time.</string>
-			<key>pfm_description_reference</key>
-			<string>When using the Defer option, set this key to true to not request enabling FileVault at user logout time. Availability: Available in macOS 10.10 and later.</string>
+			<string>If 'true', prevents requests for enabling FileVault at user logout time.</string>
 			<key>pfm_macos_min</key>
 			<string>10.10.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.MCX.TimeMachine.plist
+++ b/Manifests/ManifestsApple/com.apple.MCX.TimeMachine.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Time Machine settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Time Machine</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX.TimeMachine</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.MCX.TimeMachine</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>URL of the backup destination. (e.g., smb://server.example.com/backups/)</string>
+			<string>The URL of the backup destination.</string>
 			<key>pfm_name</key>
 			<string>BackupDestURL</string>
 			<key>pfm_require</key>
@@ -128,7 +128,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Only startup volume is backed up by default.</string>
+			<string>If true, backs up only the startup volume by default.</string>
 			<key>pfm_name</key>
 			<string>BackupAllVolumes</string>
 			<key>pfm_title</key>
@@ -140,7 +140,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>System files and folders are skipped by default.</string>
+			<string>If 'true', skips system files and folders by default.</string>
 			<key>pfm_name</key>
 			<string>BackupSkipSys</string>
 			<key>pfm_title</key>
@@ -154,7 +154,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Automatically backup at regulard intervals.</string>
+			<string>If 'true', performs automatic backups at regular intervals.</string>
 			<key>pfm_name</key>
 			<string>AutoBackup</string>
 			<key>pfm_title</key>
@@ -166,7 +166,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Creates local backup snapshots if the backup destination is offline.</string>
+			<string>If 'true', create local backup snapshots when not connected to the network.</string>
 			<key>pfm_macos_min</key>
 			<string>10.8</string>
 			<key>pfm_name</key>
@@ -180,7 +180,7 @@
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Enter a limit in MB for the size of the backup. Set to 0 for unlimited.</string>
+			<string>The backup size limit, in megabytes. Set to 0 for unlimited.</string>
 			<key>pfm_name</key>
 			<string>BackupSizeMB</string>
 			<key>pfm_title</key>
@@ -192,7 +192,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enter additional volumes and locations to exclude from the backup.</string>
+			<string>The path to skip from start volume.</string>
 			<key>pfm_name</key>
 			<string>SkipPaths</string>
 			<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.NSExtension.plist
+++ b/Manifests/ManifestsApple/com.apple.NSExtension.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-03-01T07:09:15Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Extensions settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Extensions</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.NSExtension</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.NSExtension</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Add the bundle identifier for each extension allowed to run on the Mac. Any extensions not listed are unable to run.</string>
+			<string>An array of identifiers for extensions that are allowed to run on the system.</string>
 			<key>pfm_name</key>
 			<string>AllowedExtensions</string>
 			<key>pfm_subkeys</key>
@@ -141,7 +141,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Disallow specific extensions by their bundle identifier.</string>
+			<string>An array of identifiers for extensions that aren't allowed to run on the system.</string>
 			<key>pfm_name</key>
 			<string>DeniedExtensions</string>
 			<key>pfm_subkeys</key>
@@ -166,7 +166,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Disallow specific extension points.</string>
+			<string>An array of extension points for extensions that aren't allowed to run on the system.</string>
 			<key>pfm_name</key>
 			<string>DeniedExtensionPoints</string>
 			<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>14.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-06T09:11:21Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -29,7 +29,7 @@
 			<key>pfm_default</key>
 			<string>Configures Setup Assistant settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -41,7 +41,7 @@
 			<key>pfm_default</key>
 			<string>Setup Assistant</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,7 +55,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SetupAssistant.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -69,7 +69,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SetupAssistant.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -83,7 +83,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -99,7 +99,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -111,7 +111,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -123,7 +123,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the Choose Your Look window.</string>
+			<string>If 'true', skips the Choose Your Look window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14.0</string>
 			<key>pfm_name</key>
@@ -141,7 +141,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the Apple ID setup window.</string>
+			<string>If 'true', skips the Apple ID setup window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -159,7 +159,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the iCloud Storage window.</string>
+			<string>If 'true', skips the iCloud Storage window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.4</string>
 			<key>pfm_name</key>
@@ -177,7 +177,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the Privacy consent window.</string>
+			<string>If 'true', skips the Privacy consent window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.4</string>
 			<key>pfm_name</key>
@@ -195,7 +195,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the Siri setup window.</string>
+			<string>If 'true', skips the Siri setup window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -213,9 +213,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the True Tone Display window.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, skip the True Tone Display window. Availability: Available in macOS 10.13.6 and later.</string>
+			<string>If 'true', skips the True Tone Display window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.6</string>
 			<key>pfm_name</key>
@@ -233,7 +231,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the Screen Time window.</string>
+			<string>If true, skips the Screen Time window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.15</string>
 			<key>pfm_name</key>
@@ -251,7 +249,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the TouchID setup window.</string>
+			<string>If true, skips the Touch ID setup window.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -269,7 +267,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the Unlock with Apple Watch setup window.</string>
+			<string>Skips Unlock With Apple Watch window</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -287,7 +285,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Skips the accessibility setup window.</string>
+			<string>Skips Accessibility window</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -321,7 +319,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of setup items to skip</string>
+			<string>An array strings describing setup items to skip. SkipKeys provides a list of valid strings and their meanings.
+Available in iOS 14 and later.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/skipkeys</string>
 			<key>pfm_ios_min</key>

--- a/Manifests/ManifestsApple/com.apple.ShareKitHelper.plist
+++ b/Manifests/ManifestsApple/com.apple.ShareKitHelper.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-07-28T13:46:40Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>10.12</string>
 	<key>pfm_macos_min</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures Share menu options</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>ShareKit</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ShareKitHelper</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ShareKitHelper</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -135,7 +119,7 @@ The payload organization for a payload need not match the payload organization i
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
+			<key>pfm_description</key>
 			<string>The list of plugin IDs that show up in the user's Share menu. If this array exists, only these items are permitted.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>10.12</string>
@@ -194,8 +178,8 @@ The payload organization for a payload need not match the payload organization i
 			<string>array</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>The list of plugin IDs that won't show up in the user's Share menu. This key is used only if there is no SHKAllowedShareServices key.</string>
+			<key>pfm_description</key>
+			<string>The list of plugin IDs that won't show up in the user's Share menu. This key is used only if there is no 'SHKAllowedShareServices' key.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
+++ b/Manifests/ManifestsApple/com.apple.SoftwareUpdate.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Software Update settings</string>
+	<string>Software Update Managed Settings</string>
 	<key>pfm_description_reference</key>
 	<string>The Software Update payload is designated by specifying com.apple.SoftwareUpdate as the PayloadType.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures Software Update settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>Software Update</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SoftwareUpdate</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SoftwareUpdate</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,9 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -135,8 +120,6 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Specify a URL of the desired software update catalog in the form of http://server.example.com:8088/index.sucatalog</string>
-			<key>pfm_description_reference</key>
 			<string>The URL of the software update catalog. This property is not supported in macOS 11 and later.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.0</string>
@@ -164,6 +147,8 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', deselects the 'Check for updates' option and prevents the user from changing the option.</string>
 			<key>pfm_name</key>
 			<string>AutomaticCheckEnabled</string>
 			<key>pfm_title</key>
@@ -174,6 +159,8 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', deselects the 'Download new updates when available from the App Store' option and prevents the user from changing the option.</string>
 			<key>pfm_name</key>
 			<string>AutomaticDownload</string>
 			<key>pfm_title</key>
@@ -184,6 +171,8 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', restricts the 'Install macOS Updates' option and prevents the user from changing the option.</string>
 			<key>pfm_macos_min</key>
 			<string>10.15</string>
 			<key>pfm_name</key>
@@ -196,6 +185,8 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', deselects the 'Install app updates from the App Store' option and prevents the user from changing the option.</string>
 			<key>pfm_macos_min</key>
 			<string>10.15</string>
 			<key>pfm_name</key>
@@ -208,6 +199,8 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', restricts the automatic installation of configuration data.</string>
 			<key>pfm_name</key>
 			<string>ConfigDataInstall</string>
 			<key>pfm_title</key>
@@ -219,7 +212,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>These are not regular security updates. An example is the OS X NTP Security Update 1.0 update.</string>
+			<string>If 'false', disables the automatic installation of critical updates and prevents the user from changing the 'Install system data files and security updates' option.</string>
 			<key>pfm_name</key>
 			<string>CriticalUpdateInstall</string>
 			<key>pfm_title</key>
@@ -231,9 +224,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, prerelease software can be installed on this computer. Default is true.</string>
+			<string>If 'true', prerelease software can be installed on this computer.</string>
 			<key>pfm_name</key>
 			<string>AllowPreReleaseInstallation</string>
 			<key>pfm_title</key>
@@ -257,10 +248,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>This key has the same function as the key restrict-store-require-admin-to-install in the com.apple.appstore payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, restrict app installations to admin users. This key has the same function as the key restrict-store-require-admin-to-install in the com.apple.appstore payload.
-Availability: Available in macOS 10.14 and later.</string>
+			<string>If 'true', restrict app installations to admin users. This key has the same function as the  'restrict-store-require-admin-to-install' key in the 'com.apple.appstore' payload.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.SubmitDiagInfo.plist
+++ b/Manifests/ManifestsApple/com.apple.SubmitDiagInfo.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-09-07T08:44:38Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Submit Diagnostic Information settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Submit Diagnostic Information</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SubmitDiagInfo</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SubmitDiagInfo</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.SystemConfiguration.plist
+++ b/Manifests/ManifestsApple/com.apple.SystemConfiguration.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-01-15T14:45:32Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Proxies settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Proxies</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SystemConfiguration</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.SystemConfiguration</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>macOS System Proxy Configuration</string>
+			<string>The dictionary containing all the proxies for this device.</string>
 			<key>pfm_name</key>
 			<string>Proxies</string>
 			<key>pfm_subkeys</key>
@@ -125,7 +125,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string></string>
+					<string>If 'true', enables web proxy.</string>
 					<key>pfm_name</key>
 					<string>HTTPEnable</string>
 					<key>pfm_title</key>
@@ -137,7 +137,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The IP address or fully qualified domain name (FQDN) of the http proxy server.</string>
+					<string>The host name or IP address for the web proxy.</string>
 					<key>pfm_name</key>
 					<string>HTTPProxy</string>
 					<key>pfm_title</key>
@@ -149,7 +149,7 @@
 					<key>pfm_default</key>
 					<integer>80</integer>
 					<key>pfm_description</key>
-					<string>The port on which to connect to the http proxy server.</string>
+					<string>The web proxy port.</string>
 					<key>pfm_name</key>
 					<string>HTTPPort</string>
 					<key>pfm_title</key>
@@ -161,7 +161,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string></string>
+					<string>If 'true', enables secure web proxy.</string>
 					<key>pfm_name</key>
 					<string>HTTPSEnable</string>
 					<key>pfm_title</key>
@@ -173,7 +173,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The IP address or fully qualified domain name (FQDN) of the https proxy server.</string>
+					<string>The host name or IP address for the secure web proxy.</string>
 					<key>pfm_name</key>
 					<string>HTTPSProxy</string>
 					<key>pfm_title</key>
@@ -185,7 +185,7 @@
 					<key>pfm_default</key>
 					<integer>80</integer>
 					<key>pfm_description</key>
-					<string>The port on which to connect to the https proxy server.</string>
+					<string>The secure web proxy port.</string>
 					<key>pfm_name</key>
 					<string>HTTPSPort</string>
 					<key>pfm_title</key>
@@ -197,7 +197,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string></string>
+					<string>If 'true', enables FTP proxy.</string>
 					<key>pfm_name</key>
 					<string>FTPEnable</string>
 					<key>pfm_title</key>
@@ -211,7 +211,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string></string>
+					<string>If 'true', enables passive FTP mode.</string>
 					<key>pfm_name</key>
 					<string>FTPPassive</string>
 					<key>pfm_title</key>
@@ -223,7 +223,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The IP address or fully qualified domain name (FQDN) of the ftp proxy server.</string>
+					<string>The host name or IP address for the FTP proxy.</string>
 					<key>pfm_name</key>
 					<string>FTPProxy</string>
 					<key>pfm_title</key>
@@ -235,7 +235,7 @@
 					<key>pfm_default</key>
 					<integer>80</integer>
 					<key>pfm_description</key>
-					<string>The port on which to connect to the ftp proxy server.</string>
+					<string>The FTP proxy port.</string>
 					<key>pfm_name</key>
 					<string>FTPPort</string>
 					<key>pfm_title</key>
@@ -247,7 +247,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string></string>
+					<string>If 'true', enable the SOCKS proxy.</string>
 					<key>pfm_name</key>
 					<string>SOCKSEnable</string>
 					<key>pfm_title</key>
@@ -259,7 +259,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The IP address or fully qualified domain name (FQDN) of the socks proxy server.</string>
+					<string>The host name or IP address for the SOCKS proxy.</string>
 					<key>pfm_name</key>
 					<string>SOCKSProxy</string>
 					<key>pfm_title</key>
@@ -283,7 +283,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string></string>
+					<string>If 'true', enable streaming proxy.</string>
 					<key>pfm_name</key>
 					<string>RTSPEnable</string>
 					<key>pfm_title</key>
@@ -295,7 +295,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The IP address or fully qualified domain name (FQDN) of the rtsp proxy server.</string>
+					<string>The host name or IP address for the streaming proxy.</string>
 					<key>pfm_name</key>
 					<string>RTSPProxy</string>
 					<key>pfm_title</key>
@@ -307,7 +307,7 @@
 					<key>pfm_default</key>
 					<integer>80</integer>
 					<key>pfm_description</key>
-					<string>The port on which to connect to the rtsp proxy server.</string>
+					<string>The streaming proxy port.</string>
 					<key>pfm_name</key>
 					<string>RTSPPort</string>
 					<key>pfm_title</key>
@@ -319,7 +319,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string></string>
+					<string>If 'true', enables gopher proxy.</string>
 					<key>pfm_name</key>
 					<string>GopherEnable</string>
 					<key>pfm_title</key>
@@ -331,7 +331,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The IP address or fully qualified domain name (FQDN) of the gopher proxy server.</string>
+					<string>The host name or IP address for the gopher proxy.</string>
 					<key>pfm_name</key>
 					<string>GopherProxy</string>
 					<key>pfm_title</key>
@@ -343,7 +343,7 @@
 					<key>pfm_default</key>
 					<integer>80</integer>
 					<key>pfm_description</key>
-					<string>The port on which to connect to the gopher proxy server.</string>
+					<string>The gopher proxy port.</string>
 					<key>pfm_name</key>
 					<string>GopherPort</string>
 					<key>pfm_title</key>
@@ -353,7 +353,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Bypass proxy settings for these Hosts &amp; Domains.</string>
+					<string>The list of hosts and domains that should bypass proxy settings.</string>
 					<key>pfm_name</key>
 					<string>ExceptionsList</string>
 					<key>pfm_subkeys</key>
@@ -380,7 +380,7 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string>Enable the use of a Proxy AutoConfig file.</string>
+					<string>If 'true', enables automatic proxy configuration.</string>
 					<key>pfm_name</key>
 					<string>ProxyAutoConfigEnable</string>
 					<key>pfm_title</key>
@@ -410,7 +410,7 @@
 						</dict>
 					</array>
 					<key>pfm_description</key>
-					<string>URL to the Automatic Proxy Configuration file.</string>
+					<string>The automatic proxy configuration URL.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -436,7 +436,8 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Enables fallback when set to 1. The default value is 1, except for managed devices whose default is 0.</string>
+					<string>If '1', enables fallback. Default is '1'.
+For managed devices, if not supplied, the default is '0'.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -464,7 +465,7 @@
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>Allow the device to bypass the proxy server to display the login page for captive networks.</string>
+					<string>If 1, allows client to log into captive portal network.</string>
 					<key>pfm_name</key>
 					<string>ProxyCaptiveLoginAllowed</string>
 					<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.TCC.configuration-profile-policy.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Configures Privacy Preferences Policy Control settings</string>
+	<string>Configures Security Preferences:Privacy settings</string>
 	<key>pfm_domain</key>
 	<string>com.apple.TCC.configuration-profile-policy</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Privacy Preferences Policy Control settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Privacy Preferences Policy Control</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Keys are limited to the privacy service names listed below. Each key is an array of dictionaries describing the app or process to which access is given. In the case of conflicting specifications, the most restrictive setting (deny) will be used.</string>
+			<string>A dictionary whose keys are limited to the privacy policy control services.  In the case of conflicting specifications, the most restrictive setting (deny) is used.</string>
 			<key>pfm_name</key>
 			<string>Services</string>
 			<key>pfm_require</key>
@@ -124,7 +124,7 @@
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Specifies the policies for the app via the Accessibility subsystem.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
@@ -246,7 +246,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Specifies the policies for the app sending restricted AppleEvents to another process.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
@@ -414,7 +414,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services.AppleEvents</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Specifies the policies for calendar information managed by the Calendar.app.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
@@ -536,8 +536,8 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
-					<string>A system camera. Access to the camera cannot be given in a profile; it can only be denied.</string>
+					<key>pfm_description</key>
+					<string>A system camera. Access to the camera can't be given in a profile; it can only be denied.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
 					<key>pfm_name</key>
@@ -656,7 +656,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Specifies the policies for contact information managed by the Contacts.app.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -778,7 +778,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows a File Provider application to know when the user is using files managed by the File Provider.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -898,8 +898,8 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
-					<string>Allows the application to use CoreGraphics and HID APIs to listen to (receive) CGEvents and HID events from all processes. Access to these events cannot be given in a profile; it can only be denied.</string>
+					<key>pfm_description</key>
+					<string>Allows the application to use CoreGraphics and HID APIs to listen to (receive) CGEvents and HID events from all processes. Access to these events can't be given in a profile; it can only be denied.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
 					<key>pfm_name</key>
@@ -1016,7 +1016,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application to access Apple Music, music and video activity, and the media library.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -1136,8 +1136,8 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
-					<string>A system microphone. Access to the microphone cannot be given in a profile; it can only be denied.</string>
+					<key>pfm_description</key>
+					<string>A system microphone. Access to the microphone can't be given in a profile; it can only be denied.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
 					<key>pfm_name</key>
@@ -1256,8 +1256,8 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
-					<string>Pictures managed by Photos.app in ~/Pictures/.photoslibrary.</string>
+					<key>pfm_description</key>
+					<string>The pictures managed by the Photos app in '~/Pictures/.photoslibrary'.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
 					<key>pfm_name</key>
@@ -1500,7 +1500,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Specifies the policies for reminders information managed by the Reminders app.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
@@ -1622,8 +1622,8 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
-					<string>Allows the application access to all protected files.</string>
+					<key>pfm_description</key>
+					<string>Allows the application access to all protected files, including system administration files.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
 					<key>pfm_name</key>
@@ -1744,8 +1744,8 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
-					<string>Allows the application to capture (read) the contents of the system display. Access to the contents cannot be given in a profile; it can only be denied.</string>
+					<key>pfm_description</key>
+					<string>Allows the application to capture (read) the contents of the system display. Access to the contents can't be given in a profile; it can only be denied.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
 					<key>pfm_name</key>
@@ -1862,7 +1862,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application to use the system Speech Recognition facility and to send speech data to Apple.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -1982,7 +1982,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application to access files in the user's Desktop folder.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -2102,7 +2102,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application to access files in the user's Documents folder.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -2222,7 +2222,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application to access files in the user's Downloads folder.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -2342,7 +2342,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application to access files on network volumes.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -2462,7 +2462,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application to access files on removable volumes.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
@@ -2582,7 +2582,7 @@
 					<string>com.apple.TCC.configuration-profile-policy.services</string>
 				</dict>
 				<dict>
-					<key>pfm_description_reference</key>
+					<key>pfm_description</key>
 					<string>Allows the application access to some files used in system administration.</string>
 					<key>pfm_macos_min</key>
 					<string>10.14</string>
@@ -2844,6 +2844,8 @@ Available in macOS 11 and later.</string>
 					<string>array</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>Allows the application to update or delete other apps. Available in macOS 13 and later.</string>
 					<key>pfm_macos_min</key>
 					<string>13.0</string>
 					<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.airplay.plist
+++ b/Manifests/ManifestsApple/com.apple.airplay.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>7.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.10</string>
 	<key>pfm_platforms</key>
@@ -29,9 +29,7 @@
 			<key>pfm_default</key>
 			<string>Configures AirPlay settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -43,9 +41,7 @@
 			<key>pfm_default</key>
 			<string>AirPlay settings</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -59,9 +55,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.airplay</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -75,9 +69,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.airplay</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -91,9 +83,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -109,10 +99,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -124,10 +111,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -141,10 +125,7 @@ The payload organization for a payload need not match the payload organization i
 				<string>public.plain-text</string>
 			</array>
 			<key>pfm_description</key>
-			<string>List of MAC addresses of AirPlay destinations that the device is restricted to. If this list is empty, the device can connect to any device.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only (ignored otherwise). If present, only AirPlay destinations present in this list are available to the device.
-The dictionary format is described below.</string>
+			<string>If present, only AirPlay destinations in this list are available to the device. This allow list applies to supervised devices.</string>
 			<key>pfm_ios_min</key>
 			<string>14.5</string>
 			<key>pfm_macos_min</key>
@@ -162,9 +143,7 @@ The dictionary format is described below.</string>
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>The AirPlay destination's MAC address</string>
-							<key>pfm_description_reference</key>
-							<string>The Device ID of the AirPlay destination, in the format xx:xx:xx:xx:xx:xx. This field is not case sensitive.</string>
+							<string>The device ID of the AirPlay destination in the format 'xx:xx:xx:xx:xx:xx'. This field isn't case-sensitive.</string>
 							<key>pfm_format</key>
 							<string>^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$</string>
 							<key>pfm_name</key>
@@ -200,10 +179,7 @@ The dictionary format is described below.</string>
 				<string>public.plain-text</string>
 			</array>
 			<key>pfm_description</key>
-			<string>List of MAC addresses of AirPlay destinations that the device is restricted to. If this list is empty, the device can connect to any device.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only (ignored otherwise). If present, only AirPlay destinations present in this list are available to the device.
-The dictionary format is described below.</string>
+			<string>Use 'AllowList' instead. As of macOS 11.3 and iOS 14.5 this key is deprecated.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>14.5</string>
 			<key>pfm_macos_deprecated</key>
@@ -255,9 +231,8 @@ The dictionary format is described below.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Sets passwords for known AirPlay destinations</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If present, sets passwords for known AirPlay destinations. The dictionary format is described below.</string>
+			<string>If present, sets passwords for known AirPlay destinations.
+Using multiple entries for the same destination, whether within the same payload or across multiple installed payloads, is an error and results in undefined behavior.</string>
 			<key>pfm_name</key>
 			<string>Passwords</string>
 			<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.airplay.security.plist
+++ b/Manifests/ManifestsApple/com.apple.airplay.security.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Use the AirPlay Security payload to preconfigure access and security settings when connecting to Apple TV.</string>
+	<string>AirPlay Security settings</string>
 	<key>pfm_description_reference</key>
 	<string>The AirPlay Security payload locks the Apple TV to a particular style of AirPlay Security. The AirPlay Security payload is designated by specifying com.apple.airplay.security as the PayloadType vaue.
 This payload is supported on tvOS 11.0 and later.</string>
@@ -14,7 +14,7 @@ This payload is supported on tvOS 11.0 and later.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2019-10-11T08:52:32Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>tvOS</string>
@@ -25,9 +25,7 @@ This payload is supported on tvOS 11.0 and later.</string>
 			<key>pfm_default</key>
 			<string>AirPlay Security settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,9 +37,7 @@ This payload is supported on tvOS 11.0 and later.</string>
 			<key>pfm_default</key>
 			<string>AirPlay Security</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,9 +51,7 @@ This payload is supported on tvOS 11.0 and later.</string>
 			<key>pfm_default</key>
 			<string>com.apple.airplay.security</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -71,9 +65,7 @@ This payload is supported on tvOS 11.0 and later.</string>
 			<key>pfm_default</key>
 			<string>com.apple.airplay.security</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -87,9 +79,7 @@ This payload is supported on tvOS 11.0 and later.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -105,10 +95,7 @@ This payload is supported on tvOS 11.0 and later.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +107,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -133,11 +117,9 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Network requirement for devices that connect to Apple TV using airplay.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Must be one of the defined values: ANY or WIFI_ONLY.
-ANY allows connections from both Ethernet/WiFi and AWDL.
-WIFI_ONLY allows connections only from devices on the same Ethernet/WiFi network as the Apple TV.</string>
+			<string>The access policy for AirPlay.
+'ANY' allows connections from both Ethernet/WiFi and Apple Wireless Direct Link.
+'WIFI_ONLY' allows connections only from devices on the same Ethernet/WiFi network as Apple TV.</string>
 			<key>pfm_name</key>
 			<string>AccessType</string>
 			<key>pfm_range_list</key>
@@ -159,13 +141,13 @@ WIFI_ONLY allows connections only from devices on the same Ethernet/WiFi network
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Security requirement for for devices that connect to Apple TV using airplay.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Must be one of the defined values: PASSCODE_ONCE, PASSCODE_ALWAYS, or PASSWORD.
-PASSCODE_ONCE will require an on-screen passcode to be entered on the first connection from a device. Subsequent connections from the same device will not be prompted.
-PASSCODE_ALWAYS will require an on-screen passcode to be entered upon every AirPlay connection.
-PASSWORD will require a passphrase to be entered as specified in the Password key. The Password key is required if this SecurityType is selected.
-NONE was deprecated in tvOS 11.3. Existing profiles using NONE will get the PASSWORD_ONCE behavior.</string>
+			<string>The security policy for AirPlay.
+'PASSCODE_ONCE' requires an onscreen passcode on first connection from a device. Subsequent connections from the same device aren't prompted.
+'PASSCODE_ALWAYS' requires an onscreen passcode for every AirPlay connection. After an AirPlay connection ends, reconnecting within 30 seconds is allowed without a password.
+
+'PASSWORD' requires a passphrase as specified in the 'Password' key.
+
+'NONE' was deprecated in tvOS 11.3. Existing profiles using 'NONE' get the 'PASSWORD_ONCE' behavior.</string>
 			<key>pfm_name</key>
 			<string>SecurityType</string>
 			<key>pfm_range_list</key>
@@ -209,9 +191,7 @@ NONE was deprecated in tvOS 11.3. Existing profiles using NONE will get the PASS
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The Airplay Password</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The AirPlay password. Required if SecurityType is PASSWORD.</string>
+			<string>The AirPlay password; required if SecurityType is 'PASSWORD'.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.airprint.plist
+++ b/Manifests/ManifestsApple/com.apple.airprint.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>AirPrint settings</string>
+	<string>Use this section to define settings for AirPrint.</string>
 	<key>pfm_description_reference</key>
 	<string>The AirPrint payload adds AirPrint printers to the userʼs AirPrint printer list. This makes it easier to support environ- ments where the printers and the devices are on different subnets. An AirPrint payload is designated by specifying com.apple.airprint as the PayloadType value.
 This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</string>
@@ -18,7 +18,7 @@ This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</st
 	<key>pfm_ios_min</key>
 	<string>7.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.10</string>
 	<key>pfm_platforms</key>
@@ -32,9 +32,7 @@ This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</st
 			<key>pfm_default</key>
 			<string>Configures AirPrint settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -46,9 +44,7 @@ This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</st
 			<key>pfm_default</key>
 			<string>AirPrint</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -62,9 +58,7 @@ This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</st
 			<key>pfm_default</key>
 			<string>com.apple.airprint</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -78,9 +72,7 @@ This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</st
 			<key>pfm_default</key>
 			<string>com.apple.airprint</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -94,9 +86,7 @@ This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</st
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -112,10 +102,7 @@ This payload is supported on iOS 7.0 and later and on macOS 10.10 and later.</st
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -127,10 +114,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -140,9 +124,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of printers</string>
-			<key>pfm_description_reference</key>
-			<string>An array of AirPrint printers that should always be shown.</string>
+			<string>An array of AirPrint printers that are presented to the user.</string>
 			<key>pfm_name</key>
 			<string>AirPrint</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.app.lock.plist
+++ b/Manifests/ManifestsApple/com.apple.app.lock.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Single App Mode settings</string>
+	<string>App Lock (Supervised Only)</string>
 	<key>pfm_description_reference</key>
 	<string>The App Lock payload is designated by specifying com.apple.app.lock as the PayloadType value. Only one of this payload type can be installed at any time. This payload can be installed only on a Supervised device.
 By installing an app lock payload, the device is locked to a single application until the payload is removed. The home button is disabled, and the device returns to the specified application automatically upon wake or reboot.
@@ -17,7 +17,7 @@ This payload is supported only in iOS 6.0 and later.</string>
 	<key>pfm_ios_min</key>
 	<string>6.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_note</key>
 	<string>You canʼt update any app while the device is locked in Single App Mode. You need to exit Single App Mode long enough to update apps as needed. During that time you should restrict the visible apps as much as possible, except for Settings and Phone and any other apps that cannot be denylisted.</string>
 	<key>pfm_platforms</key>
@@ -31,9 +31,7 @@ This payload is supported only in iOS 6.0 and later.</string>
 			<key>pfm_default</key>
 			<string>Configures Single App Mode</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -45,9 +43,7 @@ This payload is supported only in iOS 6.0 and later.</string>
 			<key>pfm_default</key>
 			<string>Single App Mode</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -61,9 +57,7 @@ This payload is supported only in iOS 6.0 and later.</string>
 			<key>pfm_default</key>
 			<string>com.apple.app.lock</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -77,9 +71,7 @@ This payload is supported only in iOS 6.0 and later.</string>
 			<key>pfm_default</key>
 			<string>com.apple.app.lock</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -93,9 +85,7 @@ This payload is supported only in iOS 6.0 and later.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -111,10 +101,7 @@ This payload is supported only in iOS 6.0 and later.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -126,9 +113,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -138,9 +123,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A dictionary containing information about the app</string>
-			<key>pfm_description_reference</key>
-			<string>A dictionary containing information about the app.</string>
+			<string>A dictionary that contains information about the app.</string>
 			<key>pfm_name</key>
 			<string>App</string>
 			<key>pfm_require</key>
@@ -149,9 +132,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The bundle identifier of the application.</string>
-					<key>pfm_description_reference</key>
-					<string>The bundle identifier of the application.</string>
+					<string>The app's bundle identifier.</string>
 					<key>pfm_name</key>
 					<string>Identifier</string>
 					<key>pfm_require</key>
@@ -163,10 +144,7 @@ A profile can consist of payloads with different version numbers. For example, c
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Settings enforced when in Single App Mode</string>
-					<key>pfm_description_reference</key>
-					<string>Optional. Described below.
-Availability: Available only in iOS 7.0 and later.</string>
+					<string>A dictionary of options that the user cannot change.</string>
 					<key>pfm_ios_min</key>
 					<string>7.0</string>
 					<key>pfm_name</key>
@@ -177,9 +155,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Disable Touch Screen</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, the touch screen is disabled. Default is false. Also, available in tvOS 10.2 and later to lock the touch pad on the remote.</string>
+							<string>If 'true', disables the touch screen. In tvOS, it disables the touch surface on the Apple TV Remote.</string>
 							<key>pfm_name</key>
 							<string>DisableTouch</string>
 							<key>pfm_title</key>
@@ -193,9 +169,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Disable Device Rotation</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, device rotation sensing is disabled. Default is false.</string>
+							<string>If 'true', disables device rotation sensing.</string>
 							<key>pfm_name</key>
 							<string>DisableDeviceRotation</string>
 							<key>pfm_platforms</key>
@@ -211,9 +185,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Disable Volume Buttons</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, the volume buttons are disabled. Default to false.</string>
+							<string>If 'true', disables the volume buttons.</string>
 							<key>pfm_name</key>
 							<string>DisableVolumeButtons</string>
 							<key>pfm_platforms</key>
@@ -229,9 +201,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Disable Ringer Switch</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, the ringer switch is disabled. Default is false. When disabled, the ringer behavior depends on what position the switch was in when it was first disabled.</string>
+							<string>If 'true', disables the ringer switch. When disabled, the ringer behavior depends on what position the switch was in when it was first disabled.</string>
 							<key>pfm_name</key>
 							<string>DisableRingerSwitch</string>
 							<key>pfm_platforms</key>
@@ -247,9 +217,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Disable Sleep Wake Button</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, the sleep/wake button is disabled. Default is false.</string>
+							<string>If 'true', disables the sleep/wake button.</string>
 							<key>pfm_name</key>
 							<string>DisableSleepWakeButton</string>
 							<key>pfm_platforms</key>
@@ -265,9 +233,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Disable Auto Lock</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, the device will not automatically go to sleep after an idle period. Also, available in tvOS 10.2 and later.</string>
+							<string>If 'true', the device doesn't automatically go to sleep after an idle period.</string>
 							<key>pfm_name</key>
 							<string>DisableAutoLock</string>
 							<key>pfm_title</key>
@@ -281,9 +247,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Enable Voice Over</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, VoiceOver is turned on. Default is false. Also, available in tvOS 10.2 and later.</string>
+							<string>If 'true', enables VoiceOver.</string>
 							<key>pfm_name</key>
 							<string>EnableVoiceOver</string>
 							<key>pfm_title</key>
@@ -297,9 +261,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Enable Zoom</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, Zoom is turned on. Default is false. Also, available in tvOS 10.2 and later.</string>
+							<string>If 'true', enables Zoom.</string>
 							<key>pfm_name</key>
 							<string>EnableZoom</string>
 							<key>pfm_title</key>
@@ -313,9 +275,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Enable Inverted Colors</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, Invert Colors is turned on. Default is false. Also, available in tvOS 10.2 and later.</string>
+							<string>If 'true', enables Invert Colors.</string>
 							<key>pfm_name</key>
 							<string>EnableInvertColors</string>
 							<key>pfm_title</key>
@@ -329,9 +289,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Enable Assistive Touch</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, AssistiveTouch is turned on. Default is false.</string>
+							<string>If 'true', enables AssistiveTouch.</string>
 							<key>pfm_name</key>
 							<string>EnableAssistiveTouch</string>
 							<key>pfm_platforms</key>
@@ -347,9 +305,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Enable Speak Selection</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, Speak Selection is turned on. Default is false.</string>
+							<string>If 'true', enables Speak Selection.</string>
 							<key>pfm_name</key>
 							<string>EnableSpeakSelection</string>
 							<key>pfm_platforms</key>
@@ -365,9 +321,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Enable Mono Audio</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, Mono Audio is turned on. Default is false.</string>
+							<string>If 'true', enables Mono Audio.</string>
 							<key>pfm_name</key>
 							<string>EnableMonoAudio</string>
 							<key>pfm_platforms</key>
@@ -387,10 +341,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Allow the user to change these settings when in Single App Mode</string>
-					<key>pfm_description_reference</key>
-					<string>Optional. Described below.
-Availability: Available only in iOS 7.0 and later.</string>
+					<string>A dictionary of user-editable options.</string>
 					<key>pfm_ios_min</key>
 					<string>7.0</string>
 					<key>pfm_name</key>
@@ -401,9 +352,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Allow user to enable Voice Over</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, allow VoiceOver adjustment. Default is false. Also, available in tvOS 10.2 and later.</string>
+							<string>If 'true', allows the user to toggle VoiceOver.</string>
 							<key>pfm_name</key>
 							<string>VoiceOver</string>
 							<key>pfm_title</key>
@@ -417,9 +366,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Allow user to enable Zoom</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, allow Zoom adjustment. Default is false. Also, available in tvOS 10.2 and later.</string>
+							<string>If 'true', allows the user to toggle Zoom.</string>
 							<key>pfm_name</key>
 							<string>Zoom</string>
 							<key>pfm_title</key>
@@ -433,9 +380,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Allow user to enable Inverted Colors</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, allow Zoom adjustment. Default is false. Also, available in tvOS 10.2 and later.</string>
+							<string>If 'true', allows the user to toggle Invert Colors.</string>
 							<key>pfm_name</key>
 							<string>InvertColors</string>
 							<key>pfm_title</key>
@@ -449,9 +394,7 @@ Availability: Available only in iOS 7.0 and later.</string>
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>Allow user to enable Assistive Touch</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. If true, allow AssistiveTouch adjustment. Default is false.</string>
+							<string>If 'true', allows the user to toggle AssistiveTouch.</string>
 							<key>pfm_name</key>
 							<string>AssistiveTouch</string>
 							<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>iOS Restrictions preferences</string>
+	<string>Use this section to define restrictions settings</string>
 	<key>pfm_description_reference</key>
 	<string>The Restrictions payload is designated by specifying com.apple.applicationaccess as the PayloadType value. A Restrictions payload allows the administrator to restrict the user from doing certain things with the device, such as using the camera. The Restrictions payload is supported in iOS; some keys are also supported in macOS, as noted below.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_note</key>
 	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 	<key>pfm_platforms</key>
@@ -30,9 +30,7 @@
 			<key>pfm_default</key>
 			<string>Configures restrictions</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -44,9 +42,7 @@
 			<key>pfm_default</key>
 			<string>Restrictions</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -60,9 +56,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -76,9 +70,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -92,9 +84,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -110,10 +100,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -125,10 +112,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -339,9 +323,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, the camera is completely disabled and its icon is removed from the Home screen. Users are unable to take photographs. Availability: Available in iOS and in macOS 10.11 and later.</string>
+			<string>If 'false', disables the camera, and its icon is removed from the Home screen. Users are unable to take photographs. This restriction is deprecated on unsupervised devices and will be supervised only in a future release.  Available in iOS 4 and later, and macOS 10.11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -355,9 +337,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow use of Camera is set to 'false', this will override this preference if set to 'true'.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables video conferencing. This key is deprecated on unsupervised devices.</string>
+			<string>If 'false', hides the FaceTime app. As of iOS 13, requires a supervised device. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -373,9 +353,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables backing up the device to iCloud. Availability: Available in iOS 5.0 and later.</string>
+			<string>If 'false', disables backing up the device to iCloud. This restriction is deprecated on unsupervised devices and will be supervised only in a future release. Available in iOS 5 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -389,9 +367,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, disables iCloud Photo Library. Any photos not fully downloaded from iCloud Photo Library to the device will be removed from local storage. Availability: Available in iOS 9.0 and later and in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Photo Library, including iCloud Shared Photo Library. Any photos not fully downloaded from iCloud Photo Library to the device are removed from local storage. Available in iOS 9 and later, and macOS 10.12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -405,9 +381,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Disallowing can cause data loss.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables Photo Stream. Availability: Available in iOS 5.0 and later.</string>
+			<string>If 'false', disables Photo Stream. Available in iOS 5 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -421,9 +395,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, Shared Photo Stream will be disabled. This will default to true. Availability: Available in iOS 6.0 and later.</string>
+			<string>If 'false', disables Shared Photo Stream. Available in iOS 6 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -437,9 +409,10 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, users will not be able to use the AutoFill Passwords feature on iOS and will not be prompted to use a saved password in Safari or in apps. If set to false, Automatic Strong Passwords will also be disabled and strong passwords will not be suggested to users. Defaults to true. Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
+			<string>If 'false', disables the AutoFill Passwords feature in iOS (with Keychain and third-party password managers) and the user isn't prompted to use a saved password in Safari or in apps.
+This restriction also disables Automatic Strong Passwords, and strong passwords are no longer suggested to users.
+It doesn't prevent AutoFill for contact info and credit cards in Safari.
+Requires a supervised device. Available in iOS 12 and later, and macOS 10.14 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -455,7 +428,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If 'false', disallows auto unlock. Available in macOS 10.12 and later, and iOS 14.5 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.5</string>
 			<key>pfm_name</key>
@@ -469,9 +442,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If false, prevents Touch ID from unlocking a device. Availability: Available in iOS 7 and later.</string>
+			<string>If 'false', prevents Touch ID or Face ID from unlocking a device. Available in iOS 7 and later, and macOS 10.12.4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -485,9 +456,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, Apple Books will be disabled. This will default to true. Availability: Available in iOS 6.0 and later.</string>
+			<string>If 'false', removes the Book Store tab from the Books app. Requires a supervised device. Available in iOS 6 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -503,9 +472,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables the use of iMessage with supervised devices. If the device supports text messaging, the user can still send and receive text messages. Availability: Available in iOS 6.0 and later.</string>
+			<string>If 'false', disables the use of the iMessage with supervised devices. If the device supports text messaging, the user can still send and receive text messages. Requires a supervised device. Available in iOS 5 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -521,9 +488,8 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, the iTunes Music Store is disabled and its icon is removed from the Home screen. Users cannot preview, purchase, or download content. This key is deprecated on unsupervised devices.</string>
+			<string>If 'false', disables the iTunes Music Store, and its icon is removed from the Home screen. Users cannot preview, purchase, or download content.
+As of iOS 13, requires a supervised device. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -539,9 +505,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, Music service is disabled and Music app reverts to classic mode. Defaults to true. Availability: Available in iOS 9.3 and later and macOS 10.12 and later.</string>
+			<string>If 'false', disables the Music service, and the Music app reverts to classic mode. Requires a supervised device. Available in iOS 9.3 and later, and macOS 10.12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
 			<key>pfm_name</key>
@@ -557,9 +521,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables News. Defaults to true. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', disables News. Requires a supervised device. Available in iOS 9 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -575,9 +537,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables podcasts. Defaults to true. Availability: Available in iOS 8.0 and later.</string>
+			<string>If 'false', disables podcasts. Requires a supervised device. Available in iOS 8 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -593,9 +553,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, Apple Music Radio is disabled. Defaults to true. Availability: Available in iOS 9.3 and later.</string>
+			<string>If 'false', disables Apple Music Radio. Requires a supervised device. Available in iOS 9.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
 			<key>pfm_name</key>
@@ -629,9 +587,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables document and key-value syncing to iCloud. This key is deprecated on unsupervised devices. Availability: Available in iOS 5.0 and later and in macOS 10.11 and later.</string>
+			<string>If 'false', disables document and key-value syncing to iCloud. As of iOS 13, this restriction requires a supervised device and shared iPads don't support it. Available in iOS 5 and later, and macOS 10.11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -647,9 +603,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables iCloud keychain synchronization. Default is true. Availability: Available in iOS 7.0 and later and macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud keychain synchronization. This restriction is deprecated on unsupervised devices and will be supervised only in a future release. Available in iOS 7 and later and macOS 10.12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -663,9 +617,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables definition lookup. Defaults to true. Availability: Available in iOS 8.1.3 and later and in macOS 10.11.2 and later.</string>
+			<string>If 'false', disables definition lookup. Requires a supervised device on iOS. Available in iOS 8.1.3 and later and macOS 10.11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.1.3</string>
 			<key>pfm_name</key>
@@ -697,9 +649,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disallow AirPrint. Defaults to true. Availability: Available in iOS 11.0 and later and macOS 10.13 and later.</string>
+			<string>If 'false', disables AirPrint.  Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -715,9 +665,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow AirPrint is set to 'false', it also overrides this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables iBeacon discovery of AirPrint printers. This prevents spurious AirPrint Bluetooth beacons from phishing for network traffic. Defaults to true. Availability: Available in iOS 11.0 and later and macOS 10.13.</string>
+			<string>If 'false', disables iBeacon discovery of AirPrint printers, which prevents spurious AirPrint Bluetooth beacons from phishing for network traffic. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -735,9 +683,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If Allow AirPrint is set to 'false', it also overrides this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to true, requires trusted certificates for TLS printing communication. Defaults to false. Availability: Available in iOS 11.0 and later and macOS 10.13 and later.</string>
+			<string>If 'true', requires trusted certificates for TLS printing communication. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -755,9 +701,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Updated in iOS 9.0 to include screen recordings.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, users canʼt save a screenshot of the display and are prevented from capturing a screen recording; it also prevents the Classroom app from observing remote screens. Defaults to true. Also available for user enrollment. Availability: iOS 4 and later.</string>
+			<string>If 'false', disables saving a screenshot of the display and capturing a screen recording. It also disables the Classroom app from observing remote screens. Available in iOS 4 and later, and macOS 10.14.4 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -771,10 +715,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow screenshots and screen recording is set to 'false', it also overrides this preference and prevents the Classroom app from observing remote screens.</string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, remote screen observation by the Classroom app is disabled. Defaults to true.
-This key should be nested beneath allowScreenShot as a sub-restriction. If allowScreenShot is set to false, it also prevents the Classroom app from observing remote screens. Availability: Available in iOS 9.3 and later.</string>
+			<string>If 'false', disables remote screen observation by the Classroom app. Nest this key beneath 'allowScreenShot' as a subrestriction. If 'allowScreenShot' is set to 'false', the Classroom app doesn't observe remote screens. Required a supervised device until iOS 13 and macOS 10.15. Available in iOS 12 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -788,11 +729,7 @@ This key should be nested beneath allowScreenShot as a sub-restriction. If allow
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If Allow screenshots and screen recording is set to 'false' or Allow AirPlay and View Screen by Classroom app, they also override this preference and prevents the Classroom app from unprompted remote AirPlay and view screens.
-
-Additionally, if set to true and ScreenObservationPermissionModificationAllowed is also true in the Education payload, a student enrolled in a managed course via the Classroom app will automatically give permission to that course's teacher's requests to observe the student's screen without prompting the student.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, and ScreenObservationPermissionModificationAllowed is also true in the Education payload, a student enrolled in a managed course via the Classroom app will automatically give permission to that courseʼs teacherʼs requests to observe the studentʼs screen without prompting the student. Defaults to false. Availability: Available only in iOS 11.0 and later.</string>
+			<string>If 'true' and 'ScreenObservationPermissionModificationAllowed' is also 'true' in the Education payload, a student enrolled in a managed course via the Classroom app automatically gives permission to that course teacher's requests to observe the student's screen without prompting the student. Requires a supervised device. Available in iOS 11 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -838,9 +775,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables voice dialing if the device is locked with a passcode. Default is true.</string>
+			<string>If 'false', disables voice dialing if the device is locked with a passcode. Available in iOS 4 and later.</string>
 			<key>pfm_name</key>
 			<string>allowVoiceDialing</string>
 			<key>pfm_title</key>
@@ -852,9 +787,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables Siri. Defaults to true.</string>
+			<string>If 'false', disables Siri. Available in iOS 5 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -868,9 +801,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow Siri is set to 'false', it also overrides this preference. This preference is ignored if the device does not have a passcode set.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, the user is unable to use Siri when the device is locked. Defaults to true. This restriction is ignored if the device does not have a passcode set. Availability: Available only in iOS 5.1 and later.</string>
+			<string>If 'false', disables Siri when the device is locked. This restriction is ignored if the device doesn't have a passcode set. Available in iOS 5.1 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>5.1</string>
 			<key>pfm_name</key>
@@ -884,9 +815,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow Siri is set to 'false', it also overrides this preference. This preference is ignored if the device does not have a passcode set.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. When true, forces the use of the profanity filter assistant.</string>
+			<string>If 'true', forces the use of the profanity filter assistant. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -902,9 +831,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow Siri is set to 'false', it also overrides this preference. This preference is ignored if the device does not have a passcode set.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. When false, prevents Siri from querying user-generated content from the web. Availability: Available in iOS 7 and later.</string>
+			<string>If 'false', prevents Siri from querying user-generated content from the web. Requires a supervised device. Available in iOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -938,9 +865,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, Spotlight will not return Internet search results. Availability: Available in iOS and in macOS 10.11 and later.</string>
+			<string>If 'false', disables Spotlight Internet search results in Siri Suggestions. Available in iOS 8 and later, and macOS 10.11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -956,9 +881,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. When false, the App Store is disabled and its icon is removed from the Home screen. Users are unable to install or update their applications. This key is deprecated on unsupervised devices. In iOS 10 and later, MDM commands can override this restriction.</string>
+			<string>If 'false', disables the App Store, and its icon is removed from the Home screen. Users are unable to install or update their apps. In iOS 10 and later, MDM commands can override this restriction. As of iOS 13, this restriction requires a supervised device. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -974,9 +897,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow installing apps is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. When false, the App Store is disabled and its icon is removed from the Home screen. However, users may continue to use Host apps (iTunes, Configurator) to install or update their apps. Defaults to true. In iOS 10 and later, MDM commands can override this restriction. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', disables the App Store, and its icon is removed from the Home screen. However, users may continue to use host apps (iTunes, Configurator) to install or update their apps.
+In iOS 10 and later, MDM commands can override this restriction. Requires a supervised device. Available in iOS 9 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -992,9 +914,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow installing apps is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, prevents automatic downloading of apps purchased on other devices. Does not affect updates to existing apps. Defaults to true. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', prevents automatic downloading of apps purchased on other devices. This setting doesn't affect updates to existing apps. Requires a supervised device. Available in iOS 9 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -1010,9 +930,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Deprecated on unsupervised devices.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables removal of apps from iOS device. This key is deprecated on unsupervised devices.</string>
+			<string>If 'false', disables removal of apps from an iOS device. Requires a supervised device. Available in iOS 4.2.1 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.2.1</string>
 			<key>pfm_name</key>
@@ -1028,7 +946,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If 'false', prevents a user from adding any App Clips, and removes any existing App Clips on the device. Requires a supervised device. Available in iOS 14.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.0</string>
 			<key>pfm_name</key>
@@ -1044,9 +962,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables the removal of system apps from the device. Defaults to true. Availability: Available only in iOS 11.0 and later.</string>
+			<string>If 'false', disables the removal of system apps from the device. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1062,9 +978,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, prohibits in-app purchasing.</string>
+			<string>If 'false', prohibits in-app purchasing. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -1078,9 +992,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When true, forces user to enter their iTunes password for each transaction. Availability: Available in iOS 5.0 and later.</string>
+			<string>If 'true', forces the user to enter their iTunes password for each transaction. Available in iOS 6 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -1094,9 +1006,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, prevents managed applications from using iCloud sync.</string>
+			<string>If 'false', prevents managed apps from using iCloud sync. Available in iOS 8 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -1110,9 +1020,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, Enterprise books will not be backed up. Defaults to true.</string>
+			<string>If 'false', disables backup of Enterprise books. Available in iOS 8 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -1126,9 +1034,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, Enterprise books notes and highlights will not be synced. Defaults to true.</string>
+			<string>If 'false', disables sync of Enterprise books, notes, and highlights. Available in iOS 8 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -1142,7 +1048,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to false, prevents the use of iCloud Private Relay.</string>
+			<string>If 'false', disables iCloud Private Relay. For iOS devices, this restriction requires a supervised device. Available in macOS 12 and later, and iOS 15 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_name</key>
@@ -1156,9 +1062,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables global background fetch activity when an iOS phone is roaming.</string>
+			<string>If 'false', disables global background fetch activity when an iOS phone is roaming. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -1172,9 +1076,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When true, encrypts all backups.</string>
+			<string>If 'true', encrypts all backups. Available in iOS 4 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -1188,9 +1090,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables the "Erase All Content And Settings" option in the Reset UI.</string>
+			<string>If 'false', disables the Erase All Content And Settings option in the Reset UI. Requires a supervised device. Available in iOS 8 and later, and macOS 12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -1206,9 +1106,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, automatically rejects untrusted HTTPS certificates without prompting the user. Availability: Available in iOS 5.0 and later.</string>
+			<string>If 'false', automatically rejects untrusted HTTPS certificates without prompting the user. Available in iOS 5 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -1222,9 +1120,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string> If set to false removes the Trust Enterprise Developer button in Settings-&gt;General-&gt;Profiles &amp; Device Management, preventing apps from being provisioned by universal provisioning profiles. This restriction applies to free developer accounts but it does not apply to enterprise app developers who are trusted because their apps were pushed via MDM, nor does it revoke previously granted trust. Defaults to true. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', removes the Trust Enterprise Developer button in Settings &gt; General &gt; Profiles &amp; Device Management, preventing apps from being provisioned by universal provisioning profiles. This restriction applies to free developer accounts. However, it doesn't apply to enterprise app developers who are trusted because their apps were pushed through MDM. It also doesn't revoke previously granted trust. Available in iOS 9 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -1238,9 +1134,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If false, over-the-air PKI updates are disabled. Setting this restriction to false does not disable CRL and OCSP checks. Default is true. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', disables over-the-air PKI updates. Setting this restriction to 'false' doesn't disable CRL and OCSP checks.  Available in iOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1254,9 +1148,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, the user is prohibited from installing configuration profiles and certificates interactively. This will default to true. Availability: Available in iOS 6.0 and later.</string>
+			<string>If 'false', prohibits the user from installing configuration profiles and certificates interactively. Requires a supervised device. Available in iOS 6 and later and macOS 13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -1272,9 +1164,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disallow the creation of VPN configurations. Defaults to true. Availability: Available only in iOS 11.0 and later.</string>
+			<string>If 'false', disables the creation of VPN configurations. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1290,9 +1180,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If true, enables the Set Automatically feature in Date &amp; Time and can't be disabled by the user.  The device's time zone is updated only when the device can determine its location using a cellular connection or Wi-Fi with location services enabled. Requires a supervised device. Available in iOS 12 and later, and tvOS 12.2 and later.</string>
+			<string>If 'true', enables the Set Automatically feature in Date &amp; Time and can't be disabled by the user.  The device's time zone is updated only when the device can determine its location using a cellular connection or Wi-Fi with location services enabled. Requires a supervised device. Available in iOS 12 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -1308,9 +1196,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, allow the teacher to lock apps or the device without prompting the student. Defaults to false. Availability: Available only in iOS 11.0 and later.</string>
+			<string>If 'true', allows the teacher to lock apps or the device without prompting the student. Requires a supervised device. Available in iOS 11 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1326,9 +1212,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, automatically give permission to the teacherʼs requests without prompting the student. Defaults to false. Availability: Available only in iOS 11.0 and later.</string>
+			<string>If 'true', automatically gives permission to the teacher's requests without prompting the student. Requires a supervised device. Available in iOS 11 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1344,9 +1228,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, a student enrolled in an unmanaged course via Classroom will request permission from the teacher when attempting to leave the course. Defaults to false. Availability: Available only in iOS 11.3 and later.</string>
+			<string>If 'true', a student enrolled in an unmanaged course through Classroom requests permission from the teacher when attempting to leave the course. Requires a supervised device. Available in iOS 11.3 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -1362,9 +1244,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, account modification is disabled. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If  'false', disables account modification. Requires a supervised device. Available in iOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1380,9 +1260,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, prevents modification of Bluetooth settings. Defaults to true. Availability: Available in iOS 10.0 and later.</string>
+			<string>If 'false', prevents modification of Bluetooth settings. Requires a supervised device. Available in iOS 11 and later, and macOS 13.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1398,9 +1276,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, changes to cellular data usage for apps are disabled. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', disables changing settings for cellular data usage for apps. Requires a supervised device. Available in iOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1416,9 +1292,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, users canʼt change any settings related to their cellular plan. Defaults to true. Availability: Available in iOS 11.0 and later.</string>
+			<string>If 'false', users can't change any settings related to their cellular plan. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1434,9 +1308,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables modifications to the eSIM setting. Requires a supervised device. Available in iOS 12.1 and later.</string>
+			<string>If 'false', disables modifications to carrier plan related settings (only available on select carriers). Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1452,9 +1324,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, changes to Find My Friends are disabled. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', disables changes to Find My Friends. Requires a supervised device. Available in iOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1470,9 +1340,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, notification settings cannot be modified. Defaults to true. Availability: Available in iOS 9.3 and later.</string>
+			<string>If 'false', disables modification of notification settings. Requires a supervised device. Available in iOS 9.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
 			<key>pfm_name</key>
@@ -1488,7 +1356,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to false, disables Near-field Communication functionality.</string>
+			<string>If 'false', disables NFC. Requires a supervised device. Available in iOS 14.2 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.2</string>
 			<key>pfm_name</key>
@@ -1502,9 +1370,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, prevents the device passcode from being added, changed, or removed. Defaults to true. This restriction is ignored by shared iPads. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', prevents the device passcode from being added, changed, or removed.
+This restriction is ignored by Shared iPads. Requires a supervised device. Available in iOS 9 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -1520,9 +1387,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow modifying passcode is set to 'false', this will override this preference if set to 'true'.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. Allows the user to modify Touch ID. Default is false. Availability: Available in iOS 8.3 and later.</string>
+			<string>If 'false', prevents the user from modifying Touch ID or Face ID. Requires a supervised device. Available in iOS 8.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.3</string>
 			<key>pfm_name</key>
@@ -1538,9 +1403,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to 'false', disables the "Enable ScreenTime" option in the ScreenTime UI in Settings and disables ScreenTime if already enabled.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables the "Enable Restrictions" option in the Restrictions UI in Settings. Default is true. On iOS 12 or later, if set to false disables the "Enable ScreenTime" option in the ScreenTime UI in Settings and disables ScreenTime if already enabled. Availability: Available in iOS 8.0 and later.</string>
+			<string>If 'false', disables the “Enable Restrictions” option in the Restrictions UI in Settings.
+In iOS 12 or later, if 'false', disables the “Enable ScreenTime” option in the ScreenTime UI in Settings and disables ScreenTime if already enabled. Requires a supervised device. Available in iOS 8 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -1556,9 +1420,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, prevents wallpaper from being changed. Defaults to true. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', prevents wallpaper from being changed. Requires a supervised device. Available in iOS 9 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -1574,9 +1436,9 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, device will always be able to connect to USB accessories while locked. Defaults to true. Availability: Available only in iOS 11.4.1 and later.</string>
+			<string>If 'false', allows the device to always connect to USB accessories while locked. On macOS, allows new USB accessories to connect without authorization.
+If the system has Lockdown mode enabled, the system ignores this value.
+Requires a supervised device. Available in iOS 11.4.1 and later and macOS 13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.4.1</string>
 			<key>pfm_name</key>
@@ -1592,9 +1454,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, host pairing is disabled with the exception of the supervision host. If no supervision host certificate has been configured, all pairing is disabled. Host pairing lets the administrator control which devices an iOS 7 device can pair with. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', disables host pairing with the exception of the supervision host. If no supervision host certificate has been configured, all pairing is disabled. Host pairing lets the administrator control if an iOS device can pair with a host Mac or PC. Requires a supervised device. Available in iOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1628,6 +1488,8 @@ Available on iOS 17 and later.</string>
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>If 'true', allows devices to be booted into recovery by an unpaired device. Requires a supervised device. Available in iOS 14.5 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.5</string>
 			<key>pfm_name</key>
@@ -1643,9 +1505,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If false, documents in managed apps and accounts only open in other managed apps and accounts. Default is true. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', documents in managed apps and accounts only open in other managed apps and accounts. Available in iOS 7 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1659,9 +1519,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, documents in unmanaged apps and accounts will only open in other unmanaged apps and accounts. Default is true. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', documents in unmanaged apps and accounts only open in other unmanaged apps and accounts. Available in iOS 7 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1675,9 +1533,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow unmanaged apps to read contacts from managed contacts accounts</string>
-			<key>pfm_description_reference</key>
-			<string>If true, unmanaged apps can read from managed contacts accounts. If allowOpenFromManagedToUnmanaged is true, this restriction has no effect. If this restriction is set to true, you must install the payload through MDM. Available in iOS 12 and later. Also available for user enrollment.</string>
+			<string>If 'true', unmanaged apps can read from managed contacts accounts. If 'allowOpenFromManagedToUnmanaged' is 'true', this restriction has no effect. If this restriction is set to 'true', you must install the payload through MDM. Available in iOS 12 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -1691,9 +1547,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow managed apps to write contacts to unmanaged contacts accounts</string>
-			<key>pfm_description_reference</key>
-			<string>If true, managed apps can write contacts to unmanaged contacts accounts. If allowOpenFromManagedToUnmanaged is true, this restriction has no effect. If this restriction is set to true, you must install the payload through MDM. Available in iOS 12 and later.</string>
+			<string>If 'true', managed apps can write contacts to unmanaged contacts accounts. If 'allowOpenFromManagedToUnmanaged' is 'true', this restriction has no effect. If this restriction is set to 'true', you must install the payload through MDM. Available in iOS 12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -1707,7 +1561,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When set to true, pasteboard functionality between managed and unmanaged apps mirrors that set for opening documents.</string>
+			<string>If 'true', copy and paste functionality respects the 'allowOpenFromManagedToUnmanaged' and 'allowOpenFromUnmanagedToManaged' restrictions. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_name</key>
@@ -1721,9 +1575,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, AirDrop is disabled. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', disables AirDrop. Requires a supervised device. Available in iOS 7 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -1739,9 +1591,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, causes AirDrop to be considered an unmanaged drop target. Defaults to false. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'true', causes AirDrop to be considered an unmanaged drop target. Available in iOS 9 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -1755,9 +1605,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, Activity Continuation will be disabled. Defaults to true.</string>
+			<string>If 'false', disables activity continuation. Available in iOS 8 and later, and macOS 10.15 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.0</string>
 			<key>pfm_name</key>
@@ -1771,9 +1619,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, this prevents the device from automatically submitting diagnostic reports to Apple. Defaults to true. Availability: Available only in iOS 6.0 and later.</string>
+			<string>If 'false', prevents the device from automatically submitting diagnostic reports to Apple. Available in iOS 6 and later, and macOS 10.13 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -1787,9 +1633,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow diagnostic and usage data to Apple is set to 'false', this will override this preference if set to 'true'.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, the diagnostic submission and app analytics settings in the Diagnostics &amp; Usage pane in Settings cannot be modified. Defaults to true. Availability: Available in iOS 9.3.2 and later.</string>
+			<string>If 'false', disables changing the diagnostic submission and app analytics settings in the Diagnostics &amp; Usage UI in Settings. Requires a supervised device. Available in iOS 9.3.2 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3.2</string>
 			<key>pfm_name</key>
@@ -1805,9 +1649,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, the user will have to authenticate before passwords or credit card information can be autofilled in Safari and Apps. If this restriction is not enforced, the user can toggle this feature in settings. Only supported on devices with FaceID or TouchID. Defaults to true. Availability: Available only in iOS 11.0 and later.</string>
+			<string>If 'true', the user must authenticate before passwords or credit card information can be autofilled in Safari and Apps. If this restriction isn't enforced, the user can toggle this feature in Settings. Only supported on devices with Face ID or Touch ID. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1823,9 +1665,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables pairing with an Apple Watch. Any currently paired Apple Watch is unpaired and erased. Defaults to true. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', disables pairing with an Apple Watch. Any currently paired Apple Watch is unpaired and the watch's content is erased. Requires a supervised device. Available in iOS 9 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -1841,9 +1681,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to true, a paired Apple Watch will be forced to use Wrist Detection. Defaults to false. Availability: Available in iOS 8.2 and later.</string>
+			<string>If 'true', forces a paired Apple Watch to use Wrist Detection. Available in iOS 8.2 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>8.2</string>
 			<key>pfm_name</key>
@@ -1859,9 +1697,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevents turning Wi-Fi off in Settings, Control Center, or by entering Airplane Mode.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, prevents Wi-Fi from being turned off in Settings or Control Center, even by entering or leaving Airplane Mode. It does not prevent selecting which Wi-Fi network to use. Available in iOS 13.0 and later. Defaults to false.</string>
+			<string>If 'true', prevents Wi-Fi from being turned off in Settings or Control Center, even by entering or leaving Airplane Mode. It doesn't prevent selecting which Wi-Fi network to use. Requires a supervised device. Available in iOS 13.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -1876,6 +1712,8 @@ Available on iOS 17 and later.</string>
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>If 'true', limits device to only join Wi-Fi networks set-up via configuration profile. Requires a supervised device. Available in iOS 14.5 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.5</string>
 			<key>pfm_name</key>
@@ -1891,9 +1729,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, the device can join Wi-Fi networks only if they were set up through a configuration profile. Defaults to false. Availability: Available only in iOS 10.3 and later.</string>
+			<string>Use 'forceWiFiToAllowedNetworksOnly' instead.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>14.5</string>
 			<key>pfm_ios_min</key>
@@ -1911,9 +1747,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables the prompt to setup new devices that are nearby. Defaults to true. Availability: Available only in iOS 11.0 and later.</string>
+			<string>If 'false', disables the prompt to set up new devices that are nearby. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -1929,9 +1763,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables predictive keyboards. Defaults to true. Availability: Available in iOS 8.1.3 and later.</string>
+			<string>If 'false', disables predictive keyboards. Requires a supervised device. Available in iOS 8.1.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.1.3</string>
 			<key>pfm_name</key>
@@ -1947,9 +1779,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, keyboard shortcuts cannot be used. Defaults to true. Availability: Available in iOS 9.0 and later.</string>
+			<string>If 'false', disables keyboard shortcuts. Requires a supervised device. Available in iOS 9 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -1965,9 +1795,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables keyboard auto-correction. Defaults to true. Availability: Available in iOS 8.1.3 and later.</string>
+			<string>If 'false', disables keyboard autocorrection. Requires a supervised device. Available in iOS 8.1.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.1.3</string>
 			<key>pfm_name</key>
@@ -1983,9 +1811,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Permits usage of QuickPath keyboard</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables QuickPath keyboard. Requires a supervised device. Available in iOS 13 and later.</string>
+			<string>If 'false', disables QuickPath keyboard. Requires a supervised device. Available in iOS 13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -2001,9 +1827,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables keyboard spell-check. Defaults to true. Availability: Available in iOS 8.1.3 and later.</string>
+			<string>If 'false', disables keyboard spell-check. Requires a supervised device. Available in iOS 8.1.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>8.1.3</string>
 			<key>pfm_name</key>
@@ -2019,7 +1843,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enable temporary sessions for iPads that have been enabled as Shared iPad.</string>
+			<string>If 'false', temporary sessions aren't available on Shared iPad. Available in iOS 13.4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>13.4</string>
 			<key>pfm_name</key>
@@ -2033,9 +1857,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disallows dictation input. Defaults to true. Availability: Available only in iOS 10.3 and later.</string>
+			<string>If 'false', disallows dictation input. Requires a supervised device. Available in iOS 10.3 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>10.3</string>
 			<key>pfm_name</key>
@@ -2050,6 +1872,8 @@ Available on iOS 17 and later.</string>
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>If 'true', disables connections to Siri servers for the purposes of dictation. Available in iOS 14.5 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>14.5</string>
 			<key>pfm_name</key>
@@ -2062,6 +1886,8 @@ Available on iOS 17 and later.</string>
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>If 'true', the device won't connect to Siri servers for the purposes of translation. Available in iOS 15 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_name</key>
@@ -2075,9 +1901,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, Passbook notifications will not be shown on the lock screen. This will default to true. Availability: Available in iOS 6.0 and later.</string>
+			<string>If 'false', hides Passbook notifications from the lock screen. Available in iOS 6 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -2091,9 +1915,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Allow modifying Personal Hotspot settings</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables modifications of the personal hotspot setting. Requires a supervised device. Available in iOS 12.2 and later.</string>
+			<string>If 'false', disables modifications of the personal hotspot setting. Requires a supervised device. Available in iOS 12.2 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.2</string>
 			<key>pfm_name</key>
@@ -2109,9 +1931,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If false, prevents Control Center from appearing on the Lock screen. Availability: Available in iOS 7 and later.</string>
+			<string>If 'false', prevents Control Center from appearing on the Lock screen. Available in iOS 7 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -2125,9 +1945,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, the Notifications history view on the lock screen is disabled and users can't view past notifications. Though, when the device is locked, the user will still be able to view notifications when they arrive. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', disables the Notifications history view on the lock screen, so users can't view past notifications. However, they can still see notifications when they arrive. Available in iOS 7 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -2141,9 +1959,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to false, the Today view in Notification Center on the lock screen is disabled. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'false', disables the Today view in Notification Center on the lock screen. Available in iOS 7 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -2157,9 +1973,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, forces all devices receiving AirPlay requests from this device to use a pairing password. Default is false. Availability: Available only in iOS 7.1 and later.</string>
+			<string>If 'true', forces all devices receiving AirPlay requests from this device to use a pairing password. Available in iOS 7.1 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>7.1</string>
 			<key>pfm_name</key>
@@ -2175,9 +1989,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow AirPrint is set to 'false', it also overrides this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disallows keychain storage of username and password for Airprint. Defaults to true. Availability: Available in iOS 11.0 and later.</string>
+			<string>If 'false', disables keychain storage of user name and password for AirPrint. Requires a supervised device. Available in iOS 11 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -2193,9 +2005,8 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, limits ad tracking. Default is false. Availability: Available only in iOS 7.0 and later.</string>
+			<string>If 'true', limits ad tracking. Additionally, it disables app tracking and the Allow Apps To Request To Track setting.
+Available in iOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>
@@ -2208,6 +2019,8 @@ Available on iOS 17 and later.</string>
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', limits Apple personalized advertising. Available in iOS 14 and later and macOS 12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14</string>
 			<key>pfm_name</key>
@@ -2220,6 +2033,8 @@ Available on iOS 17 and later.</string>
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', disables Mail Privacy Protection on the device. Requires a supervised device. Available in iOS 15.2 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>15.2</string>
 			<key>pfm_name</key>
@@ -2233,9 +2048,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. When false, Game Center is disabled and its icon is removed from the Home screen. Default is true. Availability: Available only in iOS 6.0 and later.</string>
+			<string>If 'false', disables Game Center, and its icon is removed from the Home screen. Requires a supervised device. Available in iOS 6 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -2251,9 +2064,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow use of Game Center is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, prohibits adding friends to Game Center. This key is deprecated on unsupervised devices.</string>
+			<string>If 'false', prohibits adding friends to Game Center. As of iOS 13, requires a supervised device. Available in iOS 4.2.1 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.2.1</string>
 			<key>pfm_name</key>
@@ -2269,9 +2080,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow use of Game Center is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, prohibits multiplayer gaming. This key is deprecated on unsupervised devices.</string>
+			<string>If 'false', prohibits multiplayer gaming. Requires a supervised device. Available in iOS 4.1 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.1</string>
 			<key>pfm_name</key>
@@ -2287,9 +2096,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, the Safari web browser application is disabled and its icon removed from the Home screen. This also prevents users from opening web clips. This key is deprecated on unsupervised devices.</string>
+			<string>If 'false', disables the Safari web browser app, and its icon is removed from the Home screen. This setting also prevents users from opening web clips. As of iOS 13, requires a supervised device. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2305,9 +2112,8 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow use of Safari is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, Safari auto-fill is disabled. Defaults to true.</string>
+			<string>If 'false', disables Safari AutoFill for passwords, contact info, and credit cards and also prevents the Keychain from being used for AutoFill. Though third-party password managers are allowed and apps can use AutoFill.
+As of iOS 13, requires a supervised device. Available in iOS 4 and later, and macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2321,9 +2127,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If Allow use of Safari is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When true, Safari fraud warning is enabled. Defaults to false.</string>
+			<string>If 'true', enables Safari fraud warning. Available in iOS 4 and later. Also available for user enrollment.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2337,9 +2141,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow use of Safari is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, Safari will not execute JavaScript. Defaults to true.</string>
+			<string>If 'false', Safari doesn't execute JavaScript. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2353,9 +2155,7 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If Allow use of Safari is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, Safari will not allow pop-up tabs. Defaults to true.</string>
+			<string>If 'false', Safari doesn't allow pop-up windows. Available in iOS 4 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2369,21 +2169,10 @@ Available on iOS 17 and later.</string>
 			<key>pfm_default</key>
 			<real>2</real>
 			<key>pfm_description</key>
-			<string>If Allow use of Safari is set to 'false', this will override this preference.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Determines conditions under which the device will accept cookies. The user facing settings changed in iOS 11, though the possible values remain the same. 
-
-- 0: PreventCross-SiteTrackingandBlockAllCookiesare enabled and the user canʼt disable either setting.
-- 1 or 1.5: PreventCross-SiteTrackingisenabledandthe user canʼt disable it. Block All Cookies is not enabled, though the user can enable it.
-- 2: PreventCross-SiteTrackingisenabledandBlockAll Cookies is not enabled. The user can toggle either setting. (Default)
-
-These are the allowed values and settings in iOS 10 and earlier:
-- 0: Never
-- 1: Allow from current website only
-- 1.5: Allow from websites visited (Available in iOS 8.0 and later); enter '&lt;real&gt;1.5&lt;/real&gt;'
-- 2: Always (Default)
-
-In iOS 10 and earlier, users can always pick an option that is more restrictive than the payload policy, but not a less restrictive policy. For example, with a payload value of 1.5, a user could switch to Never, but not Always Allow.</string>
+			<string>This value defines the conditions under which the device accepts cookies. The user-facing settings changed in iOS 11, although the possible values remain the same. Available in iOS 4 and later.
+'0': Prevent Cross-Site Tracking and Block All Cookies are enabled and the user canʼt disable either setting.
+'1' or '1.5': Prevent Cross-Site Tracking is enabled and the user canʼt disable it. Block All Cookies is not enabled, although the user can enable it.
+'2': Prevent Cross-Site Tracking is enabled and Block All Cookies is not enabled. The user can toggle either setting.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2411,9 +2200,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, prevents device name from being changed. Defaults to true. Availability: Available in iOS 9.0 and tvOS 11.0 and later.</string>
+			<string>If 'false', prevents the user from changing the device name. Requires a supervised device. Available in iOS 9 and later, and tvOS 11.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>9.0</string>
 			<key>pfm_name</key>
@@ -2427,7 +2214,8 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>When populated, prevents displaying or launching listed apps. Use bundle ID com.apple.webapp to block all webclips. Disabled when using the Allowed Apps preference.</string>
+			<string>If present, prevents bundle IDs listed in the array from being shown or launchable. Include the value 'com.apple.webapp' to restrict all webclips. Note that denying system apps may disable other functionality. For example, denying the App Store app may prevent users from accepting the terms and conditions for user-based VPP.
+Requires a supervised device. Available in iOS 9.3 and later, and tvOS 11.0 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -2466,9 +2254,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If enabled, cannot use the allowlist to restrict app usage.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If present, prevents bundle IDs listed in the array from being shown or launchable. Include the value com.apple.webapp to blacklist all webclips. Availability: Available in iOS 9.3 and later.</string>
+			<string>Use blockedAppBundleIDs instead.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -2511,7 +2297,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>When populated, prevents displaying or launching apps other than the listed ones. Use bundle ID com.apple.webapp to allow all webclips. Disabled when using the Blocked Apps preference.</string>
+			<string>If present, this property allows only bundle IDs listed in the array to be shown or launchable. Include the value 'com.apple.webapp' to allow all webclips. Requires a supervised device. Available in iOS 9.3 and later, and tvOS 11.0 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -2550,9 +2336,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If enabled, cannot use the denylist to restrict app usage.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If present, allows only bundle IDs listed in the array from being shown or launchable. Include the value com.apple.webapp to whitelist all webclips. Availability: Available in iOS 9.3 and later.</string>
+			<string>Use 'allowListedAppBundleIDs' instead.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -2597,9 +2381,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<string>us</string>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>This 2-letter key is used by profile tools to display the proper ratings for given region. It is not recognized or reported by the client. Availability: Available in iOS and tvOS 11.3 and later.</string>
+			<string>The two-letter key that profile tools use to display the proper ratings for the given region. This data isn't recognized or reported by the client.</string>
 			<key>pfm_ios_min</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -2637,9 +2419,14 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<integer>1000</integer>
 			<key>pfm_description</key>
-			<string>Integer rating value based on region. Not all integer values are used in each region. Apple's Configuration Profile documentation includes the values for the US, so you may need to do some sleuthing here.</string>
-			<key>pfm_description_reference</key>
-			<string>This value defines the maximum level of app content that is allowed on the device. Availability: Available only in iOS 5 and tvOS 11.3 and later.</string>
+			<string>The maximum level of app content allowed on the device. Available in iOS 4 and later, and tvOS 11.3 and later.
+Possible values (with the US description of the rating level):
+* 1000: All
+* 600: 17+
+* 300: 12+
+* 200: 9+
+* 100: 4+
+* 0: None</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2681,9 +2468,15 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<integer>1000</integer>
 			<key>pfm_description</key>
-			<string>Integer rating value based on region. Not all integer values are used in each region. Apple's Configuration Profile documentation includes the values for the US, so you may need to do some sleuthing here.</string>
-			<key>pfm_description_reference</key>
-			<string>This value defines the maximum level of movie content that is allowed on the device. Availability: Available only in iOS 5 and tvOS 11.3 and later.</string>
+			<string>The maximum level of movie content allowed on the device. Available in iOS 4 and later, and tvOS 11.3 and later.
+Possible values (with the US description of the rating level):
+* 1000: All
+* 500: NC-17
+* 400: R
+* 300: PG-13
+* 200: PG
+* 100: G
+* 0: None</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2725,9 +2518,18 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<integer>1000</integer>
 			<key>pfm_description</key>
-			<string>Integer rating value based on region. Not all integer values are used in each region. Apple's Configuration Profile documentation includes the values for the US, so you may need to do some sleuthing here.</string>
-			<key>pfm_description_reference</key>
-			<string>This value defines the maximum level of TV content that is allowed on the device. Availability: Available only in iOS 5 and tvOS 11.3 and later.</string>
+			<string>The maximum level of TV content allowed on the device. Available in iOS 4 and later, and tvOS 11.3 and later.
+
+Possible values (with the US description of the rating level):
+
+* 1000: All
+* 600: TV-MA
+* 500: TV-14
+* 400: TV-PG
+* 300: TV-G
+* 200: TV-Y7
+* 100: TV-Y
+* 0: None</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2769,9 +2571,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, explicit music or video content purchased from the iTunes Store is hidden. Explicit content is marked as such by content providers, such as record labels, when sold through the iTunes Store. This key is deprecated on unsupervised devices. Availability: Available in iOS and in tvOS 11.3 and later.</string>
+			<string>If 'false', hides explicit music or video content purchased from the iTunes Store. Explicit content is marked as such by content providers, such as record labels, when sold through the iTunes Store. As of iOS 13, requires a supervised device. Available in iOS 4 and later, and tvOS 11.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -2789,9 +2589,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Allow connecting to and browsing any USB storage device in the Files App</string>
-			<key>pfm_description_reference</key>
-			<string>If false, prevents connecting to any connected USB devices in the Files app. Available in iOS 13.0 and later.</string>
+			<string>If 'false', prevents connecting to any connected USB devices in the Files app. Requires a supervised device. Available in iOS 13.1 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>13.1</string>
 			<key>pfm_name</key>
@@ -2807,9 +2605,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only prior to iOS 6.1. If set to false, the user will not be able to download media from Apple Books that has been tagged as erotica. This will default to true. Availability: Available in iOS and in tvOS 11.3 and later.</string>
+			<string>If 'false', the user can't download Apple Books media that is tagged as erotica. Available in iOS 6 and later, and tvOS 11.3 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -2823,9 +2619,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, users can not share their passwords with the AirDrop Passwords feature. Defaults to true. Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
+			<string>If 'false', disables sharing passwords with the Airdrop Passwords feature. Requires a supervised device. Available in iOS 12 and later, and macOS 10.14 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -2841,9 +2635,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, a user's device will not request passwords from nearby devices. Defaults to true. Availability: Available only in iOS 12.0, macOS 10.14, and tvOS 12.0 and later.</string>
+			<string>If 'false', disables requesting passwords from nearby devices. Requires a supervised device. Available in iOS 12 and later, macOS 10.14 and later, and tvOS 12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -2859,9 +2651,9 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to true, delays user visibility of Software Updates. Defaults to false. On macOS, seed build updates will be allowed, without delay. Availability: Available in iOS 11.3 and later and macOS 10.13 and later.</string>
+			<string>If 'true', delays user visibility of software updates. In macOS, seed build updates are allowed, without delay. Requires a supervised device in iOS and tvOS.
+The delay is 30 days unless 'enforcedSoftwareUpdateDelay' is set to another value.
+Available in iOS 11.3 and later, macOS 10.13 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -2877,9 +2669,9 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<integer>30</integer>
 			<key>pfm_description</key>
-			<string>Number of days the software updates will be hidden from the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. This restriction allows the admin to set how many days a software update on the device will be delayed. With this restriction in place, the user will not see a software update until the specified number of days after the software update release date. The max is 90 days and the default value is 30. Availability: Available in iOS 11.3 and later and macOS 10.13.4 and later.</string>
+			<string>Sets how many days to delay a software update on the device. With this restriction in place, the user doesn't see a software update until the specified number of days after the software update release date. This value is used by 'forceDelayedAppSoftwareUpdates' and 'forceDelayedSoftwareUpdates'.
+Requires a supervised device in iOS and tvOS.
+Available in iOS 11.3 and later, macOS 10.13.4 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -2917,7 +2709,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to prevent the installation of rapid security responses</string>
+			<string>If 'false', prohibits installation of rapid security responses.</string>
 			<key>pfm_ios_min</key>
 			<string>16.0</string>
 			<key>pfm_name</key>
@@ -2933,7 +2725,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to prevent the removal of rapid security responses</string>
+			<string>If 'false', prohibits removal of rapid security responses.</string>
 			<key>pfm_ios_min</key>
 			<string>16.0</string>
 			<key>pfm_name</key>
@@ -2949,9 +2741,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Allows disabling Find My Device in the Find My app</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables Find My Device in the Find My app. Requires a supervised device. Available in iOS 13 and later.</string>
+			<string>If 'false', disables Find My Device in the Find My app. Requires a supervised device. Available in iOS 13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -2967,9 +2757,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Allows disabling Find My Friends in the Find My app</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables Find My Friends in the Find My app. Requires a supervised device. Available in iOS 13 and later.</string>
+			<string>If 'false', disables Find My Friends in the Find My app. Requires a supervised device. Available in iOS 13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -2985,9 +2773,7 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Allows preventing connection to network drives in the Files app</string>
-			<key>pfm_description_reference</key>
-			<string>If false, prevents connecting to network drives in the Files app. Available in iOS 13.0 and later.</string>
+			<string>If 'false', prevents connecting to network drives in the Files app. Requires a supervised device. Available in iOS 13.1 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>macOS Restrictions preferences</string>
+	<string>Use this section to define restrictions settings</string>
 	<key>pfm_description_reference</key>
 	<string>The Restrictions payload is designated by specifying com.apple.applicationaccess as the PayloadType value. A Restrictions payload allows the administrator to restrict the user from doing certain things with the device, such as using the camera. The Restrictions payload is supported in iOS; some keys are also supported in macOS, as noted below.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_note</key>
 	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 	<key>pfm_platforms</key>
@@ -30,9 +30,7 @@
 			<key>pfm_default</key>
 			<string>Restrictions</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -46,9 +44,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,9 +58,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,9 +72,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,10 +88,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -113,9 +102,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<string>Configures restrictions</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -244,9 +231,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If false, disables AirDrop.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables AirDrop. Requires a supervised device. Available in iOS 7 and later, and macOS 10.13 and later.</string>
+			<string>If 'false', disables AirDrop. Requires a supervised device. Available in iOS 7 and later, and macOS 10.13 and later.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/restrictions</string>
 			<key>pfm_macos_min</key>
@@ -261,6 +246,8 @@ A profile can consist of payloads with different version numbers. For example, c
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', disables incoming AirPlay requests. Requires a supervised device. Available in macOS 12.3 and later, and tvOS 10.2 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.3</string>
 			<key>pfm_name</key>
@@ -276,9 +263,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, users will not be able to use the AutoFill Passwords feature on iOS and will not be prompted to use a saved password in Safari or in apps. If set to false, Automatic Strong Passwords will also be disabled and strong passwords will not be suggested to users. Defaults to true. Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
+			<string>If 'false', disables the AutoFill Passwords feature in iOS (with Keychain and third-party password managers) and the user isn't prompted to use a saved password in Safari or in apps.
+This restriction also disables Automatic Strong Passwords, and strong passwords are no longer suggested to users.
+It doesn't prevent AutoFill for contact info and credit cards in Safari.
+Requires a supervised device. Available in iOS 12 and later, and macOS 10.14 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>
@@ -294,9 +282,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, disallows macOS auto unlock. Defaults to true. Availability: Available only in macOS 10.12 and later.</string>
+			<string>If 'false', disallows auto unlock. Available in macOS 10.12 and later, and iOS 14.5 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -310,9 +296,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, the camera is completely disabled and its icon is removed from the Home screen. Users are unable to take photographs. Availability: Available in iOS and in macOS 10.11 and later.</string>
+			<string>If 'false', disables the camera, and its icon is removed from the Home screen. Users are unable to take photographs. This restriction is deprecated on unsupervised devices and will be supervised only in a future release.  Available in iOS 4 and later, and macOS 10.11 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -326,7 +310,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>When false this disallows content caching. Defaults to true. Introduced in macOS 10.13 but moved to the content caching domain in 10.13.4.</string>
+			<string>If 'false', disables content caching. As of 10.13.4 this is included in the content caching payload. Available in macOS 10.13 and later.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>10.13.4</string>
 			<key>pfm_macos_min</key>
@@ -369,7 +353,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to prevent sharing mouse and keyboard between a Mac and an iPad</string>
+			<string>If 'false', disables Universal Control. Available in macOS 13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -383,9 +367,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, iTunes application file sharing services are disabled. Availability: Available in macOS 10.13 and later.</string>
+			<string>If 'false', disables iTunes file sharing services. Available in macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -411,9 +393,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables activity continuation. Available in iOS 8 and later, and macOS 10.15 and later.</string>
+			<string>If 'false', disables activity continuation. Available in iOS 8 and later, and macOS 10.15 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.15</string>
 			<key>pfm_name</key>
@@ -427,7 +407,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If false, prevents the device from automatically submitting diagnostic reports to Apple.</string>
+			<string>If 'false', prevents the device from automatically submitting diagnostic reports to Apple. Available in iOS 6 and later, and macOS 10.13 and later. Also available for user enrollment.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/restrictions</string>
 			<key>pfm_macos_min</key>
@@ -443,9 +423,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, Music service is disabled and Music app reverts to classic mode. Defaults to true. Availability: Available in iOS 9.3 and later and macOS 10.12 and later.</string>
+			<string>If 'false', disables the Music service, and the Music app reverts to classic mode. Requires a supervised device. Available in iOS 9.3 and later, and macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -494,9 +472,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disallows macOS iCloud Bookmark sync. Availability: Available in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Bookmark sync. Available in macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -510,9 +486,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disallows macOS iCloud Calendar services. Availability: Available in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Calendar services. Available in macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -526,9 +500,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disallows macOS iCloud Address Book services. Availability: Available in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Address Book services. Available in macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -542,9 +514,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables document and key-value syncing to iCloud. This key is deprecated on unsupervised devices. Availability: Available in iOS 5.0 and later and in macOS 10.11 and later.</string>
+			<string>If 'false', disables document and key-value syncing to iCloud. As of iOS 13, this restriction requires a supervised device and shared iPads don't support it. Available in iOS 5 and later, and macOS 10.11 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -560,9 +530,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, disallows macOS cloud desktop and document services. Defaults to true. Availability: Available only in macOS 10.12.4 and later.</string>
+			<string>If 'false', disables cloud desktop and document services. Available in macOS 10.12.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12.4</string>
 			<key>pfm_name</key>
@@ -608,9 +576,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disables iCloud keychain synchronization. Default is true. Availability: Available in iOS 7.0 and later and macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud keychain synchronization. This restriction is deprecated on unsupervised devices and will be supervised only in a future release. Available in iOS 7 and later and macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -624,9 +590,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disallows macOS Mail iCloud services. Availability: Available in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Mail services. Available in macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -640,9 +604,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disallows macOS iCloud Notes services. Availability: Available in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Notes services. Available in macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -656,9 +618,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, disables iCloud Photo Library. Any photos not fully downloaded from iCloud Photo Library to the device will be removed from local storage. Availability: Available in iOS 9.0 and later and in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Photo Library, including iCloud Shared Photo Library. Any photos not fully downloaded from iCloud Photo Library to the device are removed from local storage. Available in iOS 9 and later, and macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -672,9 +632,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, disallows iCloud Reminder services. Availability: Available in macOS 10.12 and later.</string>
+			<string>If 'false', disables iCloud Reminder services. Available in macOS 10.12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -688,7 +646,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to false, prevents the use of iCloud Private Relay.</string>
+			<string>If 'false', disables iCloud Private Relay. For iOS devices, this restriction requires a supervised device. Available in macOS 12 and later, and iOS 15 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -702,9 +660,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, Spotlight will not return Internet search results. Availability: Available in iOS and in macOS 10.11 and later.</string>
+			<string>If 'false', disables Spotlight Internet search results in Siri Suggestions. Available in iOS 8 and later, and macOS 10.11 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -720,9 +676,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables the "Erase All Content And Settings" option in the Reset UI.</string>
+			<string>If 'false', disables the Erase All Content And Settings option in the Reset UI. Requires a supervised device. Available in iOS 8 and later, and macOS 12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -754,9 +708,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If false, prevents Touch ID from unlocking a device. Availability: Available in iOS 7 and later and in macOS 10.12.4 and later.</string>
+			<string>If 'false', prevents Touch ID or Face ID from unlocking a device. Available in iOS 7 and later, and macOS 10.12.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12.4</string>
 			<key>pfm_name</key>
@@ -784,9 +736,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, disables definition lookup. Defaults to true. Availability: Available in iOS 8.1.3 and later and in macOS 10.11.2 and later.</string>
+			<string>If 'false', disables definition lookup. Requires a supervised device on iOS. Available in iOS 8.1.3 and later and macOS 10.11 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.11.2</string>
 			<key>pfm_name</key>
@@ -833,7 +783,7 @@ Available in iOS 9 and later, macOS 14 and later, and tvOS 11.0 and later.</stri
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If 'false', disables Game Center, and its icon is removed from the Home screen. Requires a supervised device. Available in iOS 6 and later, and macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -879,7 +829,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If 'false', prohibits adding friends to Game Center. As of iOS 13, requires a supervised device. Available in iOS 4.2.1 and later, and macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -925,9 +875,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, users can not share their passwords with the AirDrop Passwords feature. Defaults to true. Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
+			<string>If 'false', disables sharing passwords with the Airdrop Passwords feature. Requires a supervised device. Available in iOS 12 and later, and macOS 10.14 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>
@@ -983,9 +931,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables saving a screenshot of the display and capturing a screen recording. It also disables the Classroom app from observing remote screens. Available in iOS 4 and later, and macOS 10.14.4 and later. Also available for user enrollment.</string>
+			<string>If 'false', disables saving a screenshot of the display and capturing a screen recording. It also disables the Classroom app from observing remote screens. Available in iOS 4 and later, and macOS 10.14.4 and later. Also available for user enrollment.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14.4</string>
 			<key>pfm_name</key>
@@ -1033,7 +979,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If 'false', prohibits the user from installing configuration profiles and certificates interactively. Requires a supervised device. Available in iOS 6 and later and macOS 13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -1049,9 +995,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If 'Allow Screenshots and Screen Recording' is set to 'false', it also overrides this preference and prevents the Classroom app from observing remote screens.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables remote screen observation by the Classroom app. Nest this key beneath allowScreenShot as a subrestriction. If allowScreenShot is set to false, the Classroom app doesn't observe remote screens. Required a supervised device until iOS 13 and macOS 10.15. Available in iOS 12 and later, and macOS 10.14.4 and later.</string>
+			<string>If 'false', disables remote screen observation by the Classroom app. Nest this key beneath 'allowScreenShot' as a subrestriction. If 'allowScreenShot' is set to 'false', the Classroom app doesn't observe remote screens. Required a supervised device until iOS 13 and macOS 10.15. Available in iOS 12 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14.4</string>
 			<key>pfm_name</key>
@@ -1069,11 +1013,7 @@ Available in macOS 14 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If Allow screenshots and screen recording is set to 'false' or Allow AirPlay and View Screen by Classroom app, they also override this preference and prevents the Classroom app from unprompted remote AirPlay and view screens.
-
-Additionally, if set to true and ScreenObservationPermissionModificationAllowed is also true in the Education payload, a student enrolled in a managed course via the Classroom app will automatically give permission to that course's teacher's requests to observe the student's screen without prompting the student.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, and ScreenObservationPermissionModificationAllowed is also true in the Education payload, a student enrolled in a managed course via the Classroom app will automatically give permission to that courseʼs teacher's requests to observe the student's screen without prompting the student. Defaults to false. Availability: Available only in iOS 11.0 and macOS 10.14.4 and later.</string>
+			<string>If 'true' and 'ScreenObservationPermissionModificationAllowed' is also 'true' in the Education payload, a student enrolled in a managed course via the Classroom app automatically gives permission to that course teacher's requests to observe the student's screen without prompting the student. Requires a supervised device. Available in iOS 11 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1105,9 +1045,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, allow the teacher to lock apps or the device without prompting the student. Defaults to false. Availability: Available only in iOS 11.0 and macOS 10.14.4 and later.</string>
+			<string>If 'true', allows the teacher to lock apps or the device without prompting the student. Requires a supervised device. Available in iOS 11 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14.4</string>
 			<key>pfm_name</key>
@@ -1123,9 +1061,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, automatically give permission to the teacherʼs requests without prompting the student. Defaults to false. Availability: Available only in iOS 11.0 and macOS 10.14.4 and later.</string>
+			<string>If 'true', automatically gives permission to the teacher's requests without prompting the student. Requires a supervised device. Available in iOS 11 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14.4</string>
 			<key>pfm_name</key>
@@ -1141,9 +1077,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to true, a student enrolled in an unmanaged course via Classroom will request permission from the teacher when attempting to leave the course. Defaults to false. Availability: Available only in iOS 11.3 and macOS 10.14.4 and later.</string>
+			<string>If 'true', a student enrolled in an unmanaged course through Classroom requests permission from the teacher when attempting to leave the course. Requires a supervised device. Available in iOS 11.3 and later, and macOS 10.14.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14.4</string>
 			<key>pfm_name</key>
@@ -1158,6 +1092,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', prevents modification of Bluetooth settings. Requires a supervised device. Available in iOS 11 and later, and macOS 13.0 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -1171,9 +1107,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, a user's device will not request passwords from nearby devices. Defaults to true. Availability: Available only in iOS 12.0, macOS 10.14, and tvOS 12.0 and later.</string>
+			<string>If 'false', disables requesting passwords from nearby devices. Requires a supervised device. Available in iOS 12 and later, macOS 10.14 and later, and tvOS 12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>
@@ -1189,7 +1123,9 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to allow new USB accessories to connect to a Mac without authorization</string>
+			<string>If 'false', allows the device to always connect to USB accessories while locked. On macOS, allows new USB accessories to connect without authorization.
+If the system has Lockdown mode enabled, the system ignores this value.
+Requires a supervised device. Available in iOS 11.4.1 and later and macOS 13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -1219,9 +1155,9 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to true, delays user visibility of Software Updates. Defaults to false. On macOS, seed build updates will be allowed, without delay. Availability: Available in iOS 11.3 and later and macOS 10.13 and later.</string>
+			<string>If 'true', delays user visibility of software updates. In macOS, seed build updates are allowed, without delay. Requires a supervised device in iOS and tvOS.
+The delay is 30 days unless 'enforcedSoftwareUpdateDelay' is set to another value.
+Available in iOS 11.3 and later, macOS 10.13 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.4</string>
 			<key>pfm_name</key>
@@ -1239,7 +1175,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to prevent the installation of rapid security responses</string>
+			<string>If 'false', prohibits installation of rapid security responses.</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -1255,7 +1191,7 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to prevent the removal of rapid security responses</string>
+			<string>If 'false', prohibits removal of rapid security responses.</string>
 			<key>pfm_macos_min</key>
 			<string>13.0</string>
 			<key>pfm_name</key>
@@ -1271,7 +1207,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<integer>30</integer>
 			<key>pfm_description</key>
-			<string>Number of days minor software updates will be hidden from the user.</string>
+			<string>This restriction allows the admin to set how many days to delay a minor OS software update on the device. When this restriction is in place the user see a software update only after the specified delay after the release of the software update. This value controls the delay for 'forceDelayedSoftwareUpdates'.
+Available in macOS 11.3 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1307,13 +1244,9 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, delays user visibility of non-OS Software Updates. Requires a supervised device.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, delays user visibility of non-OS Software Updates. Requires a supervised device.
-Visibility of Operating System updates is controlled through forceDelayedSoftwareUpdates.
-
-The delay is 30 days unless enforcedSoftwareUpdateDelay is set to another value.
-
+			<string>If 'true', delays user visibility of non-OS Software Updates. Requires a supervised device.
+Visibility of Operating System updates is controlled through 'forceDelayedSoftwareUpdates'.
+The delay is 30 days unless 'enforcedSoftwareUpdateDelay' is set to another value.
 Available in macOS 11 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>11.0</string>
@@ -1332,9 +1265,9 @@ Available in macOS 11 and later.</string>
 			<key>pfm_default</key>
 			<integer>30</integer>
 			<key>pfm_description</key>
-			<string>Number of days the software updates will be hidden from the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. This restriction allows the admin to set how many days a software update on the device will be delayed. With this restriction in place, the user will not see a software update until the specified number of days after the software update release date. The max is 90 days and the default value is 30. Availability: Available in iOS 11.3 and later and macOS 10.13.4 and later.</string>
+			<string>Sets how many days to delay a software update on the device. With this restriction in place, the user doesn't see a software update until the specified number of days after the software update release date. This value is used by 'forceDelayedAppSoftwareUpdates' and 'forceDelayedSoftwareUpdates'.
+Requires a supervised device in iOS and tvOS.
+Available in iOS 11.3 and later, macOS 10.13.4 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1380,7 +1313,8 @@ Available in macOS 11 and later.</string>
 			<key>pfm_default</key>
 			<integer>30</integer>
 			<key>pfm_description</key>
-			<string>Number of days non-OS software updates will be hidden from the user.</string>
+			<string>This restriction allows the admin to set how many days to delay an app software update on the device. When this restriction is in place the user sees a non-OS software update only after the specified delay after the release of the software. This value controls the delay for 'forceDelayedAppSoftwareUpdates'.
+Available in macOS 11.3 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1416,7 +1350,8 @@ Available in macOS 11 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If set to true, delays user visibility of major upgrades to OS Software.
+Available in macOS 11.3 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -1432,7 +1367,8 @@ Available in macOS 11 and later.</string>
 			<key>pfm_default</key>
 			<integer>30</integer>
 			<key>pfm_description</key>
-			<string>Number of days major software updates will be hidden from the user.</string>
+			<string>This restriction allows the admin to set how many days to delay a major software upgrade on the device. When this restriction is in place the user sees a software upgrade only after the specified delay after the release of the software upgrade. This value controls the delay for 'forceDelayedMajorSoftwareUpdates'.
+Available in macOS 11.3 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1468,7 +1404,8 @@ Available in macOS 11 and later.</string>
 			<key>pfm_default</key>
 			<integer>172800</integer>
 			<key>pfm_description</key>
-			<string>Period of time in seconds after which the device will require entry of password or passcode to unlock.</string>
+			<string>The value, in seconds, after which the fingerprint unlock requires a password to authenticate. The default value is 48 hours.
+Available in macOS 12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>tvOS Restrictions preferences</string>
+	<string>Use this section to define restrictions settings</string>
 	<key>pfm_description_reference</key>
 	<string>The Restrictions payload is designated by specifying com.apple.applicationaccess as the PayloadType value. A Restrictions payload allows the administrator to restrict the user from doing certain things with the device, such as using the camera. The Restrictions payload is supported in iOS; some keys are also supported in macOS, as noted below.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_note</key>
 	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
 	<key>pfm_platforms</key>
@@ -30,9 +30,7 @@
 			<key>pfm_default</key>
 			<string>Configures restrictions</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -44,9 +42,7 @@
 			<key>pfm_default</key>
 			<string>Restrictions</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -60,9 +56,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -76,9 +70,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -92,9 +84,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -110,10 +100,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -125,10 +112,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -205,9 +189,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to false, prevents device name from being changed.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to false, prevents device name from being changed. Defaults to true. Availability: Available in iOS 9.0 and tvOS 11.0 and later.</string>
+			<string>If 'false', prevents the user from changing the device name. Requires a supervised device. Available in iOS 9 and later, and tvOS 11.0 and later.</string>
 			<key>pfm_name</key>
 			<string>allowDeviceNameModification</string>
 			<key>pfm_supervised</key>
@@ -223,9 +205,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>If true, enables the Set Automatically feature in Date &amp; Time and can't be disabled by the user.  The device's time zone is updated only when the device can determine its location using a cellular connection or Wi-Fi with location services enabled. Requires a supervised device. Available in iOS 12 and later, and tvOS 12.2 and later.</string>
+			<string>If 'true', enables the Set Automatically feature in Date &amp; Time and can't be disabled by the user.  The device's time zone is updated only when the device can determine its location using a cellular connection or Wi-Fi with location services enabled. Requires a supervised device. Available in iOS 12 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_name</key>
 			<string>forceAutomaticDateAndTime</string>
 			<key>pfm_supervised</key>
@@ -240,6 +220,8 @@ The payload organization for a payload need not match the payload organization i
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'false', disables Apple TV's automatic screen saver. Available in tvOS 15.4 and later.</string>
 			<key>pfm_name</key>
 			<string>allowAutomaticScreenSaver</string>
 			<key>pfm_title</key>
@@ -279,7 +261,8 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>When populated, prevents displaying or launching listed apps. Disabled when using the Allowed Apps preference.</string>
+			<string>If present, prevents bundle IDs listed in the array from being shown or launchable. Include the value 'com.apple.webapp' to restrict all webclips. Note that denying system apps may disable other functionality. For example, denying the App Store app may prevent users from accepting the terms and conditions for user-based VPP.
+Requires a supervised device. Available in iOS 9.3 and later, and tvOS 11.0 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -318,9 +301,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If enabled, cannot use the allowlist to restrict app usage.</string>
-			<key>pfm_description_reference</key>
-			<string>If present, prevents bundle IDs listed in the array from being shown or launchable. Include the value com.apple.webapp to blacklist all webclips. Requires a supervised device. Available in iOS 9.3 and later, and tvOS 11.0 and later. </string>
+			<string>Use blockedAppBundleIDs instead.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -363,7 +344,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>When populated, prevents displaying or launching apps other than the listed ones. Disabled when using the Blocked Apps preference.</string>
+			<string>If present, this property allows only bundle IDs listed in the array to be shown or launchable. Include the value 'com.apple.webapp' to allow all webclips. Requires a supervised device. Available in iOS 9.3 and later, and tvOS 11.0 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -402,9 +383,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If enabled, cannot use the denylist to restrict app usage.</string>
-			<key>pfm_description_reference</key>
-			<string>If present, this property allows only bundle IDs listed in the array to be shown or launchable. Include the value com.apple.webapp to whitelist all webclips. Requires a supervised device. Available in iOS 9.3 and later, and tvOS 11.0 and later.</string>
+			<string>Use 'allowListedAppBundleIDs' instead.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -479,9 +458,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>us</string>
 			<key>pfm_description</key>
-			<string>This 2-letter key is used by profile tools to display the proper ratings for given region. It is not recognized or reported by the client.</string>
-			<key>pfm_description_reference</key>
-			<string>This 2-letter key is used by profile tools to display the proper ratings for given region. It is not recognized or reported by the client. Availability: Available in iOS and tvOS 11.3 and later.</string>
+			<string>The two-letter key that profile tools use to display the proper ratings for the given region. This data isn't recognized or reported by the client.</string>
 			<key>pfm_name</key>
 			<string>ratingRegion</string>
 			<key>pfm_range_list</key>
@@ -519,9 +496,14 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>1000</integer>
 			<key>pfm_description</key>
-			<string>This value defines the maximum level of app content that is allowed on the device. Not all integer values are used in each region. Apple's Configuration Profile documentation includes the values for the US, so you may need to do some sleuthing here.</string>
-			<key>pfm_description_reference</key>
-			<string>This value defines the maximum level of app content that is allowed on the device. Availability: Available only in iOS 5 and tvOS 11.3 and later.</string>
+			<string>The maximum level of app content allowed on the device. Available in iOS 4 and later, and tvOS 11.3 and later.
+Possible values (with the US description of the rating level):
+* 1000: All
+* 600: 17+
+* 300: 12+
+* 200: 9+
+* 100: 4+
+* 0: None</string>
 			<key>pfm_name</key>
 			<string>ratingApps</string>
 			<key>pfm_range_list</key>
@@ -563,9 +545,15 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>1000</integer>
 			<key>pfm_description</key>
-			<string>This value defines the maximum level of movie content that is allowed on the device. Not all integer values are used in each region. Apple's Configuration Profile documentation includes the values for the US, so you may need to do some sleuthing here.</string>
-			<key>pfm_description_reference</key>
-			<string>This value defines the maximum level of movie content that is allowed on the device. Availability: Available only in iOS 5 and tvOS 11.3 and later.</string>
+			<string>The maximum level of movie content allowed on the device. Available in iOS 4 and later, and tvOS 11.3 and later.
+Possible values (with the US description of the rating level):
+* 1000: All
+* 500: NC-17
+* 400: R
+* 300: PG-13
+* 200: PG
+* 100: G
+* 0: None</string>
 			<key>pfm_name</key>
 			<string>ratingMovies</string>
 			<key>pfm_range_list</key>
@@ -607,9 +595,18 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>1000</integer>
 			<key>pfm_description</key>
-			<string>This value defines the maximum level of TV content that is allowed on the device. Not all integer values are used in each region. Apple's Configuration Profile documentation includes the values for the US, so you may need to do some sleuthing here.</string>
-			<key>pfm_description_reference</key>
-			<string>This value defines the maximum level of TV content that is allowed on the device. Availability: Available only in iOS 5 and tvOS 11.3 and later.</string>
+			<string>The maximum level of TV content allowed on the device. Available in iOS 4 and later, and tvOS 11.3 and later.
+
+Possible values (with the US description of the rating level):
+
+* 1000: All
+* 600: TV-MA
+* 500: TV-14
+* 400: TV-PG
+* 300: TV-G
+* 200: TV-Y7
+* 100: TV-Y
+* 0: None</string>
 			<key>pfm_name</key>
 			<string>ratingTVShows</string>
 			<key>pfm_range_list</key>
@@ -651,9 +648,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>When false, explicit music or video content purchased from the iTunes Store is hidden. Explicit content is marked as such by content providers, such as record labels, when sold through the iTunes Store. This key is deprecated on unsupervised devices.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When false, explicit music or video content purchased from the iTunes Store is hidden. Explicit content is marked as such by content providers, such as record labels, when sold through the iTunes Store. This key is deprecated on unsupervised devices. Availability: Available in iOS and in tvOS 11.3 and later.</string>
+			<string>If 'false', hides explicit music or video content purchased from the iTunes Store. Explicit content is marked as such by content providers, such as record labels, when sold through the iTunes Store. As of iOS 13, requires a supervised device. Available in iOS 4 and later, and tvOS 11.3 and later.</string>
 			<key>pfm_name</key>
 			<string>allowExplicitContent</string>
 			<key>pfm_supervised</key>
@@ -669,9 +664,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to false, the user will not be able to download media from Apple Books that has been tagged as erotica.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only prior to iOS 6.1. If set to false, the user will not be able to download media from Apple Books that has been tagged as erotica. This will default to true. Availability: Available in iOS and in tvOS 11.3 and later.</string>
+			<string>If 'false', the user can't download Apple Books media that is tagged as erotica. Available in iOS 6 and later, and tvOS 11.3 and later.</string>
 			<key>pfm_name</key>
 			<string>allowBookstoreErotica</string>
 			<key>pfm_title</key>
@@ -685,9 +678,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>If 'false', disables incoming AirPlay requests. Requires a supervised device. Available in macOS 12.3 and later, and tvOS 10.2 and later.</string>
 			<key>pfm_name</key>
 			<string>allowAirPlayIncomingRequests</string>
 			<key>pfm_supervised</key>
@@ -703,9 +694,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>It is recommended to use the AirPlay Security Payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, forces all devices sending AirPlay requests to this device to use a pairing password. Default is false. Availability: Available only in Apple TV 6.1 to tvOS 10.1. This is not supported as of tvOS 10.2. It is recommended to use the AirPlay Security Payload.</string>
+			<string>If 'true', forces all devices sending AirPlay requests to this device to use a pairing password. Available in Apple TV Software 6.2 and later. This key isn't supported in tvOS 10.2 and later. Use the AirPlay Security Payload instead.</string>
 			<key>pfm_name</key>
 			<string>forceAirPlayIncomingRequestsPairingPassword</string>
 			<key>pfm_note</key>
@@ -723,9 +712,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to false, the Apple TV cannot be paired for use with the Remote app or Control Center widget.</string>
-			<key>pfm_description_reference</key>
-			<string>If set to false, the Apple TV cannot be paired for use with the Remote app or Control Center widget. Defaults to true. Availability: Available in tvOS 10.2 and later.</string>
+			<string>If 'false', disables pairing Apple TV for use with the Remote app or Control Center widget. Requires a supervised device. Available in tvOS 10.2 and later.</string>
 			<key>pfm_name</key>
 			<string>allowRemoteAppPairing</string>
 			<key>pfm_title</key>
@@ -739,9 +726,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If set to false, a user's device will not request passwords from nearby devices.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Supervised only. If set to false, a user's device will not request passwords from nearby devices. Defaults to true. Availability: Available only in iOS 12.0, macOS 10.14, and tvOS 12.0 and later.</string>
+			<string>If 'false', disables requesting passwords from nearby devices. Requires a supervised device. Available in iOS 12 and later, macOS 10.14 and later, and tvOS 12 and later.</string>
 			<key>pfm_name</key>
 			<string>allowPasswordProximityRequests</string>
 			<key>pfm_supervised</key>
@@ -757,9 +742,9 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, delays user visibility of Software Updates.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. If set to true, delays user visibility of Software Updates. Defaults to false. On macOS, seed build updates will be allowed, without delay. Availability: Available in iOS 11.3 and later and macOS 10.13 and later.</string>
+			<string>If 'true', delays user visibility of software updates. In macOS, seed build updates are allowed, without delay. Requires a supervised device in iOS and tvOS.
+The delay is 30 days unless 'enforcedSoftwareUpdateDelay' is set to another value.
+Available in iOS 11.3 and later, macOS 10.13 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_name</key>
 			<string>forceDelayedSoftwareUpdates</string>
 			<key>pfm_supervised</key>
@@ -775,9 +760,9 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>30</integer>
 			<key>pfm_description</key>
-			<string>Number of days the software updates will be hidden from the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Supervised only. This restriction allows the admin to set how many days a software update on the device will be delayed. With this restriction in place, the user will not see a software update until the specified number of days after the software update release date. The max is 90 days and the default value is 30. Availability: Available in iOS 11.3 and later and macOS 10.13.4 and later.</string>
+			<string>Sets how many days to delay a software update on the device. With this restriction in place, the user doesn't see a software update until the specified number of days after the software update release date. This value is used by 'forceDelayedAppSoftwareUpdates' and 'forceDelayedSoftwareUpdates'.
+Requires a supervised device in iOS and tvOS.
+Available in iOS 11.3 and later, macOS 10.13.4 and later, and tvOS 12.2 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess.new.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess.new.plist
@@ -22,7 +22,7 @@ To determine if an application can be launched, these rules are evaluated:
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-13T03:14:13Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -33,9 +33,7 @@ To determine if an application can be launched, these rules are evaluated:
 			<key>pfm_default</key>
 			<string>Parental Controls: Application Access</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -47,9 +45,7 @@ To determine if an application can be launched, these rules are evaluated:
 			<key>pfm_default</key>
 			<string>Parental Controls: Application Access</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -63,9 +59,7 @@ To determine if an application can be launched, these rules are evaluated:
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess.new</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -79,9 +73,7 @@ To determine if an application can be launched, these rules are evaluated:
 			<key>pfm_default</key>
 			<string>com.apple.applicationaccess.new</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -95,9 +87,7 @@ To determine if an application can be launched, these rules are evaluated:
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -113,10 +103,7 @@ To determine if an application can be launched, these rules are evaluated:
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -128,10 +115,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -141,9 +125,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to true to enable application access restrictions.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Set to true to enable application access restrictions.</string>
+			<string>If 'true', enables app access restrictions.</string>
 			<key>pfm_name</key>
 			<string>familyControlsEnabled</string>
 			<key>pfm_require</key>
@@ -159,9 +141,7 @@ The payload organization for a payload need not match the payload organization i
 				<string>com.apple.application-bundle</string>
 			</array>
 			<key>pfm_description</key>
-			<string>List of code signatures for applications that are allowed to run.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A list of code signatures for applications that are allowed to run.</string>
+			<string>The allow list of app item dictionaries.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -191,9 +171,7 @@ The payload organization for a payload need not match the payload organization i
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>Bundle ID of application.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. Bundle ID of application.</string>
+							<string>The bundle ID of the app.</string>
 							<key>pfm_name</key>
 							<string>bundleID</string>
 							<key>pfm_require</key>
@@ -205,9 +183,7 @@ The payload organization for a payload need not match the payload organization i
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>Display name of the application.</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. Display name.</string>
+							<string>The name used for display purposes.</string>
 							<key>pfm_name</key>
 							<string>displayName</string>
 							<key>pfm_title</key>
@@ -217,9 +193,7 @@ The payload organization for a payload need not match the payload organization i
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The designated requirement describing the code signature of this executable.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. The designated requirement describing the code signature of this executable. This value is obtained from the Security.framework using SecCodeCopyDesignatedRequirement.</string>
+							<string>The identifier of the app. Obtain this value from the Security framework using SecCodeCopyDesignatedRequirement.</string>
 							<key>pfm_name</key>
 							<string>appID</string>
 							<key>pfm_require</key>
@@ -235,9 +209,7 @@ The payload organization for a payload need not match the payload organization i
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>For applications that include nested helper applications, describes the signatures of embedded applications.</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. For applications that include nested helper applications, describes the signatures of embedded applications. The dictionary format is the same as for the whiteList key.</string>
+							<string>An array of nested helper applications.</string>
 							<key>pfm_hidden</key>
 							<string>all</string>
 							<key>pfm_name</key>
@@ -331,9 +303,7 @@ Default is false.</string>
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The required signature for an unsigned binary</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. Can be used to provide the required signature for an unsigned binary. Generate an ad-hoc signature of the unsigned binary and store the signature here.</string>
+							<string>The signature for an unsigned binary.</string>
 							<key>pfm_hidden</key>
 							<string>all</string>
 							<key>pfm_name</key>
@@ -359,10 +329,7 @@ Default is false.</string>
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>Specifies whether this application information is to be included in the allowlist or not.</string>
-							<key>pfm_description_reference</key>
-							<string>Optional. Specifies whether this application information is to be included in the whiteList or not. Set to true to keep the application off the whiteList. It could still be allowed to launch via pathWhiteList, although this behavior is discouraged.
-Default is false.</string>
+							<string>If 'true', this app isn't added to the allow list.</string>
 							<key>pfm_name</key>
 							<string>disabled</string>
 							<key>pfm_title</key>
@@ -390,9 +357,7 @@ Default is false.</string>
 				<string>public.folder</string>
 			</array>
 			<key>pfm_description</key>
-			<string>The user can always launch applications in these folders.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Paths to allowed applications.</string>
+			<string>The paths to apps in the allow list. This property is deprecated in macOS 10.15 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -417,7 +382,7 @@ Default is false.</string>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The absolute path to a folder to allowlist.</string>
+					<string>A path.</string>
 					<key>pfm_name</key>
 					<string>pathWhiteListItem</string>
 					<key>pfm_title</key>
@@ -441,9 +406,7 @@ Default is false.</string>
 				<string>public.folder</string>
 			</array>
 			<key>pfm_description</key>
-			<string>The user can never launch applications in these folders.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Paths to disallowed applications.</string>
+			<string>The paths to apps in the deny list. This property is deprecated in macOS 10.15 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -468,7 +431,7 @@ Default is false.</string>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The absolute path to a folder to denylist.</string>
+					<string>A path.</string>
 					<key>pfm_name</key>
 					<string>pathBlackListItem</string>
 					<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.appstore.plist
+++ b/Manifests/ManifestsApple/com.apple.appstore.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -26,9 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures App Store settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@
 			<key>pfm_default</key>
 			<string>App Store settings</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.appstore</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.appstore</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,10 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -136,9 +120,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Restrict app installations to admin users</string>
-			<key>pfm_description_reference</key>
-			<string>If true, restricts app installations to admin users only. Deprecated in macOS 10.14. Use the com.apple.SoftwareUpdate payload key restrict-software-update-require-admin-to-install as a replacement.</string>
+			<string>If 'true', restricts app installations to admin users only. Deprecated in macOS 10.14. Use the 'com.apple.SoftwareUpdate' payload key 'restrict-software-update-require-admin-to-install' as a replacement.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>10.14</string>
 			<key>pfm_macos_min</key>
@@ -154,9 +136,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Restrict app installations to software updates only</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Restrict app installations to software updates only. Available on macOS 10.10 and later.</string>
+			<string>If 'true', prevents App Store from launching. Available in macOS 10.14 and later. Restricts installations to software updates only in macOS 10.10 - 10.13.</string>
 			<key>pfm_macos_min</key>
 			<string>10.10</string>
 			<key>pfm_name</key>
@@ -170,9 +150,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Disable App Adoption by users</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Disable App Adoption by users. Available on macOS 10.10 and later.</string>
+			<string>If 'true', disables app adoption by users. Available in macOS 10.10 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.10</string>
 			<key>pfm_name</key>
@@ -186,9 +164,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Disable software update notifications</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Disable software update notifications. Available on macOS 10.10 and later.</string>
+			<string>If 'true', disables software update notifications. Available in macOS 10.10 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.10</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.asam.plist
+++ b/Manifests/ManifestsApple/com.apple.asam.plist
@@ -17,7 +17,7 @@ To be granted access, applications must be signed with the specified bundle iden
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.4</string>
 	<key>pfm_note</key>
@@ -32,9 +32,7 @@ To be granted access, applications must be signed with the specified bundle iden
 			<key>pfm_default</key>
 			<string>Configures Autonomous Single App Mode settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -46,9 +44,7 @@ To be granted access, applications must be signed with the specified bundle iden
 			<key>pfm_default</key>
 			<string>Autonomous Single App Mode</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -62,9 +58,7 @@ To be granted access, applications must be signed with the specified bundle iden
 			<key>pfm_default</key>
 			<string>com.apple.asam</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -78,9 +72,7 @@ To be granted access, applications must be signed with the specified bundle iden
 			<key>pfm_default</key>
 			<string>com.apple.asam</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -94,9 +86,7 @@ To be granted access, applications must be signed with the specified bundle iden
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -112,10 +102,7 @@ To be granted access, applications must be signed with the specified bundle iden
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -127,10 +114,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -140,9 +124,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Array of dictionaries that specify applications that are to be granted access to Assessment APIs.</string>
-			<key>pfm_description_reference</key>
-			<string>Array of dictionaries that specify applications that are to be granted access to Assessment APIs.</string>
+			<string>An array of dictionaries that specifies the apps that can be granted access to the Accessibility APIs.</string>
 			<key>pfm_name</key>
 			<string>AllowedApplications</string>
 			<key>pfm_subkeys</key>
@@ -156,9 +138,7 @@ The payload organization for a payload need not match the payload organization i
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>The application's bundle identifier. BundleIdentifier must be unique. If two dictionaries contain the same BundleIdentifier but different TeamIdentifiers, this will be considered a hard error and the payload will not be installed.</string>
-							<key>pfm_description_reference</key>
-							<string>The applicationʼs bundle identifier. BundleIdentifier must be unique. If two dictionaries contain the same BundleIdentifier but different TeamIdentifiers, this will be considered a hard error and the payload will not be installed.</string>
+							<string>The unique bundle identifier. If two dictionaries contain the same 'BundleIdentifier' value but a different 'TeamIdentifier' value, this will be considered an error and the profile won't be installed.</string>
 							<key>pfm_name</key>
 							<string>BundleIdentifier</string>
 							<key>pfm_title</key>
@@ -170,9 +150,7 @@ The payload organization for a payload need not match the payload organization i
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The application's team identifier.</string>
-							<key>pfm_description_reference</key>
-							<string>The developerʼs team identifier used to sign the application.</string>
+							<string>The developer's team identifier, used when the app was signed.</string>
 							<key>pfm_name</key>
 							<string>TeamIdentifier</string>
 							<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.associated-domains.plist
+++ b/Manifests/ManifestsApple/com.apple.associated-domains.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Use this section to define settings for Associated Domains to be used with features such as Extensible AppSSO, universal links and Password AutoFill.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Associated Domains</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.associated-domains</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.associated-domains</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,9 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -116,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -151,7 +139,7 @@
 						<dict>
 							<key>pfm_description</key>
 							<string>The domains to be associated with the app. Each string is in the form of ''service:domain''. Domains should be fully qualified hostnames, like 'www.example.com'.
-See Supporting Associated Domains for more information.</string>
+See Supporting associated domains for more information.</string>
 							<key>pfm_name</key>
 							<string>AssociatedDomains</string>
 							<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.caldav.account.plist
+++ b/Manifests/ManifestsApple/com.apple.caldav.account.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Calendar settings</string>
+	<string>Use this section to define settings for configuration access to CalDAV servers.</string>
 	<key>pfm_description_reference</key>
 	<string>The payload is designated by specifying com.apple.caldav.account as the PayloadType. This payload configures a CalDAV account.</string>
 	<key>pfm_domain</key>
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -25,9 +25,7 @@
 			<key>pfm_default</key>
 			<string>Configures a Calendar account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,9 +37,7 @@
 			<key>pfm_default</key>
 			<string>Calendar</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,9 +51,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.caldav.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -71,9 +65,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.caldav.account</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -87,9 +79,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -105,10 +95,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +107,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -135,9 +119,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>My Calendar Account</string>
 			<key>pfm_description</key>
-			<string>The display name of the account (e.g. "Company Calendar Account")</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The description of the account.</string>
+			<string>The description of the account.</string>
 			<key>pfm_name</key>
 			<string>CalDAVAccountDescription</string>
 			<key>pfm_title</key>
@@ -147,10 +129,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the CalDAV server.</string>
-			<key>pfm_description_reference</key>
-			<string>The server address.
-In macOS, this key is required.</string>
+			<string>The server's address.</string>
 			<key>pfm_name</key>
 			<string>CalDAVHostName</string>
 			<key>pfm_require</key>
@@ -164,9 +143,7 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<integer>443</integer>
 			<key>pfm_description</key>
-			<string>The port on which to connect to the CalDAV server.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The port on which to connect to the server.</string>
+			<string>The server's port.</string>
 			<key>pfm_name</key>
 			<string>CalDAVPort</string>
 			<key>pfm_range_max</key>
@@ -180,9 +157,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The base URL to the user's calendar. In macOS this URL is required if the user doesn't provide a password, because auto-discovery of the service will fail and the account won't be created.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The base URL to the user's calendar. In macOS this URL is required if the user doesn't provide a password, because auto-discovery of the service will fail and the account won't be created.</string>
+			<string>The base URL to the user's calendar.</string>
 			<key>pfm_name</key>
 			<string>CalDAVPrincipalURL</string>
 			<key>pfm_title</key>
@@ -208,10 +183,8 @@ In macOS, this key is required.</string>
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The user name for the CalDAV account.</string>
-			<key>pfm_description_reference</key>
-			<string>The user's login name.
-In macOS, this key is required.</string>
+			<string>The user name for logins.
+If this profile part of a non-interactive install, this field is required.</string>
 			<key>pfm_name</key>
 			<string>CalDAVUsername</string>
 			<key>pfm_require</key>
@@ -223,9 +196,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The CalDAV password</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The user's password.</string>
+			<string>The user's password. This is only used with encrypted profiles.</string>
 			<key>pfm_name</key>
 			<string>CalDAVPassword</string>
 			<key>pfm_sensitive</key>
@@ -239,10 +210,7 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enable Secure Socket Layer communication with CalDAV server</string>
-			<key>pfm_description_reference</key>
-			<string>Whether or not to use SSL.
-In macOS, this key is optional.</string>
+			<string>If 'true', enables SSL.</string>
 			<key>pfm_name</key>
 			<string>CalDAVUseSSL</string>
 			<key>pfm_note</key>

--- a/Manifests/ManifestsApple/com.apple.carddav.account.plist
+++ b/Manifests/ManifestsApple/com.apple.carddav.account.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Use the Contacts payload to provide account settings for connecting to a CardDAV-compliant contact server. If you omit the account information, users need to enter it manually when the profile is installed.</string>
+	<string>Use this section to define settings for configuration access to CardDAV servers.</string>
 	<key>pfm_description_reference</key>
 	<string>The CardDAV payload is designated by specifying com.apple.carddav.account as the PayloadType value. As of macOS v10.8 and later, this payload type supports obtaining CardDAVUsername and CardDAVPassword from
 an Identification Payload, if present.</string>
@@ -14,7 +14,7 @@ an Identification Payload, if present.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:32Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -26,9 +26,7 @@ an Identification Payload, if present.</string>
 			<key>pfm_default</key>
 			<string>Configures a Contacts account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@ an Identification Payload, if present.</string>
 			<key>pfm_default</key>
 			<string>Contacts</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@ an Identification Payload, if present.</string>
 			<key>pfm_default</key>
 			<string>com.apple.carddav.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@ an Identification Payload, if present.</string>
 			<key>pfm_default</key>
 			<string>com.apple.carddav.account</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@ an Identification Payload, if present.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@ an Identification Payload, if present.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,10 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -136,9 +120,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>My Contacts Account</string>
 			<key>pfm_description</key>
-			<string>The display name of the account (e.g. "Company Contacts Account")</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The description of the account.</string>
+			<string>The description of the account.</string>
 			<key>pfm_name</key>
 			<string>CardDAVAccountDescription</string>
 			<key>pfm_title</key>
@@ -148,9 +130,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the CardDAV server.</string>
-			<key>pfm_description_reference</key>
-			<string>The server address.</string>
+			<string>The server's address.</string>
 			<key>pfm_name</key>
 			<string>CardDAVHostName</string>
 			<key>pfm_require</key>
@@ -164,9 +144,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>443</integer>
 			<key>pfm_description</key>
-			<string>The port on which to connect to the CardDAV server.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The port on which to connect to the server.</string>
+			<string>The server's port.</string>
 			<key>pfm_name</key>
 			<string>CardDAVPort</string>
 			<key>pfm_range_max</key>
@@ -180,9 +158,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The Principal URL for the CardDAV account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Not supported on macOS. The base URL to the userʼs address book.</string>
+			<string>The base URL to the user's address book.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -222,9 +198,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The CardDAV username</string>
-			<key>pfm_description_reference</key>
-			<string>The userʼs login name.</string>
+			<string>The user name for logins.</string>
 			<key>pfm_name</key>
 			<string>CardDAVUsername</string>
 			<key>pfm_require</key>
@@ -236,9 +210,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The CardDAV password</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The userʼs password.</string>
+			<string>The user's password.</string>
 			<key>pfm_name</key>
 			<string>CardDAVPassword</string>
 			<key>pfm_sensitive</key>
@@ -252,9 +224,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enable Secure Socket Layer communication with CardDAV server</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Whether or not to use SSL.</string>
+			<string>If 'true', enables SSL.</string>
 			<key>pfm_name</key>
 			<string>CardDAVUseSSL</string>
 			<key>pfm_title</key>
@@ -264,9 +234,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The communication service handler rules for this account.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>An array of communication service rules for this account.</string>
 			<key>pfm_documentation_source</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -275,7 +243,7 @@ The payload organization for a payload need not match the payload organization i
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A dictionary of service handlers for contacts from this account.</string>
 					<key>pfm_name</key>
 					<string>DefaultServiceHandlers</string>
 					<key>pfm_required</key>
@@ -284,7 +252,7 @@ The payload organization for a payload need not match the payload organization i
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>Bundle identifier for the default application that handles audio calls made to contacts from this account</string>
+							<string>A string containing the bundle identifier for the default application that handles audio calls made to contacts from this account.</string>
 							<key>pfm_name</key>
 							<string>AudioCall</string>
 							<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.cellular.plist
+++ b/Manifests/ManifestsApple/com.apple.cellular.plist
@@ -21,7 +21,7 @@ This payload replaces the com.apple.managedCarrier payload, which is supported, 
 	<key>pfm_ios_min</key>
 	<string>7.0</string>
 	<key>pfm_last_modified</key>
-	<date>2022-08-31T02:01:52Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -32,9 +32,7 @@ This payload replaces the com.apple.managedCarrier payload, which is supported, 
 			<key>pfm_default</key>
 			<string>Configures cellular data settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -46,9 +44,7 @@ This payload replaces the com.apple.managedCarrier payload, which is supported, 
 			<key>pfm_default</key>
 			<string>Cellular</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -62,9 +58,7 @@ This payload replaces the com.apple.managedCarrier payload, which is supported, 
 			<key>pfm_default</key>
 			<string>com.apple.cellular</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -78,9 +72,7 @@ This payload replaces the com.apple.managedCarrier payload, which is supported, 
 			<key>pfm_default</key>
 			<string>com.apple.cellular</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -94,9 +86,7 @@ This payload replaces the com.apple.managedCarrier payload, which is supported, 
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -112,10 +102,7 @@ This payload replaces the com.apple.managedCarrier payload, which is supported, 
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -127,10 +114,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -140,9 +124,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of Data APNs to configure</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An array of APN dictionaries, described below. Only the first entry is currently used.</string>
+			<string>An array of access point dictionaries.</string>
 			<key>pfm_name</key>
 			<string>APNs</string>
 			<key>pfm_range_max</key>
@@ -372,18 +354,14 @@ Availability: Available in iOS 10.3 and later.</string>
 			<key>pfm_default</key>
 			<dict/>
 			<key>pfm_description</key>
-			<string>Default APN configuration</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An AttachAPN configuration dictionary, described below.</string>
+			<string>A configuration dictionary.</string>
 			<key>pfm_name</key>
 			<string>AttachAPN</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The name of the default APN.</string>
-					<key>pfm_description_reference</key>
-					<string>Required. The Access Point Name.</string>
+					<string>The name for this configuration.</string>
 					<key>pfm_name</key>
 					<string>Name</string>
 					<key>pfm_require</key>
@@ -397,9 +375,7 @@ Availability: Available in iOS 10.3 and later.</string>
 					<key>pfm_default</key>
 					<string>PAP</string>
 					<key>pfm_description</key>
-					<string>Authentication type to use for the connection.</string>
-					<key>pfm_description_reference</key>
-					<string>Optional. Must contain either CHAP or PAP. Defaults to PAP.</string>
+					<string>The authentication type.</string>
 					<key>pfm_name</key>
 					<string>AuthenticationType</string>
 					<key>pfm_range_list</key>
@@ -414,9 +390,7 @@ Availability: Available in iOS 10.3 and later.</string>
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The user name for the default APN account.</string>
-					<key>pfm_description_reference</key>
-					<string>Optional. A user name used for authentication.</string>
+					<string>The user name for the APN.</string>
 					<key>pfm_name</key>
 					<string>Username</string>
 					<key>pfm_title</key>
@@ -426,9 +400,7 @@ Availability: Available in iOS 10.3 and later.</string>
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The password for the default APN account.</string>
-					<key>pfm_description_reference</key>
-					<string>Optional. A password used for authentication.</string>
+					<string>The password for the APN.</string>
 					<key>pfm_name</key>
 					<string>Password</string>
 					<key>pfm_sensitive</key>
@@ -440,9 +412,10 @@ Availability: Available in iOS 10.3 and later.</string>
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Supported Internet Protocol versions for connections</string>
-					<key>pfm_description_reference</key>
-					<string></string>
+					<string>The supported Internet Protocol versions. Possible values are:
+1 = IPv4
+2 = IPv6
+3 = Both</string>
 					<key>pfm_documentation_source</key>
 					<string></string>
 					<key>pfm_ios_min</key>

--- a/Manifests/ManifestsApple/com.apple.cellularprivatenetwork.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.cellularprivatenetwork.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>17.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Cellular Private Network Settings and Device Configuration</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Cellular Private Network</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.cellularprivatenetwork.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.cellularprivatenetwork.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,9 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -116,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.conferenceroomdisplay.plist
+++ b/Manifests/ManifestsApple/com.apple.conferenceroomdisplay.plist
@@ -14,7 +14,7 @@ It configures an Apple TV to enter Conference Room Display mode and restricts ex
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_note</key>
 	<string>When Conference Room Display mode and Single App mode are both enabled, Conference Room Display mode is active and the user canʼt access the app.</string>
 	<key>pfm_platforms</key>
@@ -27,9 +27,7 @@ It configures an Apple TV to enter Conference Room Display mode and restricts ex
 			<key>pfm_default</key>
 			<string>Configures Conference Room Display mode</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -41,9 +39,7 @@ It configures an Apple TV to enter Conference Room Display mode and restricts ex
 			<key>pfm_default</key>
 			<string>Conference Room Display</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -57,9 +53,7 @@ It configures an Apple TV to enter Conference Room Display mode and restricts ex
 			<key>pfm_default</key>
 			<string>com.apple.conferenceroomdisplay</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -73,9 +67,7 @@ It configures an Apple TV to enter Conference Room Display mode and restricts ex
 			<key>pfm_default</key>
 			<string>com.apple.conferenceroomdisplay</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -89,9 +81,7 @@ It configures an Apple TV to enter Conference Room Display mode and restricts ex
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -107,10 +97,7 @@ It configures an Apple TV to enter Conference Room Display mode and restricts ex
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -122,10 +109,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -135,9 +119,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A custom message displayed on the screen in Conference Room Display mode.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A custom message displayed on the screen in Conference Room Display mode.</string>
+			<string>The custom message displayed on the screen in Conference Room Display mode.</string>
 			<key>pfm_name</key>
 			<string>Message</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.configurationprofile.identification.plist
+++ b/Manifests/ManifestsApple/com.apple.configurationprofile.identification.plist
@@ -15,7 +15,7 @@ The Identification payload is not supported in iOS.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:50Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@ The Identification payload is not supported in iOS.</string>
 			<key>pfm_default</key>
 			<string>Configures Identification settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@ The Identification payload is not supported in iOS.</string>
 			<key>pfm_default</key>
 			<string>Identification</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@ The Identification payload is not supported in iOS.</string>
 			<key>pfm_default</key>
 			<string>com.apple.configurationprofile.identification</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@ The Identification payload is not supported in iOS.</string>
 			<key>pfm_default</key>
 			<string>com.apple.configurationprofile.identification</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@ The Identification payload is not supported in iOS.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@ The Identification payload is not supported in iOS.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -136,18 +120,14 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>The dictionary containing details about the user.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentification</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The full name of the designated accounts.</string>
-					<key>pfm_description_reference</key>
-					<string>The full name of the designated accounts.</string>
+					<string>The full name of the account.</string>
 					<key>pfm_name</key>
 					<string>FullName</string>
 					<key>pfm_require</key>
@@ -159,9 +139,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The address for the accounts.</string>
-					<key>pfm_description_reference</key>
-					<string>The address for the accounts.</string>
+					<string>The address for the account.</string>
 					<key>pfm_name</key>
 					<string>EmailAddress</string>
 					<key>pfm_require</key>
@@ -174,8 +152,6 @@ The payload organization for a payload need not match the payload organization i
 				<dict>
 					<key>pfm_description</key>
 					<string>The UNIX user name for the accounts.</string>
-					<key>pfm_description_reference</key>
-					<string>The UNIX user name for the accounts.</string>
 					<key>pfm_name</key>
 					<string>UserName</string>
 					<key>pfm_require</key>
@@ -187,9 +163,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>You can provide the password or choose to have the user provide it when he or she installs the profile.</string>
-					<key>pfm_description_reference</key>
-					<string>You can provide the password or choose to have the user provide it when he or she installs the profile.</string>
+					<string>The password for the account. Required when the 'AuthMethod' is of type 'password'.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -219,9 +193,7 @@ The payload organization for a payload need not match the payload organization i
 					<key>pfm_default</key>
 					<string>UserEnteredPassword</string>
 					<key>pfm_description</key>
-					<string>Allow the user to enter the password upon installation instead of being supplied in the payload</string>
-					<key>pfm_description_reference</key>
-					<string></string>
+					<string>The authorization method. Either the password is supplied in the profile or the user supplies it.</string>
 					<key>pfm_documentation_source</key>
 					<string></string>
 					<key>pfm_exclude</key>
@@ -252,9 +224,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Short prompt text</string>
-					<key>pfm_description_reference</key>
-					<string>Custom instruction for the user, if needed.</string>
+					<string>The custom instructions for the user, if needed.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -278,9 +248,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Additional prompt description.</string>
-					<key>pfm_description_reference</key>
-					<string></string>
+					<string>The additional descriptive text for the user prompt.</string>
 					<key>pfm_documentation_source</key>
 					<string></string>
 					<key>pfm_exclude</key>

--- a/Manifests/ManifestsApple/com.apple.dashboard.plist
+++ b/Manifests/ManifestsApple/com.apple.dashboard.plist
@@ -14,7 +14,7 @@ It is used to define a white list of dashboard widgets.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -25,9 +25,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_default</key>
 			<string>Parental Controls: Dashboard settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,9 +37,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_default</key>
 			<string>Parental Controls: Dashboard</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,9 +51,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_default</key>
 			<string>com.apple.dashboard</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -71,9 +65,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_default</key>
 			<string>com.apple.dashboard</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -87,9 +79,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -105,10 +95,7 @@ It is used to define a white list of dashboard widgets.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +107,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -133,9 +117,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to true to enable the widget white list items.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Set to true to enable the widget white list items.</string>
+			<string>If 'true', enables the widget allow list.</string>
 			<key>pfm_name</key>
 			<string>whiteListEnabled</string>
 			<key>pfm_require</key>
@@ -151,9 +133,7 @@ The payload organization for a payload need not match the payload organization i
 				<string>com.apple.dashboard-widget</string>
 			</array>
 			<key>pfm_description</key>
-			<string>List that defines Dashboard widgets.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. List that defines Dashboard widgets.</string>
+			<string>An array of widget item dictionaries that are allowed.</string>
 			<key>pfm_name</key>
 			<string>WhiteList</string>
 			<key>pfm_require</key>
@@ -169,9 +149,7 @@ The payload organization for a payload need not match the payload organization i
 							<key>pfm_default</key>
 							<string>bundleID</string>
 							<key>pfm_description</key>
-							<string>Set to "bundleID" to use a widget's bundle ID as its ID.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. Set to bundleID to use a widget's bundle ID as its ID.</string>
+							<string>The type of allow list item. Set to 'bundleID' to use a widget's bundle ID as its main ID.</string>
 							<key>pfm_hidden</key>
 							<string>all</string>
 							<key>pfm_name</key>
@@ -194,8 +172,6 @@ The payload organization for a payload need not match the payload organization i
 						<dict>
 							<key>pfm_description</key>
 							<string>The bundle ID of a widget.</string>
-							<key>pfm_description_reference</key>
-							<string>Required. The bundle ID of a widget.</string>
 							<key>pfm_name</key>
 							<string>ID</string>
 							<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.declarations.plist
+++ b/Manifests/ManifestsApple/com.apple.declarations.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>17.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>14.0</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Declarations</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>Declarations</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.declarations</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.declarations</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,9 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.desktop.plist
+++ b/Manifests/ManifestsApple/com.apple.desktop.plist
@@ -15,7 +15,7 @@ This payload sets up macOS Desktop settings and restrictions. It is supported on
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-05-03T15:38:44Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.10</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@ This payload sets up macOS Desktop settings and restrictions. It is supported on
 			<key>pfm_default</key>
 			<string>Desktop Picture settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@ This payload sets up macOS Desktop settings and restrictions. It is supported on
 			<key>pfm_default</key>
 			<string>Desktop Picture</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@ This payload sets up macOS Desktop settings and restrictions. It is supported on
 			<key>pfm_default</key>
 			<string>com.apple.desktop</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@ This payload sets up macOS Desktop settings and restrictions. It is supported on
 			<key>pfm_default</key>
 			<string>com.apple.desktop</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@ This payload sets up macOS Desktop settings and restrictions. It is supported on
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@ This payload sets up macOS Desktop settings and restrictions. It is supported on
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -138,9 +122,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevents users from modifying the desktop picture selection.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the desktop picture is locked. Default is false.</string>
+			<string>If 'true', locks the desktop picture. Replaced with allowWallpaperModification in macOS 10.13.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -152,9 +134,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The path of the file to use as the desktop picture.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If supplied, it sets the path to the desktop picture.</string>
+			<string>The path to the desktop picture. If set, this picture is always locked.</string>
 			<key>pfm_name</key>
 			<string>override-picture-path</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.dnsProxy.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.dnsProxy.managed.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>DNS Proxy settings</string>
+	<string>Use this section to configure a DNS proxy network extension</string>
 	<key>pfm_documentation_url</key>
 	<string>https://developer.apple.com/documentation/devicemanagement/dnsproxy</string>
 	<key>pfm_domain</key>
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>11.0</string>
 	<key>pfm_last_modified</key>
-	<date>2022-11-02T09:42:39Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -29,9 +29,7 @@
 			<key>pfm_default</key>
 			<string>Configures DNS Proxy settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -43,9 +41,7 @@
 			<key>pfm_default</key>
 			<string>DNS Proxy</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -59,9 +55,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.dnsProxy.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -75,9 +69,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.dnsProxy.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -91,9 +83,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -109,10 +99,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -124,10 +111,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -137,9 +121,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Bundle ID of the app containing the DNS proxy network extension.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Bundle identifer of the app containing the DNS proxy network extension.</string>
+			<string>The bundle identifier of the app containing the DNS proxy network extension.</string>
 			<key>pfm_name</key>
 			<string>AppBundleIdentifier</string>
 			<key>pfm_require</key>
@@ -151,9 +133,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Bundle ID of the DNS proxy network extension to use.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Bundle identifier of the DNS proxy network extension to use. Useful for apps that contain more than one DNS proxy extension.</string>
+			<string>The bundle identifier of the DNS proxy network extension to use. Declaring the bundle identifier is useful for apps that contain more than one DNS proxy extension.</string>
 			<key>pfm_name</key>
 			<string>ProviderBundleIdentifier</string>
 			<key>pfm_title</key>
@@ -167,9 +147,7 @@ The payload organization for a payload need not match the payload organization i
 				<string>com.apple.property-list</string>
 			</array>
 			<key>pfm_description</key>
-			<string>A plist formatted dictionary of custom options.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Dictionary of vendor-specific configuration items.</string>
+			<string>The dictionary of vendor-specific configuration items.</string>
 			<key>pfm_name</key>
 			<string>ProviderConfiguration</string>
 			<key>pfm_title</key>
@@ -183,7 +161,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Global identifier of the proxy configuration in this payload. Used for processing DNS requests of managed apps with an identical attribute by the proxy.</string>
+			<string>A globally-unique identifier for this DNS proxy configuration. Managed apps with the same 'DNSProxyUUID' in their app attributes have their DNS lookups traffic processed by the proxy.</string>
 			<key>pfm_ios_min</key>
 			<string>16.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>DNS Settings</string>
+	<string>Use this section to configure DNS settings.</string>
 	<key>pfm_description_reference</key>
 	<string>The DNS Settings payload is designated by specifying com.apple.dnsSettings.managed as the PayloadType.</string>
 	<key>pfm_documentation_url</key>
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>14.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_platforms</key>
@@ -31,9 +31,7 @@
 			<key>pfm_default</key>
 			<string>Configures DNS Settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -45,9 +43,7 @@
 			<key>pfm_default</key>
 			<string>DNS Settings</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -61,9 +57,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.dnsSettings.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -77,9 +71,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.dnsSettings.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -93,9 +85,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -111,10 +101,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -126,10 +113,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -200,7 +184,7 @@ The payload organization for a payload need not match the payload organization i
 						</dict>
 					</array>
 					<key>pfm_description</key>
-					<string>The hostname of a DNS-over-TLS server used to validate the server certificate, as defined in RFC 7858. If no ServerAddresses are provided, the hostname will be used to determine the server addresses.</string>
+					<string>The hostname of a DNS-over-TLS server used to validate the server certificate, as defined in RFC 7858. If no 'ServerAddresses' are provided, the hostname will be used to determine the server addresses. This key must be present only if the DNSProtocol is 'TLS'.</string>
 					<key>pfm_name</key>
 					<string>ServerName</string>
 					<key>pfm_note</key>
@@ -228,9 +212,7 @@ The payload organization for a payload need not match the payload organization i
 						</dict>
 					</array>
 					<key>pfm_description</key>
-					<string>The URI template of a DNS-over-HTTPS server, as defined in RFC 8484. This URL must use the https:// scheme, and the hostname or address in the URL will be used to validate the server certificate</string>
-					<key>pfm_description_reference</key>
-					<string>The URI template of a DNS-over-HTTPS server, as defined in RFC 8484. This URL must use the https:// scheme, and the hostname or address in the URL will be used to validate the server certificate. If no ServerAddresses are provided, the hostname or address in the URL will be used to determine the server addresses. This key must be present only if the DNSProtocol is HTTPS.</string>
+					<string>The URI template of a DNS-over-HTTPS server, as defined in RFC 8484. This URL must use the 'https://' scheme, and the hostname or address in the URL will be used to validate the server certificate. If no 'ServerAddresses' are provided, the hostname or address in the URL will be used to determine the server addresses. This key must be present only if the 'DNSProtocol' is 'HTTPS'.</string>
 					<key>pfm_format</key>
 					<string>^https://.*</string>
 					<key>pfm_name</key>
@@ -246,11 +228,8 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>A list of domain strings used to determine which DNS queries will use the DNS server. If this array is not provided, all domains will use the DNS server. A single wildcard * prefix is supported, but is not required.</string>
-					<key>pfm_description_reference</key>
 					<string>A list of domain strings used to determine which DNS queries will use the DNS server. If this array is not provided, all domains will use the DNS server.
-
-A single wildcard * prefix is supported, but is not required. For example, both *.example.com and example.com match against mydomain.example.com and your.domain.example.com, but do not match against mydomain-example.com.</string>
+A single wildcard '*' prefix is supported, but is not required. For example, both '*.example.com' and 'example.com' match against 'mydomain.example.com' and 'your.domain.example.com', but do not match against 'mydomain-example.com'.</string>
 					<key>pfm_name</key>
 					<string>SupplementalMatchDomains</string>
 					<key>pfm_subkeys</key>
@@ -277,7 +256,7 @@ A single wildcard * prefix is supported, but is not required. For example, both 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An array of rules defining the DNS settings. If rules are not present, the system always applies the DNS settings. These rules are identical to the OnDemandRules array in VPN payloads.</string>
+			<string>An array of rules defining the DNS settings. If rules aren't present, the system always applies the DNS settings. These rules are identical to the 'OnDemandRules' array in VPN payloads.</string>
 			<key>pfm_name</key>
 			<string>OnDemandRules</string>
 			<key>pfm_subkeys</key>
@@ -289,10 +268,10 @@ A single wildcard * prefix is supported, but is not required. For example, both 
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>The action to take if this dictionary matches the current network. Options:
-Connect: Apply DNS Settings when the dictionary matches.
-Disconnect: Do not apply DNS Settings when the dictionary matches.
-EvaluateConnection: Apply DNS Settings with per-domain exceptions when the dictionary matches.</string>
+							<string>The action to take if this dictionary matches the current network. Possible values are:
+* 'Connect': Apply DNS Settings when the dictionary matches.
+* 'Disconnect': Do not apply DNS Settings when the dictionary matches.
+* 'EvaluateConnection': Apply DNS Settings with per-domain exceptions when the dictionary matches.</string>
 							<key>pfm_name</key>
 							<string>Action</string>
 							<key>pfm_range_list</key>
@@ -330,7 +309,8 @@ EvaluateConnection: Apply DNS Settings with per-domain exceptions when the dicti
 								</dict>
 							</array>
 							<key>pfm_description</key>
-							<string>A dictionary that provides per-connection rules. This array is used only for settings where the Action value is EvaluateConnection.</string>
+							<string>A dictionary that provides per-connection rules.
+This array is used only for settings where the 'Action' value is'EvaluateConnection'.</string>
 							<key>pfm_name</key>
 							<string>ActionParameters</string>
 							<key>pfm_note</key>
@@ -339,9 +319,9 @@ EvaluateConnection: Apply DNS Settings with per-domain exceptions when the dicti
 							<array>
 								<dict>
 									<key>pfm_description</key>
-									<string>The DNS settings behavior for the specified domains. Options:
-NeverConnect: Do not use the DNS Settings for the specified domains.
-ConnectIfNeeded: Allow using the DNS Settings for the specified domains.</string>
+									<string>The DNS settings behavior for the specified domains. Allowed values are:
+* 'NeverConnect': Do not use the DNS Settings for the specified domains.
+* 'ConnectIfNeeded': Allow using the DNS Settings for the specified domains.</string>
 									<key>pfm_name</key>
 									<string>DomainAction</string>
 									<key>pfm_range_list</key>
@@ -388,7 +368,8 @@ ConnectIfNeeded: Allow using the DNS Settings for the specified domains.</string
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>An array of domain names. This rule matches if any of the domain names in the specified list matches any domain in the device's search domains list. A single wildcard * prefix is supported, but is not required.</string>
+							<string>An array of domain names. This rule matches if any of the domain names in the specified list matches any domain in the device's search domains list.
+A single wildcard '*' prefix is supported, but is not required. For example, both '*.example.com' and 'example.com' match against 'mydomain.example.com' and 'your.domain.example.com', but do not match against 'mydomain-example.com'.</string>
 							<key>pfm_name</key>
 							<string>DNSDomainMatch</string>
 							<key>pfm_subkeys</key>
@@ -407,10 +388,7 @@ ConnectIfNeeded: Allow using the DNS Settings for the specified domains.</string
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>An array of IP addresses. This rule matches if any of the network's specified DNS servers match any entry in the array. Matching with a single wildcard is supported.</string>
-							<key>pfm_description_reference</key>
 							<string>An array of IP addresses. This rule matches if any of the network's specified DNS servers match any entry in the array.
-
 Matching with a single wildcard is supported. For example, 17.* matches any DNS server in the 17.0.0.0/8 subnet.</string>
 							<key>pfm_name</key>
 							<string>DNSServerAddressMatch</string>
@@ -446,7 +424,8 @@ Matching with a single wildcard is supported. For example, 17.* matches any DNS 
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>An array of SSIDs to match against the current network. If the network is not a Wi-Fi network or if the SSID does not appear in this array, the match fails. Omit this key and the corresponding array to match against any SSID.</string>
+							<string>An array of SSIDs to match against the current network. If the network is not a Wi-Fi network or if the SSID does not appear in this array, the match fails.
+Omit this key and the corresponding array to match against any SSID.</string>
 							<key>pfm_name</key>
 							<string>SSIDMatch</string>
 							<key>pfm_subkeys</key>
@@ -487,7 +466,7 @@ Matching with a single wildcard is supported. For example, 17.* matches any DNS 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If true, prohibits users from disabling DNS settings. This key is only available on supervised devices.</string>
+			<string>If 'true', prohibits users from disabling DNS settings. This key is only available on supervised devices.</string>
 			<key>pfm_name</key>
 			<string>ProhibitDisablement</string>
 			<key>pfm_supervised</key>

--- a/Manifests/ManifestsApple/com.apple.dock.plist
+++ b/Manifests/ManifestsApple/com.apple.dock.plist
@@ -15,7 +15,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,9 +26,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 			<key>pfm_default</key>
 			<string>Dock Payload</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,9 +38,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 			<key>pfm_default</key>
 			<string>Dock</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,9 +52,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 			<key>pfm_default</key>
 			<string>com.apple.dock</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -72,9 +66,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 			<key>pfm_default</key>
 			<string>com.apple.dock</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,10 +96,7 @@ macOS. The key AllowDockFixupOverride is supported on macOS 10.12 and later.</st
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -121,10 +108,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -138,9 +122,7 @@ The payload organization for a payload need not match the payload organization i
 				<string>com.apple.application-bundle</string>
 			</array>
 			<key>pfm_description</key>
-			<string>Dock items in the Applications side that cannot be removed from the dock.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Dock items in the Applications side that cannot be removed from the dock.</string>
+			<string>An array of items located on the Applications side of the Dock and cannot be removed from that location.</string>
 			<key>pfm_name</key>
 			<string>static-apps</string>
 			<key>pfm_subkeys</key>
@@ -343,9 +325,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Dock items in the Documents side that cannot be removed from the dock.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Dock items in the Documents side that cannot be removed from the dock.</string>
+			<string>An array of items located on the Documents side of the Dock and cannot be removed from that location.</string>
 			<key>pfm_name</key>
 			<string>static-others</string>
 			<key>pfm_subkeys</key>
@@ -843,9 +823,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>64</integer>
 			<key>pfm_description</key>
-			<string>The tile size in pixels.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The tile size. Values must be in range 16 to 128.</string>
+			<string>The tile size. Values must be in the range from 16 to 128.</string>
 			<key>pfm_name</key>
 			<string>tilesize</string>
 			<key>pfm_range_max</key>
@@ -861,9 +839,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing tile size.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the size slider will be disabled.</string>
+			<string>If 'true', locks the size slider.</string>
 			<key>pfm_name</key>
 			<string>size-immutable</string>
 			<key>pfm_title</key>
@@ -875,9 +851,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Set to true to turn on magnification.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, magnification is active.</string>
+			<string>If 'true', enables magnification.</string>
 			<key>pfm_name</key>
 			<string>magnification</string>
 			<key>pfm_title</key>
@@ -889,9 +863,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing the enable magnification setting.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the magnification checkbox is disabled.</string>
+			<string>If 'true', locks magnification.</string>
 			<key>pfm_name</key>
 			<string>magnify-immutable</string>
 			<key>pfm_title</key>
@@ -903,9 +875,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>128</integer>
 			<key>pfm_description</key>
-			<string>Largest magnification tile size in pixels.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. THe size of the largest magnification. Values must be in range 16 to 128.</string>
+			<string>The size of the largest magnification.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -937,9 +907,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing magnification size.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the magnify slider is disabled.</string>
+			<string>If 'true', locks the magnification slider.</string>
 			<key>pfm_name</key>
 			<string>magsize-immutable</string>
 			<key>pfm_title</key>
@@ -949,9 +917,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Orientation of the dock.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Orientation of the dock. Values may be bottom, left, or right.</string>
+			<string>The orientation of the dock.</string>
 			<key>pfm_name</key>
 			<string>orientation</string>
 			<key>pfm_range_list</key>
@@ -975,9 +941,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing position.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the position is locked.</string>
+			<string>If 'true', locks the position.</string>
 			<key>pfm_name</key>
 			<string>position-immutable</string>
 			<key>pfm_title</key>
@@ -989,9 +953,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>genie</string>
 			<key>pfm_description</key>
-			<string>Transition effect to use when minimizing applications to the Dock.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Set minimize effect. Values may be genie or scale.</string>
+			<string>The minimize effect.</string>
 			<key>pfm_name</key>
 			<string>mineffect</string>
 			<key>pfm_range_list</key>
@@ -1008,9 +970,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing the minimization setting.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the Minimize Using popup is disabled.</string>
+			<string>If 'true', locks 'Minimize windows using.'</string>
 			<key>pfm_name</key>
 			<string>mineffect-immutable</string>
 			<key>pfm_title</key>
@@ -1022,9 +982,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Set to true to minimize windows into application icons.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, enable the minimize-to-application feature.</string>
+			<string>If 'true', enables 'Minimize windows into application icon.'</string>
 			<key>pfm_name</key>
 			<string>minimize-to-application</string>
 			<key>pfm_title</key>
@@ -1036,9 +994,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing the minimize windows into application icon setting.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the minimize-to-application checkbox is disabled.</string>
+			<string>If 'true', disables the 'Minimize windows into application icon' checkbox.</string>
 			<key>pfm_name</key>
 			<string>minintoapp-immutable</string>
 			<key>pfm_title</key>
@@ -1050,9 +1006,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to true to use launch animation.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, animate opening applications.</string>
+			<string>If 'true', enables 'Animate opening applications.'</string>
 			<key>pfm_name</key>
 			<string>launchanim</string>
 			<key>pfm_title</key>
@@ -1064,9 +1018,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing the animate opening applications setting.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the Animate Opening Applications checkbox is disabled.</string>
+			<string>If 'true', locks 'Animate opening applications.'</string>
 			<key>pfm_name</key>
 			<string>launchanim-immutable</string>
 			<key>pfm_title</key>
@@ -1078,9 +1030,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Set to true to automatically hide and show the dock.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, automatically hide and show the dock.</string>
+			<string>If 'true', enables 'Automatically hide and show the dock.'</string>
 			<key>pfm_name</key>
 			<string>autohide</string>
 			<key>pfm_title</key>
@@ -1092,9 +1042,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from changing the automatically hide and show the dock setting.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the Automatically Hide checkbox is disabled.</string>
+			<string>If 'true', locks 'Automatically hide.'</string>
 			<key>pfm_name</key>
 			<string>autohide-immutable</string>
 			<key>pfm_title</key>
@@ -1106,9 +1054,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to true to show an indicator below the application icon when an application is running.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, show the process indicator.</string>
+			<string>If true, shows the process indicator.</string>
 			<key>pfm_name</key>
 			<string>show-process-indicators</string>
 			<key>pfm_title</key>
@@ -1120,9 +1066,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to true to show recent applications in the Dock.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, the three most recent applications will be shown in the Dock.</string>
+			<string>If 'true', enables 'Show recent items.'</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>
@@ -1136,9 +1080,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Whether these settings will merge with the user's existing Dock settings.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the device will use the static-apps and static-others dictionaries for the dock and ignore any items in the persistent-apps and persistent-others dictionaries. If false, the contents will be merged with the static items listed first.</string>
+			<string>If 'true', uses the 'static-apps' and 'static-others' dictionaries for the dock and ignores any items in the 'persistent-apps' and 'persistent-others' dictionaries. If 'false', the contents are merged with the static items listed first.</string>
 			<key>pfm_name</key>
 			<string>static-only</string>
 			<key>pfm_title</key>
@@ -1150,9 +1092,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent user from removing any item from or adding any item to the dock.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the user cannot remove any item from or add any item to the dock.</string>
+			<string>If 'true', disables changes to the dock.</string>
 			<key>pfm_name</key>
 			<string>contents-immutable</string>
 			<key>pfm_title</key>
@@ -1164,9 +1104,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, use the file in /Library/Preferences/com.apple.dockfixup.plist when a new user or migrated user logs in. The format of this file currently has no documentation. This option has no effect for existing users.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, use the file in /Library/Preferences/ com.apple.dockfixup.plist when a new user or migrated user logs in. The format of this file currently has no documentation. This option has no effect for existing users.</string>
+			<string>If 'true', use the file in '/Library/Preferences/com.apple.dockfixup.plist' when a new user or migrated user logs in. This option has no effect for existing users. Available in macOS 10.12 and later. Only available on the device channel.</string>
 			<key>pfm_macos_min</key>
 			<string>10.12</string>
 			<key>pfm_name</key>
@@ -1178,9 +1116,9 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Folders added by Managed Client.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. One or more special folders that may be created at user login time and placed in the dock. Values may be AddDockMCXMyApplicationsFolder, AddDockMCXDocumentsFolder, AddDockMCXSharedFolder, or AddDockMCXOriginalNetworkHomeFolder. The ”My Applications” item is only used for Simple Finder environments. The ”Original Network Home” item is only used for mobile account users.</string>
+			<string>One or more special folders that may be created at user login time and placed in the dock.
+
+The 'My Applications' item is only used for Simple Finder environments. The 'Original Network Home' item is only used for mobile account users.</string>
 			<key>pfm_name</key>
 			<string>MCXDockSpecialFolders</string>
 			<key>pfm_repetition_max</key>

--- a/Manifests/ManifestsApple/com.apple.domains.plist
+++ b/Manifests/ManifestsApple/com.apple.domains.plist
@@ -12,10 +12,10 @@
 	<integer>1</integer>
 	<key>pfm_interaction</key>
 	<string>combined</string>
-	<key>pfm_last_modified</key>
-	<date>2023-04-18T11:14:46Z</date>
 	<key>pfm_ios_min</key>
 	<string>8.0</string>
+	<key>pfm_last_modified</key>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.10</string>
 	<key>pfm_platforms</key>
@@ -29,9 +29,7 @@
 			<key>pfm_default</key>
 			<string>Configures Managed Domains</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -43,9 +41,7 @@
 			<key>pfm_default</key>
 			<string>Domains</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -59,9 +55,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.domains</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -75,9 +69,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.domains</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -91,9 +83,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -109,10 +99,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -124,10 +111,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -137,9 +121,8 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Mail messages that are addressed to domains not in the approved list are marked in red.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An array of strings. An email address lacking a suffix that matches any of these strings will be considered out-of-domain.</string>
+			<string>An array of domains. The system considers email addresses that lack a suffix matching any of these strings out of domain and marked in Mail.
+Available in iOS 8 and later and macOS 10.10 and later.</string>
 			<key>pfm_name</key>
 			<string>EmailDomains</string>
 			<key>pfm_subkeys</key>
@@ -164,15 +147,14 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Downloads from Safari will be considered managed documents if they originate from a managed domain.</string>
+			<string>An array of domains. The system considers URLs matching the patterns listed in this property managed.
+Available in iOS 9.3 and later.</string>
 			<key>pfm_description_extended</key>
 			<string>Any email address that does not have a suffix that matches one of the unmarked email domains specified by the key EmailDomains will be considered out-of-domain and will be highlighted as such in the Mail app.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An array of URL strings. URLs matching the patterns listed here will be considered managed. Not supported in macOS.</string>
-			<key>pfm_name</key>
-			<string>WebDomains</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
+			<key>pfm_name</key>
+			<string>WebDomains</string>
 			<key>pfm_platforms</key>
 			<array>
 				<string>iOS</string>
@@ -199,7 +181,9 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>User names and passwords entered in websites with Safari can be saved if the domain is listed.</string>
+			<string>An array of domains. Users can only save passwords in Safari from URLs matching the patterns listed here. This property doesn't disable the autofill feature itself.
+Supervised devices or Shared iPads need this property to enable saving passwords in Safari.
+Available in iOS 9.3 and later.</string>
 			<key>pfm_description_extended</key>
 			<string>Opening a document originating from a managed Safari web domain causes iOS to treat the document as managed for the purpose of Managed Open In.
 				
@@ -218,10 +202,6 @@ Trailing slashes will be ignored.
 If a ManagedWebDomain string entry contains a port number, only addresses that specify that port number will be considered managed. Otherwise, the domain will be matched without regard to the port number specified. For example, the pattern *.apple.com:8080 will match http://site.apple.com:8080/page.html but not http://site.apple.com/page.html, while the pattern *.apple.com will match both URLs.
 Managed Safari Web Domain definitions are cumulative. Patterns defined by all Managed Web Domains payloads will be used to match a URL request.
 SafariPasswordAutoFillDomains definitions are cumulative. Patterns defined by all SafariPasswordAutoFillDomains payloads will be used to determine if passwords can be stored for a given URL.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An array of URL strings. Supported in iOS 9.3 and later; not supported in macOS. Users can save passwords in Safari only from URLs matching the patterns listed here. Regardless of the iCloud account that the user is using, if the device is not supervised, there can be no whitelist. If the device is supervised, there may be a whitelist, but if there is still no whitelist, note these two cases:
-• IfthedeviceisconfiguredasSharediPad, no password can be saved.
-• IfthedeviceisnotconfiguredasShared iPad, all passwords can be saved.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
 			<key>pfm_name</key>
@@ -254,11 +234,10 @@ SafariPasswordAutoFillDomains definitions are cumulative. Patterns defined by al
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Up to 10 domains can be added for which Cross-Site Tracking Prevention will be relaxed. Domains should be listed as theacmeinc.com which includes any subdomains (without needing to use *theacmeinc.com)</string>
+			<string>An array of up to 10 strings. URLs matching the patterns listed here have relaxed enforcement of cross-site tracking prevention.
+Available in iOS 16.2 and later and macOS 13.1 and later.</string>
 			<key>pfm_description_extended</key>
 			<string>As a result, organizations can leave Cross-Site Tracking Prevention turned on and benefit from tracking prevention for general browsing but also allow select domains to give third-party embedded resources the ability to use cookies. This is useful, for example, in education, where learning management systems embed content like videos or images stored by third parties, or learning tools (LTI tools) offered by third parties and presented in iFrames.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An array of URL strings; maximum of 10. Supported in iOS 16.2 and later; Supported in macOS 13.1 and later. URLs matching the patterns listed here have relaxed enforcement of cross-site tracking prevention.</string>
 			<key>pfm_ios_min</key>
 			<string>16.2</string>
 			<key>pfm_macos_min</key>

--- a/Manifests/ManifestsApple/com.apple.eas.account.plist
+++ b/Manifests/ManifestsApple/com.apple.eas.account.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Exchange Active Sync settings</string>
+	<string>Use this section to define settings for the Exchange ActiveSync account.</string>
 	<key>pfm_description_reference</key>
 	<string>In iOS, the Exchange payload is designated by specifying com.apple.eas.account as the PayloadType value. This payload configures an Exchange Active Sync Contacts account on the device. Mail and Calendar are not config- ured using this payload on iOS.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_note</key>
 	<string>As with VPN and Wi-Fi configurations, it is possible to associate an SCEP credential with an Exchange configu- ration via the PayloadCertificateUUID key.</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures an Exchange account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>Exchange ActiveSync</string>
 			<key>pfm_description</key>
-			<string>The display name for the account.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_enabled</key>
 			<true/>
 			<key>pfm_name</key>
@@ -60,9 +56,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.eas.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -76,9 +70,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.eas.account</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -92,9 +84,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -110,10 +100,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -125,10 +112,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -138,10 +122,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The user name with the optional domain (e.g "user" or "domain\user").</string>
-			<key>pfm_description_reference</key>
-			<string>This string specifies the user name for this Exchange account.
-Required in macOS or non-interactive installations (like MDM on iOS).</string>
+			<string>This user name for this Exchange account. The user name is required for noninteractive installations like MDM in iOS.</string>
 			<key>pfm_name</key>
 			<string>UserName</string>
 			<key>pfm_require</key>
@@ -153,10 +134,7 @@ Required in macOS or non-interactive installations (like MDM on iOS).</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The email address for the account (e.g. "john@company.com).</string>
-			<key>pfm_description_reference</key>
-			<string>Specifies the full email address for the account. If not present in the payload, the device prompts for this string during profile installation.
-In macOS, this key is required.</string>
+			<string>The full email address for the account. If not present in the payload, the device prompts for this string during profile installation.</string>
 			<key>pfm_name</key>
 			<string>EmailAddress</string>
 			<key>pfm_title</key>
@@ -166,9 +144,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password of the user account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The password of the account. Use only with encrypted profiles.</string>
+			<string>The password of the account. Use only with encrypted profiles.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -198,7 +174,7 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, a previously set EAS password is overriden with a new password in this payload.</string>
+			<string>If 'true',  overrides the previous user/EAS password with the new EAS password in the payload. Available in iOS 14 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.0</string>
 			<key>pfm_name</key>
@@ -210,9 +186,8 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the internal Exchange host.</string>
-			<key>pfm_description_reference</key>
-			<string>Specifies the Exchange server host name (or IP address). In macOS 10.11 and later, this key is optional.</string>
+			<string>The Exchange server host name or IP address.
+If using OAuth without an OAuthSignInURL, the host name is ignored.</string>
 			<key>pfm_name</key>
 			<string>Host</string>
 			<key>pfm_require</key>
@@ -226,9 +201,7 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Send all communication through Secure Socket Layer.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default YES. Specifies whether the Exchange server uses SSL for authentication.</string>
+			<string>If 'true', enables SSL for authentication.</string>
 			<key>pfm_name</key>
 			<string>SSL</string>
 			<key>pfm_title</key>
@@ -240,10 +213,8 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Specifies whether the connection should use OAuth for authentication.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Specifies whether the connection should use OAuth for authentication. If enabled, a password should not be specified. This defaults to false.
-Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
+			<string>If 'true', enables OAuth for authentication. If enabled, don't specify a password.
+Available only in iOS 12.0 and above.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_macos_min</key>
@@ -261,9 +232,7 @@ Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
 				<string>com.rsa.pkcs-12</string>
 			</array>
 			<key>pfm_description</key>
-			<string>X.509 certificate (.p12) for inclusion on device.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. For accounts that allow authentication via certificate, a .p12 identity certificate in NSData blob format.</string>
+			<string>The '.p12' identity certificate in NSData blob format, for accounts that allow authentication via certificate.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -287,9 +256,7 @@ Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name or description of the certificate credential.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Specifies the name or description of the certificate.</string>
+			<string>The name or description of the certificate.</string>
 			<key>pfm_name</key>
 			<string>CertificateName</string>
 			<key>pfm_title</key>
@@ -299,9 +266,7 @@ Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Password protecting the PKCS12 file.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The password necessary for the p12 identity certificate. Used with mandatory encryption of profiles.</string>
+			<string>The password necessary for the '.p12' identity certificate. Used with mandatory encryption of profiles.</string>
 			<key>pfm_name</key>
 			<string>CertificatePassword</string>
 			<key>pfm_sensitive</key>
@@ -315,11 +280,7 @@ Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, messages may not be moved out of this email account into another account. Also prevents forwarding or replying from a different account than the message was originated from.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Defaultfalse.
-If set to true, messages may not be moved out of this email account into another account. Also prevents forwarding or replying from a different account than the message was originated from.
-Availability: Available in iOS 5.0 and later.</string>
+			<string>If 'true', prevents messages from being moved out of this email account into another account. This setting also prevents forwarding or replying from an account other than the one the message was sent to.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -333,10 +294,7 @@ Availability: Available in iOS 5.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, this account will not be available for sending mail in any app other than the Apple Mail app.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, this account will not be available for sending mail in any app other than the Apple Mail app.
-Availability: Available in iOS 5.0 and later.</string>
+			<string>If 'true', prevents this account from sending mail in any app other than the Apple Mail app.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -348,10 +306,7 @@ Availability: Available in iOS 5.0 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>UUID of the certificate payload to use for the identity credential.</string>
-			<key>pfm_description_reference</key>
-			<string>UUID of the certificate payload to use for the identity credential. If this field is present, the Certificate field is not used.
-Availability: Available in iOS 5.0 and later.</string>
+			<string>The UUID of of the certificate payload within the same profile to use for the identity credential. If this field is present, the Certificate field is not used.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -365,11 +320,7 @@ Availability: Available in iOS 5.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, this account supports S/MIME.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If true, this account supports S/MIME.
-As of iOS 10.0, this key is ignored.
-Availability: Available only in iOS 5.0 through 9.3.3.</string>
+			<string>If 'true', enables S/MIME encryption. In iOS 10.0 and later, this key is ignored. Use 'SMIMESigningEnabled' instead.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>9.3.3</string>
 			<key>pfm_ios_max</key>
@@ -387,10 +338,7 @@ Availability: Available only in iOS 5.0 through 9.3.3.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, S/MIME signing is enabled for this account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default true. If set to true, S/MIME signing is enabled for this account.
-Availability: Available only in iOS 10.3 and later.</string>
+			<string>If 'true', enables S/MIME signing for this account. Available in iOS 10.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>10.3</string>
 			<key>pfm_name</key>
@@ -402,10 +350,7 @@ Availability: Available only in iOS 10.3 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The PayloadUUID of the identity certificate used to sign messages sent from this account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The PayloadUUID of the identity certificate used to sign messages sent from this account. 
-Availability: Available only in iOS 5.0 and later.</string>
+			<string>The UUID of the identity certificate used to sign messages sent from this account.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -419,10 +364,7 @@ Availability: Available only in iOS 5.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, S/MIME encryption is on by default for this account. As of iOS 12.0, this key is deprecated. It is recommended to use SMIMEEncryptByDefault instead.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, S/MIME encryption is on by default for this account.
-Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is deprecated. It is recommended to use SMIMEEncryptByDefault instead.</string>
+			<string>If 'true', enables S/MIME encryption for this account. Available in iOS 10.0 and later. As of iOS 12.0, this key is deprecated. It is recommended to use 'SMIMEEncryptByDefault' instead.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>12.0</string>
 			<key>pfm_ios_min</key>
@@ -436,9 +378,7 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The PayloadUUID of the identity certificate used to decrypt messages sent to this account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The PayloadUUID of the identity certificate used to decrypt messages sent to this account. The public certificate is attached to outgoing mail to allow encrypted mail to be sent to this user. When the user sends encrypted mail, the public certificate is used to encrypt the copy of the mail in their Sent mailbox. Availability: Available only in iOS 5.0 and later.</string>
+			<string>The payload UUID of the identity certificate used to decrypt messages sent to this account. The public certificate is attached to outgoing mail to allow encrypted mail to be sent to this user. When the user sends encrypted mail, the public certificate is used to encrypt the copy of the mail in the user's Sent mailbox.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -470,9 +410,8 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, displays the per-message encryption switch in the Mail Compose UI. As of iOS 12.0, this key is deprecated. It is recommended to use SMIMEEnableEncryptionPerMessageSwitch instead.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, displays the per-message encryption switch in the Mail Compose UI. Availability: Available only in iOS 8.0 and later. As of iOS 12.0, this key is deprecated. It is recommended to use SMIMEEnableEncryptionPerMessageSwitch instead.</string>
+			<string>If 'true', displays the per-message encryption switch in the Mail Compose UI.
+Available in iOS 8.0 and later. As of iOS 12.0, this key is deprecated. Use 'SMIMEEnableEncryptionPerMessageSwitch' instead.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>12.0</string>
 			<key>pfm_ios_min</key>
@@ -488,9 +427,7 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, the user can toggle S/MIME signing on or off in Settings.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, the user can toggle S/MIME signing on or off in Settings. Availability: Available only in iOS 12.0 and later.</string>
+			<string>If 'true', the user can turn S/MIME signing on or off in Settings. Available in iOS 12.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -504,10 +441,7 @@ Availability: Available only in iOS 10.3 and later. As of iOS 12.0, this key is 
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, the user can select the signing identity.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, the user can select the signing identity.
-Availability: Available only in iOS 12.0 and later.</string>
+			<string>If 'true', the user can select the signing identity. Available in iOS 12.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -521,9 +455,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, S/MIME encryption is enabled by default.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, S/MIME encryption is enabled by default. If SMIMEEnableEncryptionPerMessageSwitch is false, this default cannot be changed by the user. Availability: Available only in iOS 12.0 and later.</string>
+			<string>If set to true, S/MIME encryption is enabled by default. If 'SMIMEEnableEncryptionPerMessageSwitch' is false, this default cannot be changed by the user. Available in iOS 12.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -537,9 +469,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, the user can toggle the encryption by default setting.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, the user can toggle the encryption by default setting. Availability: Available only in iOS 12.0 and later.</string>
+			<string>If 'true', the user can turn encryption by default on/off, and encryption is on. Available in iOS 12.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -553,10 +483,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, the user can select the S/MIME encryption identity and encryption is enabled.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, the user can select the S/MIME encryption identity and encryption is enabled.
-Availability: Available only in iOS 12.0 and later.</string>
+			<string>If 'true', the user can select the S/MIME encryption identity, and encryption is on.Available in iOS 12.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -570,9 +497,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, displays the per-message encryption switch in the Mail Compose UI.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default false. If set to true, displays the per-message encryption switch in the Mail Compose UI. Availability: Available only in iOS 12.0 and later.</string>
+			<string>If 'true', displays the per-message encryption switch in the Mail Compose UI. Available in iOS 12.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -586,9 +511,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the Calendars service for this account.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables the Calendars service for this account. The Calendars service may be re-enabled in Settings unless EnableCalendarsUserOverridable is false.</string>
+			<string>If 'false', disables the Calendars service for this account. The Calendars service may be re-enabled in Settings unless 'EnableCalendarsUserOverridable' is 'false'.
+'EnableMail', 'EnableContacts', 'EnableCalendars', 'EnableReminders', and 'EnableNotes' can't all be set to 'false'.</string>
 			<key>pfm_name</key>
 			<string>EnableCalendars</string>
 			<key>pfm_note</key>
@@ -602,9 +526,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the Contacts service for this account.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables the Contacts service for this account. The Contacts service may be re-enabled in Settings unless EnableContactsUserOverridable is false.</string>
+			<string>If 'false', disables the Contacts service for this account. The Contacts service may be re-enabled in Settings unless 'EnableContactsUserOverridable' is 'false'.
+'EnableMail', 'EnableContacts', 'EnableCalendars', 'EnableReminders', and 'EnableNotes' can't all be set to 'false'.</string>
 			<key>pfm_name</key>
 			<string>EnableContacts</string>
 			<key>pfm_note</key>
@@ -618,9 +541,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the Mail service for this account.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables the Mail service for this account. The Mail service may be re-enabled in Settings unless EnableMailUserOverridable is false.</string>
+			<string>If 'false', disables the Mail service for this account. The Mail service may be re-enabled in Settings unless 'EnableMailUserOverridable' is 'false'.
+'EnableMail', 'EnableContacts', 'EnableCalendars', 'EnableReminders', and 'EnableNotes' can't all be set to 'false'.</string>
 			<key>pfm_name</key>
 			<string>EnableMail</string>
 			<key>pfm_note</key>
@@ -634,9 +556,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the Notes service for this account.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables the Notes service for this account. The Notes service may be re-enabled in Settings unless EnableNotesUserOverridable is false.</string>
+			<string>If 'false', disables the Notes service for this account. The Notes service may be re-enabled in Settings unless 'EnableNotesUserOverridable' is 'false'.
+'EnableMail', 'EnableContacts', 'EnableCalendars', 'EnableReminders', and 'EnableNotes' can't all be set to 'false'.</string>
 			<key>pfm_name</key>
 			<string>EnableNotes</string>
 			<key>pfm_note</key>
@@ -650,9 +571,8 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the Reminders service for this account.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, disables the Reminders service for this account. The Reminders service may be re-enabled in Settings unless EnableRemindersUserOverridable is false.</string>
+			<string>If 'false', disables the Reminders service for this account. The Reminders service may be re-enabled in Settings unless 'EnableRemindersUserOverridable' is false.
+'EnableMail', 'EnableContacts', 'EnableCalendars', 'EnableReminders', and 'EnableNotes' can't all be set to 'false'.</string>
 			<key>pfm_name</key>
 			<string>EnableReminders</string>
 			<key>pfm_note</key>
@@ -666,9 +586,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the users to modify the Calendars settings.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, prevents the user from changing the state of the Calendars service for this account in Settings.</string>
+			<string>If 'false', prevents the user from changing the state of the Calendars service for this account in Settings.</string>
 			<key>pfm_name</key>
 			<string>EnableCalendarsUserOverridable</string>
 			<key>pfm_title</key>
@@ -680,9 +598,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the users to modify the Contacts settings.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, prevents the user from changing the state of the Contacts service for this account in Settings.</string>
+			<string>If 'false', prevents the user from changing the state of the Contacts service for this account in Settings.</string>
 			<key>pfm_name</key>
 			<string>EnableContactsUserOverridable</string>
 			<key>pfm_title</key>
@@ -694,9 +610,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the users to modify the Mail settings.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, prevents the user from changing the state of the Mail service for this account in Settings.</string>
+			<string>If 'false', prevents the user from changing the state of the Mail service for this account in Settings.</string>
 			<key>pfm_name</key>
 			<string>EnableMailUserOverridable</string>
 			<key>pfm_title</key>
@@ -708,9 +622,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the users to modify the Notes settings.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, prevents the user from changing the state of the Notes service for this account in Settings.</string>
+			<string>If 'false', prevents the user from changing the state of the Notes service for this account in Settings.</string>
 			<key>pfm_name</key>
 			<string>EnableNotesUserOverridable</string>
 			<key>pfm_title</key>
@@ -722,9 +634,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enables/disables the users to modify the Reminders settings.</string>
-			<key>pfm_description_reference</key>
-			<string>If false, prevents the user from changing the state of the Reminders service for this account in Settings.</string>
+			<string>If 'false', prevents the user from changing the state of the Reminders service for this account in Settings.</string>
 			<key>pfm_name</key>
 			<string>EnableRemindersUserOverridable</string>
 			<key>pfm_title</key>
@@ -736,10 +646,7 @@ Availability: Available only in iOS 12.0 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, this account is excluded from address Recents syncing.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, this account is excluded from address Recents syncing. This defaults to false.
-Availability: Available only in iOS 6.0 and later.</string>
+			<string>If 'true', excludes this account from Recent Addresses syncing.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -753,9 +660,7 @@ Availability: Available only in iOS 6.0 and later.</string>
 			<key>pfm_default</key>
 			<integer>7</integer>
 			<key>pfm_description</key>
-			<string>The number of days since synchronization.</string>
-			<key>pfm_description_reference</key>
-			<string>The number of days since synchronization.</string>
+			<string>The number of days in the past to sync mail on the device.</string>
 			<key>pfm_name</key>
 			<string>MailNumberOfPastDaysToSync</string>
 			<key>pfm_range_list</key>
@@ -774,15 +679,13 @@ Availability: Available only in iOS 6.0 and later.</string>
 		<dict>
 			<key>pfm_description</key>
 			<string>The communication service handler rules for this account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The communication service handler rules for this account. The CommunicationServiceRules dictionary currently contains only a DefaultServiceHandlers key; its value is a dictionary which contains an AudioCall key whose value is a string containing the bundle identifier for the default application that handles audio calls made to contacts from this account.</string>
 			<key>pfm_name</key>
 			<string>CommunicationServiceRules</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>The default handlers to be used for contacts from this account.</string>
 					<key>pfm_name</key>
 					<string>DefaultServiceHandlers</string>
 					<key>pfm_required</key>
@@ -791,7 +694,7 @@ Availability: Available only in iOS 6.0 and later.</string>
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>Bundle identifier for the default application that handles audio calls made to contacts from this account</string>
+							<string>The bundle identifier of the default application to use for audio calls made to contacts from this account.</string>
 							<key>pfm_name</key>
 							<string>AudioCall</string>
 							<key>pfm_title</key>
@@ -813,7 +716,8 @@ Availability: Available only in iOS 6.0 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>UUID of a per-app VPN payload to tunnel this account communication through</string>
+			<string>The VPNUUID of the per-app VPN the account uses for network communication.
+Available in iOS 14 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.education.plist
+++ b/Manifests/ManifestsApple/com.apple.education.plist
@@ -19,7 +19,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 	<key>pfm_ios_min</key>
 	<string>9.3</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>
@@ -33,9 +33,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 			<key>pfm_default</key>
 			<string>Configures Education settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -47,9 +45,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 			<key>pfm_default</key>
 			<string>Apple Education</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -63,9 +59,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 			<key>pfm_default</key>
 			<string>com.apple.education</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -79,9 +73,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 			<key>pfm_default</key>
 			<string>com.apple.education</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -95,9 +87,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -113,10 +103,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -128,9 +115,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -140,9 +125,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The organization's display name.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. The organization's display name. This name will be shown in the iOS login screen.</string>
+			<string>The organization's display name. This name is shown in the iOS login screen.</string>
 			<key>pfm_name</key>
 			<string>OrganizationName</string>
 			<key>pfm_require</key>
@@ -154,9 +137,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>All teacher and student devices that need to communicate with one another must have the same OrganizationUUID, particularly if they originated from different Device Enrollment Programs.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. The organization's UUID identifier. This can be any valid UUID. All teacher and student devices that need to communicate with one another must have the same OrganizationUUID, particularly if they originated from different Device Enrollment Programs.</string>
+			<string>The organization's UUID identifier. This identifier can be any valid UUID. All teacher and student devices that need to communicate with one another must have the same organization UUID, particularly if they originated from different Device Enrollment Programs.</string>
 			<key>pfm_name</key>
 			<string>OrganizationUUID</string>
 			<key>pfm_require</key>
@@ -168,9 +149,8 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Used to perform client authentication between devices.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. The UUID of an identity certificate payload that will be used to perform client authentication with other devices.</string>
+			<string>The UUID of an identity certificate payload within the same profile to use for performing client authentication with other devices. This property supports PKCS12 certificates.
+This key is required to configure Classroom. It does not impact the configuration of the Shared iPad login screen.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -184,13 +164,11 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Shared: An array of dictionaries that define groups that the user can select in the login window.
-Leader: An array of dictionaries that define the groups that the user can control.
-Member: An array of dictionaries that define the groups of which the user is a member.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Shared: An array of dictionaries that define groups that the user can select in the login window.
-Leader: An array of dictionaries that define the groups that the user can control.
-Member: An array of dictionaries that define the groups of which the user is a member.</string>
+			<string>For shared iPad profiles: The array of dictionaries that defines which groups the user can select in the login window.
+
+For leader/teacher profiles: The array of dictionaries that defines the groups that the user can control.
+
+For member/student profiles: The array of dictionaries that defines the groups where the user is a member.</string>
 			<key>pfm_name</key>
 			<string>Groups</string>
 			<key>pfm_require</key>
@@ -331,15 +309,11 @@ Member: An array of dictionaries that define the groups of which the user is a m
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Shared: An array of dictionaries that define the users that are shown in the iOS login window.
-Leader: An array of dictionaries that define users that are members of the leaderʼs groups.
-Member: An array of a dictionaries that must contain the definition of the user specified in the UserIdentifier key.
-With one-to-one member devices, this key should include only the device user and the leader but not other class members.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. Shared: An array of dictionaries that define the users that are shown in the iOS login window.
-Leader: An array of dictionaries that define users that are members of the leaderʼs groups.
-Member: An array of a dictionaries that must contain the definition of the user specified in the UserIdentifier key.
-With one-to-one member devices, this key should include only the device user and the leader but not other class members.</string>
+			<string>For shared iPad profiles: The array of dictionaries that define the users that are shown in the iOS login window.
+
+For leader/teacher profiles: The array of dictionaries that define users that are members of the teacher's groups.
+
+For member/student profiles: The array of dictionaries that must contain the definition of the user specified in the 'UserIdentifier' key. With one-to-one member devices, this key should include only the device user and the teacher but not other class members.</string>
 			<key>pfm_name</key>
 			<string>Users</string>
 			<key>pfm_require</key>
@@ -473,9 +447,9 @@ With one-to-one member devices, this key should include only the device user and
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of UUIDs referring to certificate payloads that will be used to authorize leader peer certificate identities. This array must contain all certificates needed to validate the entire chain of trust. Leader certificates must have the common name prefix leader (case insensitive) and have a .cer type.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An array of UUIDs referring to certificate payloads that will be used to authorize leader peer certificate identities. This array must contain all certificates needed to validate the entire chain of trust. Leader certificates must have the common name prefix leader (case insensitive) and have a .cer type.</string>
+			<string>The array of UUIDs referring to certificate payloads within the same profile that are used to authorize leader peer certificate identities. This array must contain all certificates needed to validate the entire chain of trust. Leader certificates must have the common name prefix leader (case insensitive).
+Note: This property doesn't support identity payloads or PKCS12 certificates.
+This key is required when configuring a student device for Classroom, and is ignored when configuring an instructor device. It does not impact the configuration of the Shared iPad login screen.</string>
 			<key>pfm_name</key>
 			<string>LeaderPayloadCertificateAnchorUUID</string>
 			<key>pfm_subkeys</key>
@@ -494,9 +468,9 @@ With one-to-one member devices, this key should include only the device user and
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of UUIDs referring to certificate payloads that will be used to authorize group member peer certificate identities. This array must contain all certificates needed to validate the entire chain of trust. Member certificates must have the common name prefix member (case insensitive) and have a .cer type.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An array of UUIDs referring to certificate payloads that will be used to authorize group member peer certificate identities. This array must contain all certificates needed to validate the entire chain of trust. Member certificates must have the common name prefix member (case insensitive) and have a .cer type.</string>
+			<string>The array of UUIDs referring to certificate payloads within the same profile that are used to authorize group member peer certificate identities. This array must contain all certificates needed to validate the entire chain of trust. Member certificates must have the common name prefix member (case insensitive).
+Note: This property doesn't support identity payloads or PKCS12 certificates.
+This key is required when configuring an instructor device for Classroom, and is ignored when configuring a student device. It does not impact the configuration of the Shared iPad login screen.</string>
 			<key>pfm_name</key>
 			<string>MemberPayloadCertificateAnchorUUID</string>
 			<key>pfm_subkeys</key>
@@ -515,9 +489,8 @@ With one-to-one member devices, this key should include only the device user and
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The UUID of an identity certificate payload that will be used to perform client authentication when fetching additional resources, such as, student images. If not specified the MDM client identity will be used.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The UUID of an identity certificate payload that will be used to perform client authentication when fetching additional resources, such as, student images. If not specified the MDM client identity will be used.</string>
+			<string>The UUID of an identity certificate payload within the same profile that is used to perform client authentication when fetching additional resources, such as student images. If not specified, the MDM client identity is used.
+If present, this key is used to configure both Classroom and the Shared iPad login screen.</string>
 			<key>pfm_name</key>
 			<string>ResourcePayloadCertificateUUID</string>
 			<key>pfm_title</key>
@@ -527,9 +500,8 @@ With one-to-one member devices, this key should include only the device user and
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A unique string that identifies the user of this device within the organization.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A unique string that identifies the user of this device within the organization.</string>
+			<string>The unique string that identifies the user of this device within the organization.
+If this payload is intended to configure the Shared iPad login screen, this value must not be set.</string>
 			<key>pfm_name</key>
 			<string>UserIdentifier</string>
 			<key>pfm_require</key>
@@ -541,9 +513,8 @@ With one-to-one member devices, this key should include only the device user and
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Shared: An array of dictionaries that define departments that are shown in the iOS login window.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Shared: An array of dictionaries that define departments that are shown in the iOS login window.</string>
+			<string>For shared iPad profiles: The array of dictionaries that defines which departments  are shown in the Shared iPad login screen.
+If present, this key is used to configure both Classroom and the Shared iPad login screen.</string>
 			<key>pfm_name</key>
 			<string>Departments</string>
 			<key>pfm_subkeys</key>
@@ -598,9 +569,7 @@ With one-to-one member devices, this key should include only the device user and
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Leader: An array of dictionaries that define the device groups to which the leader can assign devices. This key is not included in member payloads.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Leader: An array of dictionaries that define the device groups to which the leader can assign devices. This key is not included in member payloads.</string>
+			<string>For leader/teacher profiles: The array of dictionaries that defines which device groups the leader can assign devices to. This key is not included in member payloads.</string>
 			<key>pfm_name</key>
 			<string>DeviceGroups</string>
 			<key>pfm_subkeys</key>
@@ -671,9 +640,7 @@ With one-to-one member devices, this key should include only the device user and
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>To allow students enrolled in managed classes to modify teacher permission for screen observation, set to 'true'.</string>
-			<key>pfm_description_reference</key>
-			<string> Optional. If set to true, students enrolled in managed classes can modify their teacher's permissions for screen observation on this device. Defaults to false.</string>
+			<string>If 'true', allows students enrolled in managed classes to modify their teacher's permissions for screen observation on their device.</string>
 			<key>pfm_name</key>
 			<string>ScreenObservationPermissionModificationAllowed</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.ews.account.plist
+++ b/Manifests/ManifestsApple/com.apple.ews.account.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-29T08:33:42Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_note</key>
 	<string>As with VPN and Wi-Fi configurations, it is possible to associate an SCEP credential with an Exchange configu- ration via the PayloadCertificateUUID key.</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures an Exchange account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -58,9 +56,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>The display name for the account.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_enabled</key>
 			<true/>
 			<key>pfm_name</key>
@@ -74,9 +70,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ews.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -90,9 +84,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ews.account</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -106,9 +98,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -124,10 +114,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -139,10 +126,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -168,10 +152,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The user name with the optional domain (e.g "user" or "domain\user").</string>
-			<key>pfm_description_reference</key>
-			<string>This string specifies the user name for this Exchange account.
-Required in macOS or non-interactive installations (like MDM on iOS).</string>
+			<string>The user name for this Exchange account. This string is required for noninteractive (for example, MDM) installation. If it's missing, the device prompts for it during interactive profile installation.</string>
 			<key>pfm_name</key>
 			<string>UserName</string>
 			<key>pfm_title</key>
@@ -197,10 +178,7 @@ Required in macOS or non-interactive installations (like MDM on iOS).</string>
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The email address for the account (e.g. john@company.com).</string>
-			<key>pfm_description_reference</key>
-			<string>Specifies the full email address for the account. If not present in the payload, the device prompts for this string during profile installation.
-In macOS, this key is required.</string>
+			<string>The full email address for the account. If the email address string isn't present in the payload, the device prompts for it during profile installation.</string>
 			<key>pfm_name</key>
 			<string>EmailAddress</string>
 			<key>pfm_title</key>
@@ -210,9 +188,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password of the user account.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The password of the account. Use only with encrypted profiles.</string>
+			<string>The password of the account. Use only with encrypted profiles.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -256,9 +232,8 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the internal Exchange host.</string>
-			<key>pfm_description_reference</key>
-			<string>Specifies the Exchange server host name (or IP address). In macOS 10.11 and later, this key is optional.</string>
+			<string>The Exchange server host name or IP address.
+If using OAuth, the host name is ignored..</string>
 			<key>pfm_name</key>
 			<string>Host</string>
 			<key>pfm_title</key>
@@ -268,9 +243,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The port on which to connect to the internal Exchange host.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. The password of the account. Use only with encrypted profiles.</string>
+			<string>The server port number.</string>
 			<key>pfm_name</key>
 			<string>Port</string>
 			<key>pfm_range_max</key>
@@ -284,9 +257,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The server path for the internal Exchange host.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional.</string>
+			<string>The server path.</string>
 			<key>pfm_name</key>
 			<string>Path</string>
 			<key>pfm_title</key>
@@ -298,9 +269,7 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Send all communication through Secure Socket Layer.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Default YES. Specifies whether the Exchange server uses SSL for authentication.</string>
+			<string>If 'true', enables SSL.</string>
 			<key>pfm_name</key>
 			<string>SSL</string>
 			<key>pfm_title</key>
@@ -310,9 +279,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the external Exchange host.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional.</string>
+			<string>The external server address.</string>
 			<key>pfm_name</key>
 			<string>ExternalHost</string>
 			<key>pfm_title</key>
@@ -322,9 +289,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The port on which to connect to the external Exchange host.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional.</string>
+			<string>The external server port number.</string>
 			<key>pfm_name</key>
 			<string>ExternalPort</string>
 			<key>pfm_range_max</key>
@@ -338,9 +303,7 @@ In macOS, this key is required.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The server path for the external Exchange host.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional.</string>
+			<string>The external server path.</string>
 			<key>pfm_name</key>
 			<string>ExternalPath</string>
 			<key>pfm_title</key>
@@ -352,9 +315,7 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Send all communication through Secure Socket Layer.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional.</string>
+			<string>If 'true', enables SSL for connections to the external server.</string>
 			<key>pfm_name</key>
 			<string>ExternalSSL</string>
 			<key>pfm_title</key>
@@ -366,10 +327,8 @@ In macOS, this key is required.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Specifies whether the connection should use OAuth for authentication.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Specifies whether the connection should use OAuth for authentication. If enabled, a password should not be specified. This defaults to false.
-Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
+			<string>If 'true', enables OAuth for authentication. If OAuth is enabled, don't specify a password.
+Available in macOS 10.14 and later</string>
 			<key>pfm_macos_min</key>
 			<string>10.14</string>
 			<key>pfm_name</key>
@@ -381,10 +340,7 @@ Availability: Available only in iOS 12.0 and macOS 10.14 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>URL to load into a webview for authentication via OAuth when auto-discovery is not used.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Specifies the URL to load into a webview for authentication via OAuth when auto-discovery is not used. Requires a Host value.
-Availability: Available only in macOS 10.14 and later.</string>
+			<string>The URL to load into a web view for authentication via OAuth when autodiscovery isn't used. This setting requires a 'Host' value.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.extensiblesso.plist
+++ b/Manifests/ManifestsApple/com.apple.extensiblesso.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Single Sign-On Extension settings. User-level payload support for macOS 11.x and later.</string>
+	<string>Configures an app extension to handle Kerberos SSO.</string>
 	<key>pfm_description_reference</key>
 	<string>The payload for configuring an app extension that performs single sign-on.</string>
 	<key>pfm_documentation_url</key>
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>13.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -31,9 +31,7 @@
 			<key>pfm_default</key>
 			<string>Configures an app extension that performs single sign-on</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -45,9 +43,7 @@
 			<key>pfm_default</key>
 			<string>Single Sign-On Extensions</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -61,9 +57,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.extensiblesso</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -77,9 +71,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.extensiblesso</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -93,9 +85,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -111,10 +101,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -126,10 +113,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -139,7 +123,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The bundle identifier of the app extension that performs single sign-on (SSO) for the specified URLs. Enter com.apple.AppSSOKerberos.KerberosExtension to use Apple's Kerberos SSO extension.</string>
+			<string>This value must be  'com.apple.AppSSOKerberos.KerberosExtension' for this extension.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_macos_min</key>
@@ -165,7 +149,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The type of SSO.</string>
+			<string>This value must be 'Credential' for the Kerberos extension.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_macos_min</key>
@@ -200,7 +184,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The team identifier of the app extension. This key is required on macOS and ignored elsewhere.</string>
+			<string>This value must be 'apple' for the Kerberos extension.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_macos_min</key>
@@ -232,7 +216,8 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>An array of host names or domain names that can be authenticated through the app extension. Required for Credential payloads. Ignored for Redirect payloads.</string>
+			<string>One or more host or domain names for which the app extension performs SSO. Host or domain names are matched case-insensitively, and all the host/domain names of all installed Extensible SSO payloads must be unique.
+Hosts that begin with a “.” are wildcard suffixes and will match all subdomains, otherwise the host must be an exact match.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_macos_min</key>
@@ -273,7 +258,7 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The realm name for Credential payloads. This value should be properly capitalized. This key is ignored for Redirect payloads.</string>
+			<string>The Kerberos realm, which should be properly capitalized. If in an Active Directory forest, this is the realm where the user logs in.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_macos_min</key>
@@ -303,7 +288,9 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The realm name for Credential payloads. This value should be properly capitalized. This key is ignored for Redirect payloads.</string>
+			<string>An array of URL prefixes of identity providers where the app extension performs SSO.
+Required for 'Redirect' payloads. Ignored for 'Credential' payloads.
+The URLs must begin with 'http://' or 'https://', the scheme and host name are matched case-insensitively, query parameters and URL fragments are not allowed, and the URLs of all installed Extensible SSO payloads must be unique.</string>
 			<key>pfm_ios_min</key>
 			<string>13.0</string>
 			<key>pfm_macos_min</key>
@@ -331,6 +318,9 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 			<string>array</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>An array of bundle identifiers of apps that don't use SSO provided by this extension.
+Available in iOS 15 and later and macOS 12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_macos_min</key>
@@ -354,6 +344,9 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 		<dict>
 			<key>pfm_default</key>
 			<string>Cancel</string>
+			<key>pfm_description</key>
+			<string>If set to 'Cancel', the system cancels authentication requests when the screen is locked. If set to 'DoNotHandle', the request continues without SSO instead. This does not apply to requests where 'userInterfaceEnabled' is set to 'false' or background NSURLSession requests.
+Available in iOS 15 and later and macOS 12 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_macos_min</key>
@@ -393,7 +386,7 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Used by the Apple built-in Kerberos extension.</string>
+			<string>This is the dictionary used by the Apple built-in Kerberos extension.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -424,7 +417,7 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>If false, passwords are not allowed to be saved to the keychain.</string>
+					<string>If 'false', passwords are not allowed to be saved to the keychain.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -456,7 +449,7 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>If false, disables password changes. Available in macOS 10.15 and later.</string>
+					<string>If 'false', disables password changes. Available in macOS 10.15 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -486,7 +479,8 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If true, the configured SSO extension must use a ticket-granting ticket (TGT) from Platform SSO.</string>
+					<string>If 'true', requires this configuration uses a TGT from Platform SSO instead of requesting a new one.
+Available in macOS 13 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -520,7 +514,8 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>If true, allows manual sign-ins as fallback.</string>
+					<string>If 'true' and 'usePlatformSSOTGT' is 'true', allows the user to manually sign in.
+Available in macOS 13 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -567,7 +562,8 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If true, the configured extension only handles Kerberos requests and does not check for or show the expiration of the password, does not check external password changes, does not sync passwords, and does not retrieve the user's home directory.</string>
+					<string>If 'true', the Kerberos Extension handles Kerberos requests only. It doesn't check for password expiration, show the password expiration in the menu, check for external password changes, perform password sync, or retrieve the home directory.
+Available in macOS 13 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -708,7 +704,11 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 					<key>pfm_default</key>
 					<string>always</string>
 					<key>pfm_description</key>
-					<string>This setting affects how the Kerberos Extension credential is used by other processes. Available in macOS 11 and later.</string>
+					<string>This setting affects how the Kerberos Extension credential is used by other processes. Use of the following:
+* 'always -' The extension credential will always be used if the SPN matches the Kerberos Extension 'Hosts' array. The credential will not be used if the calling app is not in the 'credentialBundleIDACL'.
+* 'whenNotSpecified -' The credential will only be used when another credential has not been specified by the caller and the SPN matches the Kerberos Extensions 'Hosts' array. The credential will not be used if the calling app is not in the 'credentialBundleIDACL'.
+* 'kerberosDefault - 'The default Kerberos processes for selecting credentials is used which normally uses the default Kerberos credential. This is the same as turning off this capability.
+Available in macOS 11 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -754,7 +754,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The custom user name label used in the Kerberos extension instead of "Username". For example, "Company ID". Available on macOS 11 and later.</string>
+					<string>The custom user name label used in the Kerberos extension instead of “Username”. For example, “Company ID”. Available in macOS 11 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -784,7 +784,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If true, doesn't prompt the user to setup the Kerberos extension until either the administrator enables it with the app-sso tool or a Kerberos challenge is received. Available in macOS 11 and later.</string>
+					<string>If 'true', doesn't prompt the user to setup the Kerberos extension until either the administrator enables it with the 'app-sso' tool or a Kerberos challenge is received. Available in macOS 11 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -876,7 +876,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If true, the Kerberos extension will allow only managed apps to access and use the credential. This is in addition to the credentialBundleIDACL, if it is specified. Available in iOS 14 and later.</string>
+					<string>If 'true', the Kerberos extension allows only managed apps to access and use the credential. This is in addition to the 'credentialBundleIDACL', if it is specified. Available in iOS 14 and later, and macOS 12 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -908,7 +908,8 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If true, the Kerberos extension will allow standard Kerberos utilities such as TicketViewer and klist to access and use the credential. This is in addition to either includeManagedAppsInBundleIdACL or credentialBundleIDACL, if any are specified.</string>
+					<string>If 'true', the Kerberos extension allows the standard kerberos utilities including 'TicketViewer' and 'klist' to access and use the credential. This is in addition to 'includeManagedAppsInBundleIdACL' or the 'credentialBundleIdACL', if it is specified.
+Available in macOS 12 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -938,7 +939,8 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>If false, the credential is requested on the next matching Kerberos challenge or network state change. If the credential is expired or missing, a new one will be created. Available in macOS 11 and later.</string>
+					<string>If 'false', the credential is requested on the next matching Kerberos challenge or network state change.
+If the credential is expired or missing, a new one will be created. Available in macOS 11 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -996,7 +998,10 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Preferred Key Distribution Centers for Kerberos traffic when the servers cannot be discovered via DNS.</string>
+					<string>The ordered list of preferred Key Distribution Centers (KDCs) to use for Kerberos traffic. Use this if the servers are not discoverable via DNS. If the servers are specified, then they are used for both connectivity checks and attempted first for Kerberos traffic. If the servers do not respond, then the device falls back to DNS discovery. Each entry is formatted the same as it would be in a 'krb5.conf' file. Examples of entries are:
+* 'adserver1.example.com'
+* 'tcp/adserver1.example.com:88'
+* 'kkdcp://kerberosproxy.example.com:443/kkdcp'</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1131,7 +1136,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If true, passwords must meet Active Directory's definition of "complex". Available in macOS 10.15 and later.</string>
+					<string>If 'true', passwords must meet Active Directory's definition of 'complex'.Available in macOS 10.15 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1159,7 +1164,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The number of prior passwords that cannot be re-used on this domain. Available in macOS 10.15 and later.</string>
+					<string>The number of prior passwords that cannot be re-used on this domain.Available in macOS 10.15 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1189,7 +1194,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The minimum length of passwords on the domain. Available in macOS 10.15 and later.</string>
+					<string>The minimum length of passwords on the domain.Available in macOS 10.15 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1249,7 +1254,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The text version of the domain's password requirements. Only for use if pwReqComplexity or pwReqLength aren't specified. Available in macOS 10.15 and later.</string>
+					<string>The text version of the domain's password requirements. Only for use if 'pwReqComplexity' or 'pwReqLength' aren't specified. Available in macOS 10.15 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1341,7 +1346,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If true, requires the user to provide Touch ID, Face ID or their passcode to access the keychain entry.</string>
+					<string>If 'true', requires the user to provide Touch ID, Face ID or their passcode to access the keychain entry.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1403,7 +1408,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If false, disables password sync. Note that this will not work if the user is logged in with a mobile account. Available in macOS 10.15 and later.</string>
+					<string>If 'false', disables password sync. Note that this will not work if the user is logged in with a mobile account. Available in macOS 10.15 and later.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1433,7 +1438,7 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>If false, the Kerberos extension doesn't automatically use LDAP and DNS to determine its AD site name.</string>
+					<string>If 'false', the Kerberos extension doesn't automatically use LDAP and DNS to determine its AD site name.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1796,7 +1801,8 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Platform SSO authentication method supported and used by the configured SSO extension.</string>
+			<string>The Platform SSO authentication method the extension uses. Requires that the SSO Extension also supports the method.
+Available in macOS 13 and later.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>14.0</string>
 			<key>pfm_macos_min</key>
@@ -1824,7 +1830,8 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Platform SSO token for use in silent registration.</string>
+			<string>The token this device uses for registration with Platform SSO. Use it for silent registration with the Identity Provider. Requires that 'AuthenticationMethod' isn't empty.
+Available in macOS 13 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.familycontrols.contentfilter.plist
+++ b/Manifests/ManifestsApple/com.apple.familycontrols.contentfilter.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-09-16T02:20:42Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Parental Controls: Web Content Filter settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Parental Controls: Web Content Filter</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.familycontrols.contentfilter</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.familycontrols.contentfilter</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to true to enable Web content filters.</string>
+			<string>If 'true', enables web content filters.</string>
 			<key>pfm_name</key>
 			<string>restrictWeb</string>
 			<key>pfm_require</key>
@@ -128,7 +128,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Set to true to use the filterWhiteList and filterBlackList lists.</string>
+			<string>If 'true', enables web content filters.</string>
 			<key>pfm_name</key>
 			<string>whitelistEnabled</string>
 			<key>pfm_title</key>
@@ -156,7 +156,9 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>If specified, this key contains an array of dictionaries that define additional allowed sites besides those in the automated list of allowed and unallowed sites, including disallowed adult sites.</string>
+			<string>An array of sites that defines an allow list. If specified, this defines additional allowed sites besides those in the automated allow list and deny list, including disallowed adult sites.
+
+This key is required if 'whiteListEnabled' is 'true'.</string>
 			<key>pfm_name</key>
 			<string>siteWhitelist</string>
 			<key>pfm_subkeys</key>
@@ -168,7 +170,7 @@
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>Site prefix, including http(s) scheme.</string>
+							<string>The site prefix, including http(s) scheme.</string>
 							<key>pfm_name</key>
 							<string>address</string>
 							<key>pfm_title</key>
@@ -178,7 +180,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>Optional Page Title</string>
+							<string>The site page title.</string>
 							<key>pfm_name</key>
 							<string>pageTitle</string>
 							<key>pfm_title</key>
@@ -202,7 +204,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Set to true to try to automatically filter content.</string>
+			<string>If 'true', filters content automatically.</string>
 			<key>pfm_name</key>
 			<string>useContentFilter</string>
 			<key>pfm_title</key>
@@ -212,14 +214,14 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If specified and restrictWeb is true, an array of URLs designating the only allowed Websites.</string>
+			<string>The array of URLs that defines an allow list. When 'restrictWeb' and 'useContentFilter' are enabled, only URLs in the allow list are available to the user.</string>
 			<key>pfm_name</key>
 			<string>filterWhitelist</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>An allowed site.</string>
 					<key>pfm_name</key>
 					<string>filterWhitelistItem</string>
 					<key>pfm_title</key>
@@ -235,14 +237,14 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If specified and restrictWeb is true, an array of URLs of Websites never to be allowed.</string>
+			<string>The array of URLs that defines a deny list. When 'restrictWeb' and 'useContentFilter' are enabled, no URLs in the deny list are available to the user.</string>
 			<key>pfm_name</key>
 			<string>filterBlacklist</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A disallowed site.</string>
 					<key>pfm_name</key>
 					<string>filterBlacklistItem</string>
 					<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.familycontrols.timelimits.v2.plist
+++ b/Manifests/ManifestsApple/com.apple.familycontrols.timelimits.v2.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-29T03:07:17Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Parental Controls: Time Limit settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Parental Controls: Time Limits</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.familycontrols.timelimits.v2</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.familycontrols.timelimits.v2</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -118,7 +118,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Set to true to enable family control time limits</string>
+			<string>If 'true', enables time limits.</string>
 			<key>pfm_name</key>
 			<string>familyControlsEnabled</string>
 			<key>pfm_require</key>
@@ -129,6 +129,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>The time limits to enforce if 'familyControlsEnabled' is enabled.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -151,12 +153,14 @@
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>Weekday allowance settings</string>
+					<string>The weekday allowance settings.</string>
 					<key>pfm_name</key>
 					<string>weekday-allowance</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
+							<key>pfm_description</key>
+							<string>If 'true', enable these settings.</string>
 							<key>pfm_name</key>
 							<string>enabled</string>
 							<key>pfm_require</key>
@@ -167,6 +171,8 @@
 							<string>boolean</string>
 						</dict>
 						<dict>
+							<key>pfm_description</key>
+							<string>The allowance for that day, in seconds.</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -193,6 +199,10 @@
 						<dict>
 							<key>pfm_default</key>
 							<integer>0</integer>
+							<key>pfm_description</key>
+							<string>The type of day range:
+0 = Weekday
+1 = Weekend</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -233,11 +243,15 @@
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>The weekday curfew settings.</string>
 					<key>pfm_name</key>
 					<string>weekday-curfew</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
+							<key>pfm_description</key>
+							<string>If 'true', enable these settings.</string>
 							<key>pfm_name</key>
 							<string>enabled</string>
 							<key>pfm_require</key>
@@ -249,7 +263,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The start time for the curfew in 'hours:minutes:seconds' format.</string>
+							<string>The curfew start time, in the format '%d:%d:%d'.</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -275,7 +289,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The end time for the curfew in 'hours:minutes:seconds' format.</string>
+							<string>The curfew end time, in the format '%d:%d:%d'.</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -302,6 +316,10 @@
 						<dict>
 							<key>pfm_default</key>
 							<integer>0</integer>
+							<key>pfm_description</key>
+							<string>The type of day range:
+0 = Weekday
+1 = Weekend</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -342,11 +360,15 @@
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>The weekend allowance settings.</string>
 					<key>pfm_name</key>
 					<string>weekend-allowance</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
+							<key>pfm_description</key>
+							<string>If 'true', enable these settings.</string>
 							<key>pfm_name</key>
 							<string>enabled</string>
 							<key>pfm_require</key>
@@ -357,6 +379,8 @@
 							<string>boolean</string>
 						</dict>
 						<dict>
+							<key>pfm_description</key>
+							<string>The allowance for that day, in seconds.</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -383,6 +407,10 @@
 						<dict>
 							<key>pfm_default</key>
 							<integer>1</integer>
+							<key>pfm_description</key>
+							<string>The type of day range:
+0 = Weekday
+1 = Weekend</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -423,11 +451,15 @@
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_description</key>
+					<string>The weekend curfew settings.</string>
 					<key>pfm_name</key>
 					<string>weekend-curfew</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
+							<key>pfm_description</key>
+							<string>If 'true', enable these settings.</string>
 							<key>pfm_name</key>
 							<string>enabled</string>
 							<key>pfm_require</key>
@@ -439,7 +471,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The start time for the curfew in 'hours:minutes:seconds' format.</string>
+							<string>The curfew start time, in the format '%d:%d:%d'.</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -465,7 +497,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The end time for the curfew in 'hours:minutes:seconds' format.</string>
+							<string>The curfew end time, in the format '%d:%d:%d'.</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
@@ -492,6 +524,10 @@
 						<dict>
 							<key>pfm_default</key>
 							<integer>1</integer>
+							<key>pfm_description</key>
+							<string>The type of day range:
+0 = Weekday
+1 = Weekend</string>
 							<key>pfm_exclude</key>
 							<array>
 								<dict>

--- a/Manifests/ManifestsApple/com.apple.fileproviderd.plist
+++ b/Manifests/ManifestsApple/com.apple.fileproviderd.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-06-26T15:33:18Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures File Provider settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>File Provider</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.fileproviderd</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.fileproviderd</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,9 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile. The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -137,7 +122,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, enables file providers access to the path of the requesting process.</string>
+			<string>If 'true', enables file providers access to the path of the requesting process.</string>
 			<key>pfm_name</key>
 			<string>AllowManagedFileProvidersToRequestAttribution</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.finder.plist
+++ b/Manifests/ManifestsApple/com.apple.finder.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-03-06T08:05:44Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Finder settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Finder</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.finder</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.finder</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -118,7 +118,7 @@
 			<key>pfm_default</key>
 			<string>Full</string>
 			<key>pfm_description</key>
-			<string>Select if the standard (Full) or Simple Finder should be used</string>
+			<string>If Finder should operate in Simple or Full mode.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_macos_deprecated</key>
@@ -139,7 +139,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Warning message requiring user approval before emptying the Trash</string>
+			<string>If set to false, user will not be warned before emptying the trash.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -153,7 +153,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Opens a dialog box for finding servers on the network</string>
+			<string>If set to true, Connect to Server will be disabled.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -169,7 +169,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Ejects removable media and mountable volumes</string>
+			<string>If set to true, Eject will be disabled.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -206,7 +206,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Writes permanent information to a CD or DVD. Disc burning restrictions require both Disc Burning and Finder payloads.</string>
+			<string>If 'true', disables the Finder's burn support.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -222,7 +222,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allows user to open files or folders by typing a pathname</string>
+			<string>If set to true, Go To Folder will be disabled.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -238,7 +238,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Show hard disks on the desktop</string>
+			<string>If set to false, internal hard drives will not appear on the desktop.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -252,7 +252,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Show external disks on the desktop</string>
+			<string>If set to false, external hard drives will not appear on the desktop.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -266,7 +266,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Show removable media on the desktop</string>
+			<string>If set to false, removable media will not appear on the desktop.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>
@@ -280,7 +280,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Show connected servers on the desktop</string>
+			<string>If set to false, mounted file servers will not appear on the desktop.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/finder</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures First Active Ethernet settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>802.1X Ethernet: First Active</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.firstactiveethernet.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.firstactiveethernet.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures First Ethernet settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>802.1X Ethernet: First</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.firstethernet.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.firstethernet.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.font.plist
+++ b/Manifests/ManifestsApple/com.apple.font.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-04-15T00:45:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -25,7 +25,7 @@
 			<key>pfm_default</key>
 			<string>Configures Font settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -37,7 +37,7 @@
 			<key>pfm_default</key>
 			<string>Font</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -51,7 +51,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.font</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -65,7 +65,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.font</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -79,7 +79,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -95,7 +95,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -107,7 +107,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -117,8 +117,6 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The user-visible name for the font. This field is replaced by the actual name of the font after installation.</string>
-			<key>pfm_description_reference</key>
 			<string>The user-visible name for the font. This field is replaced by the actual name of the font after installation. Each payload must contain exactly one font file in trueType (.ttf) or OpenType (.otf) format. Collection formats (.ttc or .otc) are not supported.
 
 Fonts are identified by their embedded PostScript names. Two fonts with the same PostScript name are considered to be the same font even if their contents differ. Installing two different fonts with the same PostScript name isn't supported, and the resulting behavior is undefined.</string>
@@ -138,7 +136,7 @@ Fonts are identified by their embedded PostScript names. Two fonts with the same
 				<string>public.truetype-font</string>
 			</array>
 			<key>pfm_description</key>
-			<string>Font file (.otf or .ttf) for inclusion on device</string>
+			<string>The contents of the font file.</string>
 			<key>pfm_name</key>
 			<string>Font</string>
 			<key>pfm_note</key>

--- a/Manifests/ManifestsApple/com.apple.gamed.plist
+++ b/Manifests/ManifestsApple/com.apple.gamed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-05-03T15:38:44Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Parental Controls: Game Center settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Parental Controls: Game Center</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.gamed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.gamed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to disable Game Center.</string>
+			<string>If 'true', enables Game Center.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -130,7 +130,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to disable account modifications.</string>
+			<string>If 'true', allows account modifications.</string>
 			<key>pfm_name</key>
 			<string>GKFeatureAccountModificationAllowed</string>
 			<key>pfm_title</key>
@@ -142,7 +142,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to disable adding Game Center friends.</string>
+			<string>If 'true', allows adding Game Center friends.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -156,7 +156,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to disable multiplayer gaming.</string>
+			<string>If 'true', allows multiplayer gaming.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.3</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.globalethernet.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>17.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -30,7 +30,7 @@
 			<key>pfm_default</key>
 			<string>Configures Global Ethernet settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,7 +42,7 @@
 			<key>pfm_default</key>
 			<string>802.1X Ethernet: Global</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,7 +56,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.globalethernet.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,7 +70,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.globalethernet.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,7 +84,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,7 +100,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -112,7 +112,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.google-oauth.plist
+++ b/Manifests/ManifestsApple/com.apple.google-oauth.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>9.3</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures a Google account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Google Account</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.google-oauth</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.google-oauth</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Description of the account shown to the user</string>
+			<string>A user-visible description of the Google account, shown in the Mail and Settings apps.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
 			<key>pfm_name</key>
@@ -128,7 +128,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Full user name of the Google account</string>
+			<string>The user's full name for the Google account. This name appears in sent messages.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
 			<key>pfm_name</key>
@@ -140,7 +140,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Full Google/Gmail email address for the account</string>
+			<string>The full Google email address for the account.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3</string>
 			<key>pfm_name</key>
@@ -154,7 +154,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The communication service handler rules for this account</string>
+			<string>The communication service handler rules for this account.</string>
 			<key>pfm_ios_min</key>
 			<string>10.0</string>
 			<key>pfm_name</key>
@@ -163,7 +163,7 @@
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A dictionary defining which app to use for audio calls made from this account.</string>
 					<key>pfm_name</key>
 					<string>DefaultServiceHandlers</string>
 					<key>pfm_required</key>
@@ -172,7 +172,7 @@
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>Bundle identifier for the default application that handles audio calls made to contacts from this account</string>
+							<string>A string containing the bundle identifier for the default application that handles audio calls made to contacts from this account.</string>
 							<key>pfm_name</key>
 							<string>AudioCall</string>
 							<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.ironwood.support.plist
+++ b/Manifests/ManifestsApple/com.apple.ironwood.support.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Parental Controls: Dictation and Profanity settings</string>
+	<string>Parental controls for restricting Siri, Dictation and Profanity</string>
 	<key>pfm_domain</key>
 	<string>com.apple.ironwood.support</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Parental Controls: Dictation and Profanity settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Parental Controls: Dictation and Profanity</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ironwood.support</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ironwood.support</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to disable dictation.</string>
+			<string>If 'false', disables dictation.</string>
 			<key>pfm_name</key>
 			<string>Ironwood Allowed</string>
 			<key>pfm_title</key>
@@ -128,7 +128,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set to false to suppress profanity.</string>
+			<string>If 'false', suppresses profanity.</string>
 			<key>pfm_name</key>
 			<string>Profanity Allowed</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.jabber.account.plist
+++ b/Manifests/ManifestsApple/com.apple.jabber.account.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Messages: Jabber settings</string>
+	<string>Use this section to define settings for configuration access to Jabber servers.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.jabber.account</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-17T16:39:02Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Messages: Jabber settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Messages: Jabber</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.jabber.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mobiledevice.passwordpolicy</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The display name for the account.</string>
+			<string>The description of the account.</string>
 			<key>pfm_name</key>
 			<string>JabberAccountDescription</string>
 			<key>pfm_require</key>
@@ -126,7 +126,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The chat name of the user.</string>
+			<string>The user's user name.</string>
 			<key>pfm_name</key>
 			<string>JabberUserName</string>
 			<key>pfm_title</key>
@@ -136,7 +136,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for the account.</string>
+			<string>The user's password.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -164,7 +164,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The authentication method for the server.</string>
+			<string>The authentication method for the account.</string>
 			<key>pfm_name</key>
 			<string>JabberAuthentication</string>
 			<key>pfm_range_list</key>
@@ -186,7 +186,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the server.</string>
+			<string>The server's address.</string>
 			<key>pfm_name</key>
 			<string>JabberHostName</string>
 			<key>pfm_require</key>
@@ -200,7 +200,7 @@
 			<key>pfm_default</key>
 			<integer>5223</integer>
 			<key>pfm_description</key>
-			<string>The port on which to connect to the server.</string>
+			<string>The server's port.</string>
 			<key>pfm_name</key>
 			<string>JabberPort</string>
 			<key>pfm_range_max</key>
@@ -218,7 +218,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enable Secure Socket Layer for this connection.</string>
+			<string>If 'true', enables SSL.</string>
 			<key>pfm_name</key>
 			<string>JabberUseSSL</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.ldap.account.plist
+++ b/Manifests/ManifestsApple/com.apple.ldap.account.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>LDAP settings</string>
+	<string>Use this section to define settings for configuration access to LDAP servers.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.ldap.account</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -23,7 +23,7 @@
 			<key>pfm_default</key>
 			<string>Configures an LDAP account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -35,7 +35,7 @@
 			<key>pfm_default</key>
 			<string>LDAP</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -49,7 +49,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ldap.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -63,7 +63,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.ldap.account</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -77,7 +77,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -93,7 +93,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -105,7 +105,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -115,7 +115,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The display name of the account (e.g. 'Company LDAP Account')</string>
+			<string>The description of the account.</string>
 			<key>pfm_name</key>
 			<string>LDAPAccountDescription</string>
 			<key>pfm_title</key>
@@ -125,7 +125,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The username for this LDAP account</string>
+			<string>The user's user name.</string>
 			<key>pfm_name</key>
 			<string>LDAPAccountUserName</string>
 			<key>pfm_title</key>
@@ -135,7 +135,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for this LDAP account</string>
+			<string>The user's password. The password is enabled only with encrypted profiles.</string>
 			<key>pfm_name</key>
 			<string>LDAPAccountPassword</string>
 			<key>pfm_sensitive</key>
@@ -147,7 +147,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The LDAP Hostname or IP address</string>
+			<string>The server's address.</string>
 			<key>pfm_name</key>
 			<string>LDAPAccountHostName</string>
 			<key>pfm_require</key>
@@ -161,7 +161,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enable Secure Socket Layer for this connection</string>
+			<string>If 'true', enables SSL.</string>
 			<key>pfm_name</key>
 			<string>LDAPAccountUseSSL</string>
 			<key>pfm_title</key>
@@ -171,7 +171,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Scope and search base for this LDAP server.</string>
+			<string>An array of search settings dictionaries.</string>
 			<key>pfm_name</key>
 			<string>LDAPSearchSettings</string>
 			<key>pfm_subkeys</key>
@@ -196,7 +196,7 @@
 							<key>pfm_default</key>
 							<string>My Search</string>
 							<key>pfm_description</key>
-							<string>Description for this setting</string>
+							<string>The description of this search setting.</string>
 							<key>pfm_name</key>
 							<string>LDAPSearchSettingDescription</string>
 							<key>pfm_title</key>
@@ -208,7 +208,10 @@
 							<key>pfm_default</key>
 							<string>LDAPSearchSettingScopeSubtree</string>
 							<key>pfm_description</key>
-							<string>Defines what recursion to use in the search</string>
+							<string>The type of recursion to use in the search. It is one of the following values:
+* 'LDAPSearchSettingScopeBase': Only the immediate node that the search base points to.
+* 'LDAPSearchSettingScopeOneLevel': The node plus its immediate children.
+* 'LDAPSearchSettingScopeSubtree': The node plus all children, regardless of depth.</string>
 							<key>pfm_name</key>
 							<string>LDAPSearchSettingScope</string>
 							<key>pfm_range_list</key>
@@ -232,7 +235,7 @@
 							<key>pfm_default</key>
 							<string>o=My Company,ou=My Department</string>
 							<key>pfm_description</key>
-							<string>Conceptually, the path to the the node to start a search at</string>
+							<string>The path to the node where a search should start.</string>
 							<key>pfm_name</key>
 							<string>LDAPSearchSettingSearchBase</string>
 							<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.loginitems.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.loginitems.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-12-08T10:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Login Items settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Login Items</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.loginitems.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.loginitems.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Automatically launch these items at login.</string>
+			<string>An array of login item dictionaries.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://github.com/ProfileCreator/ProfileCreator/wiki/Login-Items</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.loginwindow.plist
+++ b/Manifests/ManifestsApple/com.apple.loginwindow.plist
@@ -16,7 +16,7 @@ window payloads may be installed together.</string>
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -27,9 +27,7 @@ window payloads may be installed together.</string>
 			<key>pfm_default</key>
 			<string>Configures Loginwindow settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -41,9 +39,7 @@ window payloads may be installed together.</string>
 			<key>pfm_default</key>
 			<string>Loginwindow</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -57,9 +53,7 @@ window payloads may be installed together.</string>
 			<key>pfm_default</key>
 			<string>com.apple.loginwindow</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -73,9 +67,7 @@ window payloads may be installed together.</string>
 			<key>pfm_default</key>
 			<string>com.apple.loginwindow</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -89,9 +81,7 @@ window payloads may be installed together.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -107,10 +97,7 @@ window payloads may be installed together.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -122,10 +109,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -204,9 +188,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<string>HostName</string>
 			<key>pfm_description</key>
-			<string>Cycle through the hostname, macOS version, and IP address when the menu bar is clicked.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If this key is included in the payload, its value will be displayed as additional computer information on the login window. Before macOS 10.10, this string could contain only particular information (HostName, SystemVersion, or IPAddress). After macOS 10.10, setting this key to any value will allow the user to click the "time" area of the menu bar to toggle through various computer information values.</string>
+			<string>If this key is included in the payload, its value is displayed in the login window as additional computer information. Before macOS 10.10, this string could contain only certain information (host name, system version, or IP address). After macOS 10.10, setting this key to any value allows the user to click the time area of the menu bar to toggle through various computer information values.</string>
 			<key>pfm_name</key>
 			<string>AdminHostInfo</string>
 			<key>pfm_range_list</key>
@@ -224,9 +206,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enter a message that's displayed above the login prompt. You might use this to provide a warning about unauthorized use.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Text to display in the login window.</string>
+			<string>The text to display in the login window.</string>
 			<key>pfm_name</key>
 			<string>LoginwindowText</string>
 			<key>pfm_title</key>
@@ -238,9 +218,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>The display style and related options of the login prompt.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Set to true to show the name and password dialog. Set to false to display a list of users.</string>
+			<string>If 'true', shows the name and password dialog; if 'false', displays a list of users.</string>
 			<key>pfm_name</key>
 			<string>SHOWFULLNAME</string>
 			<key>pfm_range_list_titles</key>
@@ -257,9 +235,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When showing a user list, set to true to show only network and system users.</string>
+			<string>If 'true', shows only network and system users when showing a user list.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -289,9 +265,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, mobile account users will not be visible in a user list. In some cases mobile users will show up as network users.</string>
+			<string>If 'true', hides mobile account users in a user list. In some cases, mobile users show up as network users.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -321,9 +295,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When showing a user list, set to true to show network users.</string>
+			<string>If 'true', shows network users when showing a user list.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -351,9 +323,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When showing a user list, set to false to hide the administrator users.</string>
+			<string>If 'true', hides administrator users when showing a user list.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -383,9 +353,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. When showing a list of users, set to true to display Other... users.</string>
+			<string>If 'true', displays Other... when showing a list of users.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -413,9 +381,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Sleep button item will be hidden.</string>
+			<string>If 'true', disables the Sleep button.</string>
 			<key>pfm_name</key>
 			<string>SleepDisabled</string>
 			<key>pfm_title</key>
@@ -429,9 +395,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Restart item will be hidden.</string>
+			<string>If 'true', disables the Restart item.</string>
 			<key>pfm_name</key>
 			<string>RestartDisabled</string>
 			<key>pfm_title</key>
@@ -445,9 +409,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Shut Down button item will be hidden.</string>
+			<string>If 'true', disables the Shut Down button.</string>
 			<key>pfm_name</key>
 			<string>ShutDownDisabled</string>
 			<key>pfm_title</key>
@@ -461,9 +423,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Restart menu item will be disabled when the user is logged in.</string>
+			<string>If 'true', disables the Restart menu item when the user is logged in.</string>
 			<key>pfm_name</key>
 			<string>RestartDisabledWhileLoggedIn</string>
 			<key>pfm_title</key>
@@ -475,9 +435,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Shut Down menu item will be disabled when the user is logged in.</string>
+			<string>If 'true', disables the Shut Down menu item when the user is logged in.</string>
 			<key>pfm_name</key>
 			<string>ShutDownDisabledWhileLoggedIn</string>
 			<key>pfm_title</key>
@@ -489,9 +447,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Power Off menu item will be disabled when the user is logged in.</string>
+			<string>If 'true', disables the Power Off menu item when the user is logged in.</string>
 			<key>pfm_name</key>
 			<string>PowerOffDisabledWhileLoggedIn</string>
 			<key>pfm_title</key>
@@ -503,10 +459,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, this will disable the Log Out menu item when the user is logged in.
-Availability: Available in macOS 10.13 and later.</string>
+			<string>If 'true', disables the Log Out menu item when the user is logged in. Available in macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -520,10 +473,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the immediate Screen Lock functions will be disabled.
-Availability: Available in macOS 10.13 and later.</string>
+			<string>If 'true', disables the immediate Screen Lock functions. Available in macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -573,9 +523,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Both the EFI Login and loginwindow password will be required to login.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>If t'rue', disables the automatic login option when using FileVault.</string>
 			<key>pfm_documentation_source</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -589,9 +537,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Allows users to use &gt;console at the login window.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If set to true, the Other user will disregard use of the '&gt;console' special user name.</string>
+			<string>If 'true', disregards the '&gt;console' special user name, which will provide a command line UI.</string>
 			<key>pfm_name</key>
 			<string>DisableConsoleAccess</string>
 			<key>pfm_title</key>
@@ -663,9 +609,7 @@ Availability: Available in macOS 10.13 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>User or group GUIDs of users that are allowed to log in. An asterisk '*' string specifies all users or groups.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. User or group GUIDs of users that are allowed to log in. An asterisk '*' string specifies all users or groups.</string>
+			<string>The list of user GUIDs or group GUIDs of users that are allowed to log in. An asterisk '*' string specifies all users or groups.</string>
 			<key>pfm_name</key>
 			<string>AllowList</string>
 			<key>pfm_subkeys</key>
@@ -692,9 +636,7 @@ Availability: Available in macOS 10.13 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>User or group GUIDs of users that cannot log in. This list takes priority over the list in the AllowList key.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. User or group GUIDs of users that cannot log in. This list takes priority over the list in the AllowList key.</string>
+			<string>The list of user GUIDs or group GUIDs of users that cannot log in. This list takes priority over the list in the 'AllowList' key.</string>
 			<key>pfm_name</key>
 			<string>DenyList</string>
 			<key>pfm_subkeys</key>
@@ -823,9 +765,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>If 'True', shows the Input Menu in the login window.</string>
 			<key>pfm_documentation_source</key>
 			<string></string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.lom.plist
+++ b/Manifests/ManifestsApple/com.apple.lom.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Use this section to define settings for Lights Out Management (LOM).</string>
+	<string>Configures a computer to send or receive "PowerON". "PowerOFF", "Reset" requests.</string>
 	<key>pfm_description_reference</key>
 	<string>The Lights Off Management payload is designated by specifying com.apple.lom as the PayloadType.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures Lights Out Management settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>Lights Out Management settings</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.lom</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.lom</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -136,7 +120,8 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An array of UUIDs of payloads in this profile that contain certificates that will be used for controller certificate trustworthiness evaluation.</string>
+			<string>Array of payload UUIDs containing CA certificates that devices use to evaluate trust of controller certificates.
+This key configures the device to accept the LOMDeviceRequestCommand from MDM and then send it to the target device. This certificate must contain the Key Usage attributes of Digital Signature, Key Encipherment and Data Encipherment. As well as the Extended Key Usage attributes of Server Authentication and Client Authentication.</string>
 			<key>pfm_name</key>
 			<string>ControllerCACertificateUUIDs</string>
 			<key>pfm_subkeys</key>
@@ -157,7 +142,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>UUID of a payload in this profile that contains the certificate of the LOM controller. Configures the device to accept LOMDeviceRequestCommand.</string>
+			<string>The UUID certificate for the LOM controller. This key configures the device to accept the LOMDeviceRequestCommand from MDM and then send it to the target device.</string>
 			<key>pfm_name</key>
 			<string>ControllerCertificateUUID</string>
 			<key>pfm_title</key>
@@ -167,7 +152,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An array of UUIDs of payloads in this profile that contain certificates that will be used for device certificate trustworthiness evaluation.</string>
+			<string>Array of payload UUIDs containing CA certificates that controllers use to evaluate trust of device certificates.</string>
 			<key>pfm_name</key>
 			<string>DeviceCACertificateUUIDs</string>
 			<key>pfm_subkeys</key>
@@ -186,7 +171,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>UUID of a payload in this profile that contains the certificate of the LOM device. Configures the device to accept PowerON, PowerOFF, and Reset requests.</string>
+			<string>The UUID certificate for the device. This key indicates the device can receive 'PowerON', 'PowerOFF', and 'Reset' requests from a LOM controller. This certificate must contain the Key Usage attributes of Digital Signature, Key Encipherment and Data Encipherment. As well as the Extended Key Usage attributes of Server Authentication and Client Authentication.</string>
 			<key>pfm_name</key>
 			<string>DeviceCertificateUUID</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.mail.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.mail.managed.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Mail settings</string>
+	<string>Use this section to define settings for access to Email servers.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.mail.managed</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-17T11:42:43Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -23,7 +23,7 @@
 			<key>pfm_default</key>
 			<string>Configures a Mail account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -35,7 +35,7 @@
 			<key>pfm_default</key>
 			<string>Mail</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -49,7 +49,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mail.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -63,7 +63,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mail.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -77,7 +77,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -93,7 +93,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -105,7 +105,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -117,7 +117,7 @@
 			<key>pfm_default</key>
 			<string>EmailTypeIMAP</string>
 			<key>pfm_description</key>
-			<string>The protocol for accessing the account</string>
+			<string>Defines the protocol to be used for the account.</string>
 			<key>pfm_name</key>
 			<string>EmailAccountType</string>
 			<key>pfm_range_list</key>
@@ -139,7 +139,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The display name of the account (e.g. "Company Mail Account")</string>
+			<string>A user-visible description of the email account, shown in the Mail and Settings applications.</string>
 			<key>pfm_name</key>
 			<string>EmailAccountDescription</string>
 			<key>pfm_title</key>
@@ -149,8 +149,6 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Path prefix for IMAP mail server</string>
-			<key>pfm_description_reference</key>
 			<string>The path prefix for the IMAP mail server.</string>
 			<key>pfm_exclude</key>
 			<array>
@@ -177,7 +175,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The display name of the user (e.g. "John Appleseed")</string>
+			<string>The full user name for the account. This name is shown in sent messages.</string>
 			<key>pfm_name</key>
 			<string>EmailAccountName</string>
 			<key>pfm_require</key>
@@ -189,7 +187,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The address of the account (e.g. "john@company.com")</string>
+			<string>The full email address for the account. If this string isn't present in the payload, the device prompts for this string during interactive profile installation in Settings or System Preferences.</string>
 			<key>pfm_name</key>
 			<string>EmailAddress</string>
 			<key>pfm_require</key>
@@ -219,7 +217,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Messages can be moved out of this account into another.</string>
+			<string>If 'true', prevents messages from being moved out of this email account and into another account. It also prevents forwarding or replying from an account other than one the message was sent to.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -239,7 +237,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Include this account in recent address syncing</string>
+			<string>If 'true', excludes this account from Recent Addresses syncing.</string>
 			<key>pfm_ios_min</key>
 			<string>6.0</string>
 			<key>pfm_name</key>
@@ -259,7 +257,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow Mail Drop for this account</string>
+			<string>If 'true', enables this account to use Mail Drop.</string>
 			<key>pfm_ios_min</key>
 			<string>9.2</string>
 			<key>pfm_name</key>
@@ -277,7 +275,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Send outgoing mail from this account only from Mail app</string>
+			<string>If 'true', prevents this account from sending mail in any app other than the Apple Mail app.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -295,7 +293,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set to true, this account will support S/MIME</string>
+			<string>If 'true', enables S/MIME encryption. In iOS 10.0 and later, this key is ignored.</string>
 			<key>pfm_ios_max</key>
 			<string>9.3.3</string>
 			<key>pfm_ios_min</key>
@@ -315,7 +313,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Support S/MIME signing for this account</string>
+			<string>If 'true', enables S/MIME signing for this account.</string>
 			<key>pfm_ios_min</key>
 			<string>10.3</string>
 			<key>pfm_name</key>
@@ -331,7 +329,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The PayloadUUID of the identity certificate used to sign messages sent from this account.</string>
+			<string>The payload UUID of the identity certificate used to sign messages sent from this account.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -367,7 +365,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Support S/MIME encryption from this account</string>
+			<string>If 'true', enables S/MIME encryption for this account.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>12.0</string>
 			<key>pfm_ios_min</key>
@@ -385,7 +383,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The PayloadUUID of the identity certificate used to decrypt messages coming into this account.</string>
+			<string>The UUID of the identity certificate used to decrypt messages sent to this account. The public certificate is attached to outgoing mail to allow encrypted mail to be sent to this user. When the user sends encrypted mail, the public certificate is used to encrypt the copy of the mail in their Sent mailbox.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -421,7 +419,9 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow the user to choose whether to encrypt each message</string>
+			<string>If 'true', displays the per-message encryption switch in the Mail Compose UI.
+
+As of iOS 12.0, this key is deprecated. Use 'SMIMEEnableEncryptionPerMessageSwitch' instead.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>12.0</string>
 			<key>pfm_ios_min</key>
@@ -441,7 +441,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow the user to toggle S/MIME signing on or off in Settings.</string>
+			<string>If 'true', the user can turn S/MIME signing on or off in Settings.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -459,7 +459,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow the user to select the signing identity.</string>
+			<string>If 'true', the user can select the signing identity.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -477,7 +477,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If SMIMEEnableEncryptionPerMessageSwitch is false, this default cannot be changed by the user.</string>
+			<string>If 'true', enables S/MIME encryption by default.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -495,7 +495,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow the user to toggle the encryption by default setting.</string>
+			<string>If 'true', the user can turn encryption by default on/off, and encryption is on.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -513,7 +513,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow the user to select the signing identity and encryption is enabled.</string>
+			<string>If 'true', the user can select the S/MIME encryption identity, and encryption is on.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -531,7 +531,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow the user toggle encrytion in the compose view and encryption is enabled.</string>
+			<string>If 'true', displays the per-message encryption switch in the Mail Compose UI.</string>
 			<key>pfm_ios_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -583,7 +583,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Hostname or IP Address for incoming mail</string>
+			<string>The incoming mail server host name.</string>
 			<key>pfm_name</key>
 			<string>IncomingMailServerHostName</string>
 			<key>pfm_require</key>
@@ -597,7 +597,7 @@
 			<key>pfm_default</key>
 			<integer>993</integer>
 			<key>pfm_description</key>
-			<string>Port number for incoming mail</string>
+			<string>The incoming mail server port number. If no port number is specified, the default port for a given protocol is used.</string>
 			<key>pfm_name</key>
 			<string>IncomingMailServerPortNumber</string>
 			<key>pfm_range_max</key>
@@ -611,7 +611,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The username used to connect to the server for incoming mail</string>
+			<string>The user name for the email account, usually the same as the email address up to the @ character. If the user name isn't present in the payload and the account is set up to require authentication for incoming email, the device prompts for this string during interactive profile installation in Settings or System Preferences.</string>
 			<key>pfm_name</key>
 			<string>IncomingMailServerUsername</string>
 			<key>pfm_require</key>
@@ -625,7 +625,7 @@
 			<key>pfm_default</key>
 			<string>EmailAuthPassword</string>
 			<key>pfm_description</key>
-			<string>The authentication method for the incoming mail server</string>
+			<string>The authentication scheme for incoming mail.</string>
 			<key>pfm_name</key>
 			<string>IncomingMailServerAuthentication</string>
 			<key>pfm_range_list</key>
@@ -653,7 +653,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for the incoming mail server</string>
+			<string>The password for the incoming mail server. This password is used only with encrypted profiles.</string>
 			<key>pfm_name</key>
 			<string>IncomingPassword</string>
 			<key>pfm_title</key>
@@ -665,7 +665,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Retrieve incoming mail through Secure Socket Layer</string>
+			<string>If 'true', enables SSL for authentication on the incoming mail server.</string>
 			<key>pfm_name</key>
 			<string>IncomingMailServerUseSSL</string>
 			<key>pfm_title</key>
@@ -675,7 +675,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Hostname or IP address for outgoing mail</string>
+			<string>The outgoing mail server host name.</string>
 			<key>pfm_name</key>
 			<string>OutgoingMailServerHostName</string>
 			<key>pfm_require</key>
@@ -689,7 +689,7 @@
 			<key>pfm_default</key>
 			<integer>587</integer>
 			<key>pfm_description</key>
-			<string>The port number for outgoing mail</string>
+			<string>The outgoing mail server port number. If no port number is specified, ports 25, 587, and 465 are used, in that order.</string>
 			<key>pfm_name</key>
 			<string>OutgoingMailServerPortNumber</string>
 			<key>pfm_range_max</key>
@@ -703,7 +703,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The username used to connect to the server for outgoing mail</string>
+			<string>The user name for the email account, usually the same as the email address up to the @ character. If the user name isn't present in the payload and the account is set up to require authentication for outgoing email, the device prompts for this string during interactive profile installation in Settings or System Preferences.</string>
 			<key>pfm_name</key>
 			<string>OutgoingMailServerUsername</string>
 			<key>pfm_require</key>
@@ -717,7 +717,7 @@
 			<key>pfm_default</key>
 			<string>EmailAuthPassword</string>
 			<key>pfm_description</key>
-			<string>The authentication method for the outgoing mail server</string>
+			<string>The authentication scheme for outgoing mail.</string>
 			<key>pfm_name</key>
 			<string>OutgoingMailServerAuthentication</string>
 			<key>pfm_range_list</key>
@@ -745,7 +745,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for the outgoing mail server</string>
+			<string>The password for the outgoing mail server. This password is used only with encrypted profiles.</string>
 			<key>pfm_name</key>
 			<string>OutgoingPassword</string>
 			<key>pfm_title</key>
@@ -757,7 +757,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>SMTP authentication uses the same password as POP/IMAP</string>
+			<string>If 'true', the user is prompted only once for the password, which is used for both outgoing and incoming mail.
+This setting is only supported by interactive profile installations. Not supported by non-interactive installations (like MDM on iOS).</string>
 			<key>pfm_name</key>
 			<string>OutgoingPasswordSameAsIncomingPassword</string>
 			<key>pfm_title</key>
@@ -769,7 +770,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Send outgoing mail through Secure Socket Layer</string>
+			<string>If 'true', enables SSL authentication on the outgoing mail server.</string>
 			<key>pfm_name</key>
 			<string>OutgoingMailServerUseSSL</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.mcxloginscripts.plist
+++ b/Manifests/ManifestsApple/com.apple.mcxloginscripts.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Login Window: Scripts settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Login Window: Scripts</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mcxloginscripts</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mcxloginscripts</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Select the script that runs when users log in</string>
+			<string>An array of one or more dictionaries of scripts to run at user login time.</string>
 			<key>pfm_name</key>
 			<string>loginscripts</string>
 			<key>pfm_range_min</key>
@@ -179,7 +179,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Run any LoginHook script in addition to the Login script</string>
+			<string>If 'true', doesn't execute the login scripts during login.</string>
 			<key>pfm_name</key>
 			<string>skipLoginHook</string>
 			<key>pfm_title</key>
@@ -191,7 +191,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Select the script that runs when users log out</string>
+			<string>An array of one or more dictionaries of scripts to run at user logout time.</string>
 			<key>pfm_name</key>
 			<string>logoutscripts</string>
 			<key>pfm_range_min</key>
@@ -256,7 +256,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Run any LogoutHook script in addition to the Logout script</string>
+			<string>If 'true', doesn't execute the logout scripts during logout.</string>
 			<key>pfm_name</key>
 			<string>skipLogoutHook</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.mcxprinting.plist
+++ b/Manifests/ManifestsApple/com.apple.mcxprinting.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>exlusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures Printing settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>Printing</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mcxprinting</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mcxprinting</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -138,7 +122,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If true, allows printers that connect directly to a user's computer.</string>
+			<string>If 'true', allows printers that connect directly to a user's computer.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -152,7 +136,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The default printer for the user. This information should match one of the printers in the Printer List.</string>
+			<string>The default printer for the user.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_exclude</key>
@@ -177,7 +161,7 @@ The payload organization for a payload need not match the payload organization i
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The printer display name. This should match one of the printers in the Printer List.</string>
+					<string>The display name.</string>
 					<key>pfm_documentation_url</key>
 					<string>https://developer.apple.com/documentation/devicemanagement/printing/defaultprinter</string>
 					<key>pfm_macos_min</key>
@@ -195,7 +179,7 @@ The payload organization for a payload need not match the payload organization i
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The device URI. This should match one of the printers in the Printer List.</string>
+					<string>The device URI.</string>
 					<key>pfm_documentation_url</key>
 					<string>https://developer.apple.com/documentation/devicemanagement/printing/defaultprinter</string>
 					<key>pfm_macos_min</key>
@@ -221,7 +205,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, prints the page footer (including the user name and date).</string>
+			<string>If 'true', prints the page footer (including the user name and date).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -235,7 +219,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The font to use when printing a footer.</string>
+			<string>The footer font name.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -249,7 +233,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The font size to use when printing a footer.</string>
+			<string>The footer font size.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -265,7 +249,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, includes the MAC address.</string>
+			<string>If 'true', includes the MAC address.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -281,7 +265,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If true, requires an administrator password to add printers.</string>
+			<string>If 'true', requires an administrator password to add printers.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -297,7 +281,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, requires an administrator password to print locally.</string>
+			<string>If 'true', requires an administrator password to print locally.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -313,7 +297,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, shows only managed printers.</string>
+			<string>If 'true', shows only managed printers.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://developer.apple.com/documentation/devicemanagement/printing</string>
 			<key>pfm_macos_min</key>
@@ -338,7 +322,7 @@ The payload organization for a payload need not match the payload organization i
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>A printer item in the printer list</string>
+					<string>A dictionary of printer details.</string>
 					<key>pfm_hidden</key>
 					<string>container</string>
 					<key>pfm_name</key>
@@ -349,7 +333,7 @@ The payload organization for a payload need not match the payload organization i
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>The printer display name.</string>
+							<string>The display name.</string>
 							<key>pfm_name</key>
 							<string>DisplayName</string>
 							<key>pfm_require</key>
@@ -417,7 +401,7 @@ The payload organization for a payload need not match the payload organization i
 							<key>pfm_default</key>
 							<false/>
 							<key>pfm_description</key>
-							<string>If true, locks the printer.</string>
+							<string>If 'true', locks the printer.</string>
 							<key>pfm_name</key>
 							<string>PrinterLocked</string>
 							<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.mdm.plist
+++ b/Manifests/ManifestsApple/com.apple.mdm.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Use this section to define mobile device management (MDM) settings.</string>
+	<string>Use this section to define settings for mobile device management.</string>
 	<key>pfm_documentation_url</key>
 	<string>https://developer.apple.com/documentation/devicemanagement/mdm</string>
 	<key>pfm_domain</key>
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -28,7 +28,7 @@
 			<key>pfm_default</key>
 			<string>Use this section to define mobile device management (MDM) settings.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,7 +40,7 @@
 			<key>pfm_default</key>
 			<string>MDM</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,7 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mdm</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,7 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mdm</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,7 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -98,7 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -110,7 +110,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -120,7 +120,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>URL used by the device to contact and retrieve device management instructions. Must be an HTTPS URL and may contain a port number.</string>
+			<string>The URL that the device contacts to retrieve device management instructions. The URL must begin with the 'https://' URL scheme, and may contain a port number (':1234', for example).</string>
 			<key>pfm_format</key>
 			<string>^https://.+$</string>
 			<key>pfm_name</key>
@@ -134,7 +134,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An array of UUIDs of Certificate payloads in this profile. The certificates are used for evaluating trustworthiness of the Connect URLs of MDM servers.</string>
+			<string>An array of strings, each containing the UUID of a certificate to be used when evaluating trust to the '.../connect/' URLs of MDM servers.</string>
 			<key>pfm_name</key>
 			<string>ServerURLPinningCertificateUUIDs</string>
 			<key>pfm_subkeys</key>
@@ -151,7 +151,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An array of unique capability identifiers.</string>
+			<string>A unique array of strings indicating server capabilities. If the server manages macOS devices or a Shared iPad, this field is mandatory and must contain the value 'com.apple.mdm.per-user-connections', which indicates that the server supports both device and user connections.
+Starting with macOS 11, it is also recommended that macOS device enrollment profiles contain the value 'com.apple.mdm.bootstraptoken' to ensure the Bootstrap Token is created and escrowed with the MDM server at enrollment time.</string>
 			<key>pfm_name</key>
 			<string>ServerCapabilities</string>
 			<key>pfm_subkeys</key>
@@ -178,7 +179,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The topic that MDM listens to for Push notifications. The topic must have the prefix 'com.apple.mgmt.'. Also, certificate used by the server to send notifications must contain this topic in its subject.</string>
+			<string>The topic that MDM listens to for push notifications. The certificate that the server uses to send push notifications must have the same topic in its subject. The topic must begin with the 'com.apple.mgmt.' prefix.</string>
 			<key>pfm_format</key>
 			<string>^com\.apple\.mgmt\..+$</string>
 			<key>pfm_name</key>
@@ -192,7 +193,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>UUID of a Certificate or SCEP payload in this profile, which will be used for the identity of the device.</string>
+			<string>The UUID of the certificate payload for the device's identity. It may also point to a SCEP payload.</string>
 			<key>pfm_name</key>
 			<string>IdentityCertificateUUID</string>
 			<key>pfm_require</key>
@@ -204,7 +205,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The Managed Apple ID of the user. Available in iOS 13.1 and later, and macOS 10.15 and later. This is only used with the profile-driven BYOD enrollment flow, and must not be present in the BYOD and ADDE account-driven enrollment flows. As of iOS 17 and macOS 14, profile-driven user enrollments are deprecated and will be removed in a future release.</string>
+			<string>The Managed Apple ID of the user. Available in iOS 13.1 and later, and macOS 10.15 and later. This is only used with the profile-based BYOD enrollment flow.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>17.0</string>
 			<key>pfm_ios_min</key>
@@ -227,7 +228,22 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Logical OR of access rights bit-flags. When 2 is specified 1 must be specified along. When 128 is specified 64 must be specified along. This property is ignored when ManagedAppleID is present.</string>
+			<string>Logical OR of the following bit flags:
+'1': Allow inspection of installed configuration profiles.
+'2': Allow installation and removal of configuration profiles.
+'4': Allow device lock and passcode removal.
+'8': Allow device erase.
+'16': Allow query of device information (device capacity, serial number).
+'32': Allow query of network information (phone/SIM numbers, MAC addresses).
+'64': Allow inspection of installed provisioning profiles.
+'128': Allow installation and removal of provisioning profiles.
+'256': Allow inspection of installed applications.
+'512': Allow restriction-related queries.
+'1024': Allow security-related queries.
+'2048': Allow manipulation of settings.
+'4096': Allow app management.
+The value can't be '0'. If '2' is specified, '1' must also be specified. If '128' is specified, '64' must also be specified.
+If the 'ManagedAppleID' is included, then 'AccessRights' are ignored.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -266,7 +282,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>URL used by the device for checking-in during installation. When omitted, ServerURL will be used for checking-in as well instead. Must be an HTTPS URL and may contain a port number.</string>
+			<string>The URL that the device should use to check in during installation. The URL must begin with the 'https://' URL scheme and may contain a port number (':1234', for example). If this URL isn't given, 'ServerURL' is used for both purposes.</string>
 			<key>pfm_format</key>
 			<string>^https://.+$</string>
 			<key>pfm_name</key>
@@ -278,7 +294,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An array of UUIDs of Certificate payloads in this profile. The certificates are used for evaluating trustworthiness of the Check-In URLs of MDM servers.</string>
+			<string>An array of strings, each containing the payload UUID of a certificate to be used when evaluating trust to the '.../checkin/' URLs of MDM servers.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -311,7 +327,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When enabled, the device will attempt to send a check-out message on removal of this profile.</string>
+			<string>If 'true', the device attempts to send a CheckOut &lt;https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/MobileDeviceManagementProtocolRef/2-MDM_Check_In_Protocol/MDM_Check_In_Protocol..html#//apple_ref/doc/uid/TP40017387-CH4-SW7&gt; message to the 'CheckInURL' when the profile is removed.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -337,7 +353,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When enabled, verified positive responses are required in order to pass certificate revocation checks. Otherwise, failed attemps to reach the server may not fail checks.</string>
+			<string>If 'true', fails the connection attempt unless a verified positive response is obtained during certificate revocation checks.
+If 'false', revocation checks are done on a best-attempt basis, where failure to reach the server isn't considered fatal.</string>
 			<key>pfm_name</key>
 			<string>PinningRevocationCheckRequired</string>
 			<key>pfm_title</key>
@@ -349,7 +366,11 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When enabled, notifies the user about needing to reboot into RecoveryOS and allowing the MDM to use the Bootstrap Token for authentication for certain operations (e.g. enabling some kernel extensions or software updates). When these operations are unnecessary for the MDM server to perform, this key can remain false.</string>
+			<string>If 'true', warns the user that they need to reboot into RecoveryOS and allow the MDM to use the Bootstrap Token for authentication for certain sensitive operations such as enabling kernel extensions or installing some types of software updates. If the MDM doesn't need to perform these operations, it can leave this key set to 'false', and the user won't be notified.
+The SettingsCommand.Command.Settings.MDMOptions.MDMOptions command overrides this default value.
+This setting only applies to devices that have 'BootstrapTokenRequiredForSoftwareUpdate' or 'BootstrapTokenRequiredForKernelExtensionApproval' set to 'true' in their SecurityInfoResponse.SecurityInfo.
+DEP-enrolled devices are automatically allowed to use the Bootstrap Token for authentication.
+Available in macOS 11 and later.</string>
 			<key>pfm_name</key>
 			<string>PromptUserToAllowBootstrapTokenForAuthentication</string>
 			<key>pfm_title</key>
@@ -361,7 +382,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When enabled, messages coming from the device will bear the Mdm-Signature HTTP header.</string>
+			<string>If 'true', each message coming from the device carries the additional 'Mdm-Signature' HTTP header.</string>
 			<key>pfm_name</key>
 			<string>SignMessage</string>
 			<key>pfm_title</key>
@@ -373,7 +394,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>When enabled, the device will you development APNS servers instead of production ones. Must not be enabled when using Apple Push Notification Service certificate issued by the Apple Push Certificate Portal.</string>
+			<string>If 'true', the device uses the development APNS servers. Otherwise, the device uses the production servers.
+Note that this property must be set to 'false' if your Apple Push Notification Service certificate was issued by the Apple Push Certificate Portal ('https://identity.apple.com/pushcert'). That portal only issues certificates for the production push environment.</string>
 			<key>pfm_name</key>
 			<string>UseDevelopmentAPNS</string>
 			<key>pfm_title</key>
@@ -383,7 +405,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The Managed Apple ID pre-assigned to the authenticated user of a user-enrolled (non-supervised) device.</string>
+			<string>The Managed Apple ID pre-assigned to the authenticated user. This is only used with the account-based BYOD enrollment flow. Available in iOS 15 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_macos_min</key>
@@ -399,7 +421,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The enrollment mode for a user-enrolled (non-supervised) device.</string>
+			<string>The enrollment mode the server indicates must be used when enrolling. This must be present for account-based BYOD enrollments, but must not be present for profile-based BYOD enrollments. Available in iOS 15 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>15.0</string>
 			<key>pfm_macos_min</key>
@@ -422,7 +444,9 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>iTunesStoreID of a single app that the MDM service can require and push to a user-enrolled (non-supervised) device.</string>
+			<string>This property specifies an iTunes Store ID for an app the system can install with the InstallApplicationCommand, without any approval from the user. The MDM vendor or managing organization generally provides this app, which enhances the management experience for the user. The device shows the user details about this app in the account-driven enrollment process prior to installing the MDM profile. Use this property with account-driven MDM enrollments that normally require user approval for app installs through MDM.
+Only account-driven user enrollments support this property and other enrollment types ignore it.
+Available in iOS 15.1 and later.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.apple.com/en-in/guide/deployment/dep950aed53e/web</string>
 			<key>pfm_ios_min</key>

--- a/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
+++ b/Manifests/ManifestsApple/com.apple.mobiledevice.passwordpolicy.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Passcode settings</string>
+	<string>Use this section to define passcode policy settings</string>
 	<key>pfm_domain</key>
 	<string>com.apple.mobiledevice.passwordpolicy</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -23,7 +23,7 @@
 			<key>pfm_default</key>
 			<string>Configures Passcode settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -35,7 +35,7 @@
 			<key>pfm_default</key>
 			<string>Passcode</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -49,7 +49,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mobiledevice.passwordpolicy</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -63,7 +63,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.mobiledevice.passwordpolicy</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -77,7 +77,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -93,7 +93,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -105,7 +105,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -117,9 +117,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Enforce the use of a passcode before using the device.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, forces the user to enter a PIN.</string>
+			<string>If 'true', forces the user to enter a PIN.</string>
 			<key>pfm_name</key>
 			<string>forcePIN</string>
 			<key>pfm_title</key>
@@ -131,9 +129,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Permits the use of repeating, ascending, and descending character sequences in passcodes. For example, "3333" or "DEFG".</string>
-			<key>pfm_description_reference</key>
-			<string>If true, allows a simple passcode. A simple passcode contains repeated characters, or increasing or decreasing characters (such as 123 or CBA). Setting this value to false has the same result as setting minComplexChars to 1.</string>
+			<string>If 'false', prevents use of a simple passcode. A simple passcode contains repeated characters, or increasing or decreasing characters (such as '123' or 'CBA').</string>
 			<key>pfm_name</key>
 			<string>allowSimple</string>
 			<key>pfm_note</key>
@@ -147,9 +143,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Requires that the passcode contain at least one letter and one number.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, requires alphabetic characters (abcd) instead of only numeric characters.</string>
+			<string>If 'true', requires alphabetic characters (abcd) instead of only numeric characters.</string>
 			<key>pfm_name</key>
 			<string>requireAlphanumeric</string>
 			<key>pfm_title</key>
@@ -161,8 +155,6 @@
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Minimum number of characters a passcode can contain.</string>
-			<key>pfm_description_reference</key>
 			<string>The minimum overall length of the passcode. This parameter is independent of the also optional minComplexChars argument.</string>
 			<key>pfm_name</key>
 			<string>minLength</string>
@@ -179,9 +171,8 @@
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Minimum number of non-alphanumeric characters the passcode must contain.</string>
-			<key>pfm_description_reference</key>
-			<string>The minimum number of complex characters that a passcode must contain. A complex character is a character other than a number or a letter, such as &amp; % $ #.</string>
+			<string>The minimum number of complex characters that a passcode must contain. A complex character is a character other than a number or a letter, such as &amp; % $ #.
+This property is ignored for User Enrollments.</string>
 			<key>pfm_name</key>
 			<string>minComplexChars</string>
 			<key>pfm_range_max</key>
@@ -195,8 +186,6 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Requires users to change their passcode at the specified interval. It can be set to between 1 and 730 days, or turned off with a value of 0.</string>
-			<key>pfm_description_reference</key>
 			<string>The number of days for which the passcode can remain unchanged. After this number of days, the user is forced to change the passcode before the device is unlocked.</string>
 			<key>pfm_name</key>
 			<string>maxPINAgeInDays</string>
@@ -213,9 +202,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If the device isn't used for the period of time you specify, it automatically locks. It can be set to lock after 1 to 15 minutes, or turned off with a value of 0. In macOS, this inactivity value is translated to screen-saver settings.</string>
-			<key>pfm_description_reference</key>
-			<string>The maximum number of minutes for which the device can be idle, without being unlocked by the user, before it gets locked by the system. When this limit is reached, the device is locked and the passcode must be entered. The user can edit this setting, but the value cannot exceed the maxInactivity value. In macOS, this inactivity value is translated to screen-saver settings.</string>
+			<string>The maximum number of minutes for which the device can be idle, without being unlocked by the user, before it gets locked by the system. When this limit is reached, the device is locked and the passcode must be entered. The user can edit this setting, but the value cannot exceed the 'maxInactivity' value. In macOS, this inactivity value is translated to screen-saver settings. The maximum value for macOS is 60 minutes.</string>
 			<key>pfm_name</key>
 			<string>maxInactivity</string>
 			<key>pfm_range_max</key>
@@ -229,7 +216,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The device refuses a new passcode if it matches a previously used passcode. You can specify how many previous passcodes are remembered and compared. It can be set to between 1 and 50 passcodes, or turned off with a value of 0.</string>
+			<string>This value defines N, where the new passcode must be unique within the last N entries in the passcode history.</string>
 			<key>pfm_name</key>
 			<string>pinHistory</string>
 			<key>pfm_range_max</key>
@@ -247,8 +234,6 @@
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>How soon the device can be unlocked again after use, without reprompting again for the passcode. (0 = no grace period, which requires a passcode immediately). In macOS, this grace period value is translated to screen-saver settings.</string>
-			<key>pfm_description_reference</key>
 			<string>The maximum grace period, in minutes, to unlock the phone without entering a passcode. The default is 0, which is no grace period and requires a passcode immediately. In macOS, this grace period value is translated to screen-saver settings.</string>
 			<key>pfm_name</key>
 			<string>maxGracePeriod</string>
@@ -279,9 +264,7 @@
 			<key>pfm_default</key>
 			<integer>11</integer>
 			<key>pfm_description</key>
-			<string>The number of failed passcode attempts that can be made before an iOS device is erased or a macOS device is locked.</string>
-			<key>pfm_description_reference</key>
-			<string>The number of allowed failed attempts to enter the passcode at the device's lock screen. After six failed attempts, a time delay is imposed before a passcode can be entered again. The delay increases with each attempt. In macOS, set minutesUntilFailedLoginReset to define a delay before the next passcode can be entered. When this number is exceeded in macOS, the device is locked; in iOS, the device is wiped.</string>
+			<string>The number of allowed failed attempts to enter the passcode at the device's lock screen. After six failed attempts, a time delay is imposed before a passcode can be entered again. The delay increases with each attempt. In macOS, set 'minutesUntilFailedLoginReset' to define a delay before the next passcode can be entered. When this number is exceeded in macOS, the device is locked; in iOS, the device is wiped.</string>
 			<key>pfm_name</key>
 			<string>maxFailedAttempts</string>
 			<key>pfm_range_max</key>
@@ -295,9 +278,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The number of minutes before the login window reappears, after the maximum number of failed attempts is reached. This key requires setting maxFailedAttempts.</string>
-			<key>pfm_description_reference</key>
-			<string>The number of minutes before the login is reset after the maximum number of unsuccessful login attempts is reached. This key requires setting maxFailedAttempts. Available in macOS 10.10 and later.</string>
+			<string>The number of minutes before the login is reset after the maximum number of unsuccessful login attempts is reached. This key requires setting 'maxFailedAttempts'. Available in macOS 10.10 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.10.0</string>
 			<key>pfm_name</key>
@@ -317,9 +298,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Causes a password reset to occur the next time the user tries to authenticate.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, causes a password reset to occur the next time the user tries to authenticate. If this key is set in a device profile, the setting takes effect for all users, and admin authentications may fail until the admin user password is also reset. Available in macOS 10.13 and later.</string>
+			<string>If 'true', causes a password reset to occur the next time the user tries to authenticate. If this key is set in a device profile, the setting takes effect for all users, and admin authentications may fail until the admin user password is also reset. Available in macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.networkusagerules.plist
+++ b/Manifests/ManifestsApple/com.apple.networkusagerules.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-05-19T15:22:16Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Network Usage Rules settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Network Usage Rules</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.networkusagerules</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.networkusagerules</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Specify how managed apps use cellular data networks</string>
+			<string>An array of application rules, that apply to only managed apps.</string>
 			<key>pfm_name</key>
 			<string>ApplicationRules</string>
 			<key>pfm_subkeys</key>
@@ -128,7 +128,9 @@
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>A list of managed app identifiers, as strings, that must follow the associated rules. If this key is missing, the rules will apply to all managed apps on the device.</string>
+							<string>A list of managed app identifiers, as strings, that must follow the associated rules. If this key is missing, the rules apply to all managed apps on the device.
+
+Each string in the 'AppIdentifierMatches' array may either be an exact app identifier match (for example, 'com.mycompany.myapp') or it may specify a prefix match for the bundle ID by using the * wildcard character. If used, this character must appear after a period (.) and may only appear once, at the end of the string; for example, 'com.mycompany.*'.</string>
 							<key>pfm_name</key>
 							<string>AppIdentifierMatches</string>
 							<key>pfm_subkeys</key>
@@ -155,7 +157,7 @@
 							<key>pfm_default</key>
 							<true/>
 							<key>pfm_description</key>
-							<string>Allow cellular data over the network</string>
+							<string>If 'false', disables cellular data for all matching managed apps.</string>
 							<key>pfm_name</key>
 							<string>AllowCellularData</string>
 							<key>pfm_title</key>
@@ -167,7 +169,7 @@
 							<key>pfm_default</key>
 							<true/>
 							<key>pfm_description</key>
-							<string>Allow data roaming over the network</string>
+							<string>If 'false', disables cellular data while roaming for all matching managed apps.</string>
 							<key>pfm_name</key>
 							<string>AllowRoamingCellularData</string>
 							<key>pfm_title</key>
@@ -189,7 +191,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Specify the Wi-Fi assist policy to be used with specific SIM cards</string>
+			<string>An array of SIM rules, that apply to all apps.</string>
 			<key>pfm_name</key>
 			<string>SIMRules</string>
 			<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.notificationsettings-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.notificationsettings-iOS.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Configures Notification settings for iOS apps</string>
+	<string>Configures notifications settings for apps</string>
 	<key>pfm_documentation_url</key>
 	<string>https://developer.apple.com/documentation/devicemanagement/notifications/notificationsettingsitem?changes=latest_minor</string>
 	<key>pfm_domain</key>
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>9.3</string>
 	<key>pfm_last_modified</key>
-	<date>2022-06-07T07:38:53Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -28,7 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures Notification settings for iOS apps</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,7 +40,7 @@
 			<key>pfm_default</key>
 			<string>Notifications</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,7 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.notificationsettings</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,7 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.notificationsettings</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,7 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -98,7 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -110,7 +110,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -120,7 +120,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Notification settings for iOS apps</string>
+			<string>An array of notification settings dictionaries.</string>
 			<key>pfm_name</key>
 			<string>NotificationSettings</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.notificationsettings-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.notificationsettings-macOS.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Configures Notification settings for iOS &amp; macOS apps</string>
+	<string>Configures notifications settings for apps</string>
 	<key>pfm_documentation_url</key>
 	<string>https://developer.apple.com/documentation/devicemanagement/notifications/notificationsettingsitem?changes=latest_minor</string>
 	<key>pfm_domain</key>
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Notification settings for macOS apps</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Notifications</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.notificationsettings</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.notificationsettings</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -118,7 +118,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Notification settings for macOS apps</string>
+			<string>An array of notification settings dictionaries.</string>
 			<key>pfm_name</key>
 			<string>NotificationSettings</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.osxserver.account.plist
+++ b/Manifests/ManifestsApple/com.apple.osxserver.account.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Use the macOS Server Accounts payload to specify macOS Server account information allowing an iOS device to use it as a document repository.</string>
+	<string>Use this section to define a macOS Server account</string>
 	<key>pfm_domain</key>
 	<string>com.apple.osxserver.account</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures a macOS Server account</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Server Account</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.osxserver.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.osxserver.account</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 			<key>pfm_default</key>
 			<string>My macOS Server Account</string>
 			<key>pfm_description</key>
-			<string>The display name for the macOS Server Account.</string>
+			<string>The description of the account.</string>
 			<key>pfm_name</key>
 			<string>AccountDescription</string>
 			<key>pfm_require</key>
@@ -128,7 +128,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of the server.</string>
+			<string>The server's address.</string>
 			<key>pfm_name</key>
 			<string>HostName</string>
 			<key>pfm_require</key>
@@ -140,7 +140,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The name of the user.</string>
+			<string>The user's user name.</string>
 			<key>pfm_name</key>
 			<string>UserName</string>
 			<key>pfm_require</key>
@@ -152,7 +152,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for the user.</string>
+			<string>The user's password.</string>
 			<key>pfm_name</key>
 			<string>Password</string>
 			<key>pfm_title</key>
@@ -162,7 +162,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The port on macOS Server over which the connection is established.</string>
+			<string>Array of dictionaries containing configured account types and relevant settings</string>
 			<key>pfm_name</key>
 			<string>ConfiguredAccounts</string>
 			<key>pfm_range_max</key>

--- a/Manifests/ManifestsApple/com.apple.preference.security.plist
+++ b/Manifests/ManifestsApple/com.apple.preference.security.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures System Preferences: Security settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>System Preferences: Security</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.preference.security</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.preference.security</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If 'true', disables user changes to the password.</string>
 			<key>pfm_name</key>
 			<string>dontAllowPasswordResetUI</string>
 			<key>pfm_title</key>
@@ -130,7 +130,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
+			<string>If 'true', disables user changes to the lock message.</string>
 			<key>pfm_name</key>
 			<string>dontAllowLockMessageUI</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.profileRemovalPassword.plist
+++ b/Manifests/ManifestsApple/com.apple.profileRemovalPassword.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-09-27T09:00:30Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures a password for profile removal</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Profile Removal</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.profileRemovalPassword</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.profileRemovalPassword</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for profile removal.</string>
+			<string>The password for allowing the profile to be removed.</string>
 			<key>pfm_name</key>
 			<string>RemovalPassword</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.proxy.http.global.plist
+++ b/Manifests/ManifestsApple/com.apple.proxy.http.global.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Global HTTP Proxy settings</string>
+	<string>Global HTTP Proxy (Supervised devices only)</string>
 	<key>pfm_domain</key>
 	<string>com.apple.proxy.http.global</string>
 	<key>pfm_format_version</key>
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>6.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -28,7 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures Global HTTP Proxy settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,7 +40,7 @@
 			<key>pfm_default</key>
 			<string>Global HTTP Proxy</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,7 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.proxy.http.global</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,7 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.proxy.http.global</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,7 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -98,7 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -110,7 +110,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -122,7 +122,7 @@
 			<key>pfm_default</key>
 			<string>Manual</string>
 			<key>pfm_description</key>
-			<string>Use Manual for proxies that require authentication.</string>
+			<string>The proxy type. For a manual proxy type, the profile contains the proxy server address, including its port, and optionally a user name and password. For an auto proxy type, you can enter a PAC URL.</string>
 			<key>pfm_name</key>
 			<string>ProxyType</string>
 			<key>pfm_range_list</key>
@@ -157,7 +157,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The proxy server's network address. This is required if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
+			<string>The proxy server's network address.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -203,7 +203,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The proxy server's port number. This is required if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
+			<string>The proxy server's port number.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -229,7 +229,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The user name used to authenticate to the proxy server. This setting is only used if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
+			<string>The user name used to authenticate to the proxy server.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -255,7 +255,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password used to authenticate to the proxy server. This setting is only used if the ProxyType is set to Manual, and is ignored if the ProxyType is set to Automatic.</string>
+			<string>The password used to authenticate to the proxy server.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -281,7 +281,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The URL of the PAC file that defines the proxy configuration.</string>
+			<string>The URL of the PAC file that defines the proxy configuration. Starting in iOS 13 and macOS 10.15, only URLs that begin with 'http://' or 'https://' are allowed.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -313,7 +313,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Proxy PAC Fallback Allowed</string>
+			<string>If 'true', allows connecting directly to the destination if the proxy autoconfiguration (PAC) file is unreachable.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -341,7 +341,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allow the device to bypass the proxy server to display the login page for captive networks.</string>
+			<string>If 'true', allows the device to bypass the proxy server to display the login page for captive networks.</string>
 			<key>pfm_name</key>
 			<string>ProxyCaptiveLoginAllowed</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.relay.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.relay.managed.plist
@@ -11,7 +11,7 @@
 	<key>pfm_ios_min</key>
 	<string>17.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>14.0</string>
 	<key>pfm_platforms</key>
@@ -25,9 +25,7 @@
 			<key>pfm_default</key>
 			<string>Use this section to define settings for network relays.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,9 +37,7 @@
 			<key>pfm_default</key>
 			<string>Relay</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,9 +51,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.relay.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -71,9 +65,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.relay.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -85,9 +77,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -103,9 +93,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -117,7 +105,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.screensaver.plist
+++ b/Manifests/ManifestsApple/com.apple.screensaver.plist
@@ -15,7 +15,7 @@ password function.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.11</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@ password function.</string>
 			<key>pfm_default</key>
 			<string>Screensaver settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@ password function.</string>
 			<key>pfm_default</key>
 			<string>Screensaver</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@ password function.</string>
 			<key>pfm_default</key>
 			<string>com.apple.screensaver</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@ password function.</string>
 			<key>pfm_default</key>
 			<string>com.apple.screensaver</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@ password function.</string>
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@ password function.</string>
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -154,10 +138,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, the user will be prompted for a password when the screensaver is unlocked or stopped.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If true, the user will be prompted for a password when the screensaver is unlocked or stopped. When using this prompt, askForPasswordDelay must also be provided.
-Availability: Available in macOS 10.13 and later.</string>
+			<string>If 'true', the user is prompted for a password when the screen saver is unlocked or stopped. When you use this prompt, you must also provide 'askForPasswordDelay'. Available in macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -189,10 +170,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Number of seconds to delay before the password will be required to unlock or stop the screen saver (the "grace period"). A value of 2147483647 can be used to disable this requirement.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Number of seconds to delay before the password will be required to unlock or stop the screen saver (the ”grace period”). A value of 2147483647 (eg 0x7FFFFFFF) can be used to disable this requirement, and on 10.13, the payload is one of the only ways of disabling the feature. Note that askForPassword must be set to true to use this option.
-Availability: Available in macOS 10.13 and later.</string>
+			<string>The number of seconds to delay before the password will be required to unlock or stop the screen saver (the grace period). A value of '2147483647' (for example, '0x7FFFFFFF') disables this requirement. To use this option, you must set 'askForPassword' to 'true'. Available in macOS 10.13 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13</string>
 			<key>pfm_name</key>
@@ -204,9 +182,7 @@ Availability: Available in macOS 10.13 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A full path to the screen saver module to be used.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A full path to the screen saver module to be used. Availability: Available in macOS 10.11 and later.</string>
+			<string>The full path to the screen-saver module to use.</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -220,10 +196,7 @@ Availability: Available in macOS 10.13 and later.</string>
 			<key>pfm_default</key>
 			<integer>300</integer>
 			<key>pfm_description</key>
-			<string>Number of seconds of inactivity before screensaver activates. (0 = never activate).</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Number of seconds of inactivity before screensaver activates. (0=never activate).
-Availability: Available in macOS 10.11 and later.</string>
+			<string>The number of seconds of inactivity before the screen saver activates (0 = Never activate).</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -254,9 +227,7 @@ Availability: Available in macOS 10.11 and later.</string>
 			<key>pfm_default</key>
 			<string>Flurry</string>
 			<key>pfm_description</key>
-			<string>Name of the screensaver module to use.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>The name of the screen saver module.</string>
 			<key>pfm_documentation_source</key>
 			<string></string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.screensaver.user.plist
+++ b/Manifests/ManifestsApple/com.apple.screensaver.user.plist
@@ -14,7 +14,7 @@ The user level screensaver settings are specific to a user, instead of the devic
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-09-14T09:45:33Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.11</string>
 	<key>pfm_platforms</key>
@@ -27,9 +27,7 @@ The user level screensaver settings are specific to a user, instead of the devic
 			<key>pfm_default</key>
 			<string>Screensaver User settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -41,9 +39,7 @@ The user level screensaver settings are specific to a user, instead of the devic
 			<key>pfm_default</key>
 			<string>Screensaver User</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -57,9 +53,7 @@ The user level screensaver settings are specific to a user, instead of the devic
 			<key>pfm_default</key>
 			<string>com.apple.screensaver.user</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -73,9 +67,7 @@ The user level screensaver settings are specific to a user, instead of the devic
 			<key>pfm_default</key>
 			<string>com.apple.screensaver.user</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -89,9 +81,7 @@ The user level screensaver settings are specific to a user, instead of the devic
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -107,10 +97,7 @@ The user level screensaver settings are specific to a user, instead of the devic
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -122,10 +109,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -135,9 +119,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A full path to the screen saver module to be used.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A full path to the screen saver module to be used. Availability: Available in macOS 10.11 and later.</string>
+			<string>A full path to the screen-saver module to use.</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -151,10 +133,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<integer>300</integer>
 			<key>pfm_description</key>
-			<string>Number of seconds of inactivity before screensaver activates. (0 = never activate).</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. Number of seconds of inactivity before screensaver activates. (0=never activate).
-Availability: Available in macOS 10.11 and later.</string>
+			<string>The number of seconds of inactivity before the screen saver activates ('0' = Never activate).</string>
 			<key>pfm_macos_min</key>
 			<string>10.11</string>
 			<key>pfm_name</key>
@@ -166,7 +145,7 @@ Availability: Available in macOS 10.11 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name of the screensaver module to use.</string>
+			<string>The name of the screen saver module.</string>
 			<key>pfm_name</key>
 			<string>moduleName</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Second Active Ethernet settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>802.1X Ethernet: Second Active</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.secondactiveethernet.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.secondactiveethernet.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Second Ethernet settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>802.1X Ethernet: Second</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.secondethernet.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.secondethernet.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.security.FDERecoveryKeyEscrow.plist
+++ b/Manifests/ManifestsApple/com.apple.security.FDERecoveryKeyEscrow.plist
@@ -21,7 +21,7 @@ Note these cautions:
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -34,9 +34,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>FileVault Recovery Key Escrow settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -48,9 +46,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>FileVault Recovery Key Escrow</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -64,9 +60,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>com.apple.security.FDERecoveryKeyEscrow</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -80,9 +74,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>com.apple.security.FDERecoveryKeyEscrow</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -96,9 +88,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -114,10 +104,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-	A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -129,10 +116,7 @@ Note these cautions:
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-	The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -142,9 +126,7 @@ Note these cautions:
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>A short description of the location where the recovery key will be escrowed. This text will be inserted into the message the user sees when enabling FileVault.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. A short description of the location where the recovery key will be escrowed. This text will be inserted into the message the user sees when enabling FileVault.</string>
+			<string>The description of the location where the recovery key will be escrowed. This text will be inserted into the message the user sees when enabling FileVault.</string>
 			<key>pfm_name</key>
 			<string>Location</string>
 			<key>pfm_require</key>
@@ -156,9 +138,7 @@ Note these cautions:
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The UUID of a payload within the same profile that contains the certificate that will be used to encrypt the recovery key. The referenced payload must be of type com.apple.security.pkcs1.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. The UUID of a payload within the same profile that contains the certificate that will be used to encrypt the recovery key. The referenced payload must be of type com.apple.security.pkcs1.</string>
+			<string>The UUID of a payload within the same profile that contains the certificate that will be used to encrypt the recovery key. The referenced payload must be of type 'com.apple.security.pkcs1'.</string>
 			<key>pfm_name</key>
 			<string>EncryptCertPayloadUUID</string>
 			<key>pfm_require</key>
@@ -170,9 +150,9 @@ Note these cautions:
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An optional string that will be included in help text if the user appears to have forgotten the password. Can be used by a site admin to look up the escrowed key for the particular machine. Replaces the RecordNumber key used in previous escrow mechanism. If missing, the device serial number will be used instead.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. An optional string that will be included in help text if the user appears to have forgotten the password. Can be used by a site admin to look up the escrowed key for the particular machine. Replaces the RecordNumber key used in previous escrow mechanism. If missing, the device serial number will be used instead.</string>
+			<string>The string that's included in help text if the user appears to have forgotten the password. Site admins can use this key to look up the escrowed key for the particular computer.
+
+This key replaces the 'RecordNumber' key used in the previous escrow mechanism. If the key is missing, the device serial number is used instead.</string>
 			<key>pfm_name</key>
 			<string>DeviceKey</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.security.FDERecoveryRedirect.plist
+++ b/Manifests/ManifestsApple/com.apple.security.FDERecoveryRedirect.plist
@@ -17,7 +17,7 @@ Note these cautions:
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_max</key>
 	<string>10.12.6</string>
 	<key>pfm_platforms</key>
@@ -30,9 +30,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>FileVault Recovery Key Redirection settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -44,9 +42,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>FileVault Recovery Key Redirection</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -60,9 +56,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>com.apple.security.FDERecoveryRedirect</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -76,9 +70,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string>com.apple.security.FDERecoveryRedirect</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -92,9 +84,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -110,10 +100,7 @@ Note these cautions:
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-	A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -125,10 +112,7 @@ Note these cautions:
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-	The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -138,9 +122,7 @@ Note these cautions:
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The URL to which FDE recovery keys should be sent instead of Apple. Must begin with https://.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. The URL to which FDE recovery keys should be sent instead of Apple. Must begin with https://.</string>
+			<string>The URL to which FDE recovery keys should be sent instead of to Apple. The URL must begin with https://.</string>
 			<key>pfm_format</key>
 			<string>^https://.*$</string>
 			<key>pfm_name</key>
@@ -154,9 +136,7 @@ Note these cautions:
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The UUID of a payload within the same profile that contains a certificate whose public key is used to encrypt the recovery key when it is sent to the redirected URL. The referenced payload must be of type com.apple.security.pkcs1.</string>
-			<key>pfm_description_reference</key>
-			<string>Required. The UUID of a payload within the same profile that contains a certificate that will be used to encrypt the recovery key when it is sent to the redirected URL. The referenced payload must be of type com.apple.security.pkcs1.</string>
+			<string>The UUID of a payload within the same profile that contains a certificate used to encrypt the recovery key when it's sent to the redirected URL. The referenced payload must be of type `com.apple.security.pkcs1`.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.security.acme.plist
+++ b/Manifests/ManifestsApple/com.apple.security.acme.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>16.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>13.1</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Use this section to define settings to have an ACME server issue a client certificate.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>ACME Certificate</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.acme</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.acme</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -88,9 +80,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -106,9 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -189,7 +177,8 @@
 			<key>pfm_description</key>
 			<string>If 'false', the private key isn't bound to the device.
 If 'true', the private key is bound to the device. The Secure Enclave generates the key pair, and the private key is cryptographically entangled with a system key. This prevents the system from exporting the private key.
-If 'true', 'KeyType' must be 'ECSECPrimeRandom' and 'KeySize' must be 256 or 384.</string>
+If 'true', 'KeyType' must be 'ECSECPrimeRandom' and 'KeySize' must be 256 or 384.
+On macOS, this key is required but must have a value of 'false'.</string>
 			<key>pfm_name</key>
 			<string>HardwareBound</string>
 			<key>pfm_require</key>
@@ -338,7 +327,8 @@ The device requests this field for the certificate that the ACME server issues. 
 			<false/>
 			<key>pfm_description</key>
 			<string>If 'true', the device provides attestations describing the device and the generated key to the ACME server. The server can use the attestations as strong evidence that the key is bound to the device, and that the device has properties listed in the attestation. The server can use that as part of a trust score to decide whether to issue the requested certificate.
-When 'Attest' is 'true', 'HardwareBound' must also be 'true'.</string>
+When 'Attest' is 'true', 'HardwareBound' must also be 'true'.
+On macOS, if this key is present, it must have a value of 'false'.</string>
 			<key>pfm_name</key>
 			<string>Attest</string>
 			<key>pfm_title</key>
@@ -350,7 +340,7 @@ When 'Attest' is 'true', 'HardwareBound' must also be 'true'.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Whether the private key of the identity obtained via SCEP should be tagged as "non-extractable" in the keychain.</string>
+			<string>If true, the private key of the identity obtained via SCEP should be tagged as “non-extractable” in the keychain.</string>
 			<key>pfm_name</key>
 			<string>KeyIsExtractable</string>
 			<key>pfm_platforms</key>
@@ -366,7 +356,7 @@ When 'Attest' is 'true', 'HardwareBound' must also be 'true'.</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If true, all apps have access to the private key.</string>
+			<string>If 'true', all apps have access to the private key.</string>
 			<key>pfm_name</key>
 			<string>AllowAllAppsAccess</string>
 			<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.certificatepreference.plist
+++ b/Manifests/ManifestsApple/com.apple.security.certificatepreference.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-04-28T16:53:42Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Identify a certificate preference item in the user's keychain that references a certificate payload included in the same profile.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Certificate Preference</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.certificatepreference</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.certificatepreference</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -117,8 +117,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>An email address (RFC822), DNS hostname, or other name that uniquely identifies a service requiring this certificate.</string>
+			<key>pfm_description</key>
+			<string>An email address (in RFC 822 format) or other name for which a preferred certificate is requested.</string>
 			<key>pfm_name</key>
 			<string>Name</string>
 			<key>pfm_note</key>
@@ -127,7 +127,7 @@
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
+			<key>pfm_description</key>
 			<string>The UUID of the certificate payload within the same profile to use for the identity credential.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>

--- a/Manifests/ManifestsApple/com.apple.security.certificatetransparency.plist
+++ b/Manifests/ManifestsApple/com.apple.security.certificatetransparency.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Certificate Transparency settings</string>
+	<string>Use this section to define settings for certificate transparency.</string>
 	<key>pfm_description_reference</key>
 	<string>Certificate Preference payloads are designated by specifying com.apple.security.certificatetransparency as the PayloadType value.
 A Certificate Transparency payload controls Certificate Transparency enforcement. It can only appear in a device profile, not a user profile. You can include multiple Certificate Transparency payloads as needed.
@@ -18,7 +18,7 @@ Available in iOS 12.1.1, MacOS 10.14.2, tvOS 12.1.1, and watchOS 5.1.1 and later
 	<key>pfm_ios_min</key>
 	<string>12.1.1</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14.2</string>
 	<key>pfm_platforms</key>
@@ -33,9 +33,7 @@ Available in iOS 12.1.1, MacOS 10.14.2, tvOS 12.1.1, and watchOS 5.1.1 and later
 			<key>pfm_default</key>
 			<string>Configures Certificate Transparency settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -47,9 +45,7 @@ Available in iOS 12.1.1, MacOS 10.14.2, tvOS 12.1.1, and watchOS 5.1.1 and later
 			<key>pfm_default</key>
 			<string>Certificate Transparency</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -63,9 +59,7 @@ Available in iOS 12.1.1, MacOS 10.14.2, tvOS 12.1.1, and watchOS 5.1.1 and later
 			<key>pfm_default</key>
 			<string>com.apple.security.certificatetransparency</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -79,9 +73,7 @@ Available in iOS 12.1.1, MacOS 10.14.2, tvOS 12.1.1, and watchOS 5.1.1 and later
 			<key>pfm_default</key>
 			<string>com.apple.security.certificatetransparency</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -95,9 +87,7 @@ Available in iOS 12.1.1, MacOS 10.14.2, tvOS 12.1.1, and watchOS 5.1.1 and later
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -113,10 +103,7 @@ Available in iOS 12.1.1, MacOS 10.14.2, tvOS 12.1.1, and watchOS 5.1.1 and later
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -128,10 +115,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -141,9 +125,8 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of domains where certificate transparency is disabled.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. List of domains where certificate transparency is disabled. A leading period can be used to match subdomains, but a domain matching rule must not match all domains within a top level domain (”.example.com” and ”.example.co.uk” are allowed while ”.com” and ”.co.uk” are not allowed).</string>
+			<string>An array of strings representing the domains to be excluded from certificate transparency enforcement. A leading period (.) is supported to signify subdomains.
+Wildcard domains are not supported. If a leading period (.) is specified, the domain cannot be a top-level domain (for example, '.com' and '.co.uk' are disallowed).</string>
 			<key>pfm_name</key>
 			<string>DisabledForDomains</string>
 			<key>pfm_subkeys</key>
@@ -164,12 +147,10 @@ The payload organization for a payload need not match the payload organization i
 				<string>public.x509-certificate</string>
 			</array>
 			<key>pfm_description</key>
-			<string>A list of certificate hashes for which certificate transparency is disabled.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A list of hashed subjectPublicKeyInfo dictionaries defining the certificates where certificate transparency is disabled. For certificate transparency enforcement to be disabled, one of the following conditions must be met:
-• The hash is of the server certificate's subjectPublicKeyInfo.
-• The hash is of a subjectPublicKeyInfo that appears in a CA certificate in the certificate chain, the CA certificate is constrained via the X. 509v3 nameConstraints extension, one or more directoryName nameConstraints are present in the permittedSubtrees, and the directoryName contains an organizationName attribute.
-• The hash is of a subjectPublicKeyInfo that appears in a CA certificate in the certificate chain, the CA certificate has one or more organizationName attributes in the certificate Subject, and the server's certificate contains the same number of organizationName attributes, in the same order, and with byte-for- byte identical values.</string>
+			<string>An array of certificates for which certificate transparency is disabled. For Certificate Transparency enforcement to be disabled when this policy is set, one of the following conditions must be met:
+* The hash is of the server certificate's 'subjectPublicKeyInfo'.
+* The hash is of a 'subjectPublicKeyInfo' that appears in a CA certificate in the certificate chain; the CA certificate is constrained through the X.509v3 'nameConstraints' extension; one or more 'directoryName' 'nameConstraints' are present in the 'permittedSubtrees;' and the 'directoryName' contains an 'organizationName' attribute.
+* The hash is of a 'subjectPublicKeyInfo' that appears in a CA certificate in the certificate chain; the CA certificate has one or more 'organizationName' attributes in the certificate 'Subject;' and the server's certificate contains the same number of 'organizationName' attributes, in the same order, and with byte-for-byte identical values.</string>
 			<key>pfm_name</key>
 			<string>DisabledForCerts</string>
 			<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.security.firewall.plist
+++ b/Manifests/ManifestsApple/com.apple.security.firewall.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Firewall settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Firewall</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.firewall</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.firewall</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enables the firewall on managed Mac computers.</string>
+			<string>If 'true', enables the firewall.</string>
 			<key>pfm_name</key>
 			<string>EnableFirewall</string>
 			<key>pfm_require</key>
@@ -130,7 +130,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Blocks all incoming connections except those required for basic Internet services, such as DHCP, Bonjour and IPSec.</string>
+			<string>If 'true', enables blocking of all incoming connections.</string>
 			<key>pfm_name</key>
 			<string>BlockAllIncoming</string>
 			<key>pfm_title</key>
@@ -142,7 +142,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Don't respond to or acknowledge attempts to access this computer from the network by test applications using ICMP, such as Ping.</string>
+			<string>If 'true', enables stealth mode.</string>
 			<key>pfm_name</key>
 			<string>EnableStealthMode</string>
 			<key>pfm_title</key>
@@ -156,7 +156,7 @@
 				<string>com.apple.application-bundle</string>
 			</array>
 			<key>pfm_description</key>
-			<string>Add applications to either allow or block them from connecting to your network and the Internet.</string>
+			<string>The list of apps with connections controlled by the firewall.</string>
 			<key>pfm_name</key>
 			<string>Applications</string>
 			<key>pfm_subkeys</key>
@@ -223,6 +223,9 @@
 		<dict>
 			<key>pfm_default</key>
 			<false/>
+			<key>pfm_description</key>
+			<string>If 'true', enables logging.
+Available in macOS 12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -233,6 +236,9 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>This string specifies the type of logging.
+Available in macOS 12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>
@@ -257,6 +263,9 @@
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'true', allows built-in software to receive incoming connections.
+Available in macOS 12.3 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.3</string>
 			<key>pfm_name</key>
@@ -269,6 +278,9 @@
 		<dict>
 			<key>pfm_default</key>
 			<true/>
+			<key>pfm_description</key>
+			<string>If 'true', allows downloaded signed software to receive incoming connections.
+Available in macOS 12.3 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.3</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.security.pem.plist
+++ b/Manifests/ManifestsApple/com.apple.security.pem.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Use this section to define settings for a PEM certificate.</string>
+	<string>Use this section to define settings for a pem certificate.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.security.pem</string>
 	<key>pfm_format_version</key>
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:32Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Adds a PEM-formatted certificate</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Certificate</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.pem</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.pem</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name or description of the certificate credential.</string>
+			<string>The file name of the enclosed certificate.</string>
 			<key>pfm_name</key>
 			<string>PayloadCertificateFileName</string>
 			<key>pfm_title</key>
@@ -130,7 +130,7 @@
 				<string>public.x509-certificate</string>
 			</array>
 			<key>pfm_description</key>
-			<string>X.509 certificate (.pem, .cer, .crt, etc) for inclusion on device.</string>
+			<string>The binary representation of the payload, encoded in Base64.</string>
 			<key>pfm_name</key>
 			<string>PayloadContent</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.security.pkcs1.plist
+++ b/Manifests/ManifestsApple/com.apple.security.pkcs1.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:51Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Adds a PKCS#1-formatted certificate</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Certificate</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.pkcs1</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.pkcs1</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name or description of the certificate credential.</string>
+			<string>The file name of the enclosed certificate.</string>
 			<key>pfm_name</key>
 			<string>PayloadCertificateFileName</string>
 			<key>pfm_title</key>
@@ -130,7 +130,7 @@
 				<string>public.x509-certificate</string>
 			</array>
 			<key>pfm_description</key>
-			<string>X.509 certificate (.cer, .crt, etc) for inclusion on device.</string>
+			<string>The binary representation of the payload, encoded in Base64.</string>
 			<key>pfm_name</key>
 			<string>PayloadContent</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.security.pkcs12.plist
+++ b/Manifests/ManifestsApple/com.apple.security.pkcs12.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-07-13T10:23:04Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Adds a PKCS#12-formatted certificate</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Certificate</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.pkcs12</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.pkcs12</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name or description of the certificate credential.</string>
+			<string>The file name of the enclosed certificate.</string>
 			<key>pfm_name</key>
 			<string>PayloadCertificateFileName</string>
 			<key>pfm_title</key>
@@ -130,7 +130,7 @@
 				<string>com.rsa.pkcs-12</string>
 			</array>
 			<key>pfm_description</key>
-			<string>X.509 certificate (.p12) for inclusion on device.</string>
+			<string>The binary representation of the payload, encoded in Base64.</string>
 			<key>pfm_name</key>
 			<string>PayloadContent</string>
 			<key>pfm_require</key>
@@ -142,7 +142,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Password protecting the PKCS12 file.</string>
+			<string>This is the password to the identity.
+Security Caution: Because the password string is stored in the clear (unencrypted) in the profile, you should encrypt the entire profile.</string>
 			<key>pfm_name</key>
 			<string>Password</string>
 			<key>pfm_require</key>
@@ -158,7 +159,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Allows all apps on the device to access the private key of this certificate</string>
+			<string>If 'true', allows apps access to the private key. Available in macOS 10.10 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.10</string>
 			<key>pfm_name</key>
@@ -176,7 +177,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Allows exporting the private key from the keychain</string>
+			<string>If false, does not tag the private key data as extractable in the keychain.</string>
 			<key>pfm_name</key>
 			<string>KeyIsExtractable</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.security.root.plist
+++ b/Manifests/ManifestsApple/com.apple.security.root.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Certificate Root settings</string>
+	<string>Use this section to define settings for a root certificate.</string>
 	<key>pfm_description_reference</key>
 	<string>The payload for configuring a root certificate.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-04-28T13:36:08Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -28,7 +28,7 @@
 			<key>pfm_default</key>
 			<string>Adds a Certificate Root</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,7 +40,7 @@
 			<key>pfm_default</key>
 			<string>Certificate Root</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,7 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.root</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,7 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.root</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,7 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -98,7 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -110,7 +110,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -120,7 +120,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Name or description of the certificate credential.</string>
+			<string>The file name of the enclosed certificate.</string>
 			<key>pfm_name</key>
 			<string>PayloadCertificateFileName</string>
 			<key>pfm_title</key>
@@ -134,7 +134,7 @@
 				<string>public.x509-certificate</string>
 			</array>
 			<key>pfm_description</key>
-			<string>X.509 Root certificate (.cer, .crt, etc) for inclusion on device.</string>
+			<string>The binary representation of the payload encoded in base64.</string>
 			<key>pfm_name</key>
 			<string>PayloadContent</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.security.scep.plist
+++ b/Manifests/ManifestsApple/com.apple.security.scep.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures SCEP settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>SCEP</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.scep</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.scep</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This dictionary contains the payload contents</string>
+			<string>An array of payload dictionaries. This array isn't present if 'IsEncrypted' is 'true'.</string>
 			<key>pfm_name</key>
 			<string>PayloadContent</string>
 			<key>pfm_require</key>
@@ -125,7 +125,7 @@
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The base URL for the SCEP server</string>
+					<string>The SCEP URL. See Over-the-Air Profile Delivery and Configuration for more information about SCEP.</string>
 					<key>pfm_name</key>
 					<string>URL</string>
 					<key>pfm_require</key>
@@ -137,7 +137,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Any string that is understood by the SCEP server. For example, it could be a domain name like example.org. If a certificate authority has multiple CA certificates this field can be used to distinguish which is required.</string>
+					<string>A string that's understood by the SCEP server; for example, a domain name like example.org. If a certificate authority has multiple CA certificates, this field can be used to distinguish which is required.</string>
 					<key>pfm_name</key>
 					<string>Name</string>
 					<key>pfm_title</key>
@@ -147,7 +147,10 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The representation of a X.500 name represented as an array of OID and value. OIDs can be represented as dotted numbers, with shortcuts for country (C), locality (L), state (ST), organization (O), organizational unit (OU), and common name (CN).</string>
+					<string>The representation of an X.500 name as an array of OID and value.
+For example, '/C=US/O=Apple Inc./CN=foo/1.2.5.3=bar' translates to '[ [ [“C”, “US”] ], [ [“O”, “Apple Inc.'] ], …, [ [ “1.2.5.3”, “bar” ] ] ]'.
+
+OIDs can be represented as dotted numbers, with shortcuts for country (C), locality (L), state (ST), organization (O), organizational unit (OU), and common name (CN).</string>
 					<key>pfm_format</key>
 					<string>(,?[^=,]+=[^=,]+(,|$))</string>
 					<key>pfm_name</key>
@@ -319,7 +322,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Used as the pre-shared secret for automatic enrollment.</string>
+					<string>A preshared secret.</string>
 					<key>pfm_name</key>
 					<string>Challenge</string>
 					<key>pfm_title</key>
@@ -331,7 +334,7 @@
 					<key>pfm_default</key>
 					<integer>1024</integer>
 					<key>pfm_description</key>
-					<string>Key size in bits</string>
+					<string>The key size, in bits.</string>
 					<key>pfm_name</key>
 					<string>Keysize</string>
 					<key>pfm_range_list</key>
@@ -346,7 +349,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The fingerprint (hex string) of the Certificate Authority certificate.</string>
+					<string>The fingerprint of the Certificate Authority certificate.</string>
 					<key>pfm_name</key>
 					<string>CAFingerprint</string>
 					<key>pfm_title</key>
@@ -362,7 +365,7 @@
 					<key>pfm_default</key>
 					<string>RSA</string>
 					<key>pfm_description</key>
-					<string>Currently always "RSA".</string>
+					<string>Always 'RSA'.</string>
 					<key>pfm_name</key>
 					<string>Key Type</string>
 					<key>pfm_range_list</key>
@@ -378,7 +381,12 @@
 					<key>pfm_default</key>
 					<integer>0</integer>
 					<key>pfm_description</key>
-					<string>A bitmask indicating the use of the key.\n• 1 - signing\n• 4 - encryption\n• 5 - signing and encryption</string>
+					<string>A bitmask indicating the use of the key.
+
+* 1: Signing
+* 4: Encryption
+
+Some certificate authorities, such as Windows CA, support only encryption or signing, but not both at the same time.</string>
 					<key>pfm_ios_min</key>
 					<string>4.0</string>
 					<key>pfm_name</key>
@@ -406,9 +414,7 @@
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>Allow / restrict exporting the private key from the keychain.</string>
-					<key>pfm_description_reference</key>
-					<string>If `false`, disables exporting the private key from the keychain.</string>
+					<string>If 'false', disables exporting the private key from the keychain.</string>
 					<key>pfm_macos_min</key>
 					<string>10.15</string>
 					<key>pfm_name</key>
@@ -420,14 +426,14 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Specifies the Subject Alt Name for the certificate.</string>
+					<string>The SCEP payload can specify an optional 'SubjectAltName' dictionary that provides values required by the CA for issuing a certificate. You can specify a single string or an array of strings for each key. The values you specify depend on the CA you're using, but might include DNS name, URL, or email values. For an example, see Sample Configuration Profile or Over-the-Air Profile Delivery and Configuration.</string>
 					<key>pfm_name</key>
 					<string>SubjectAltName</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>RFC 822 (email address) string</string>
+							<string>The RFC 822 (email address) string.</string>
 							<key>pfm_name</key>
 							<string>rfc822Name</string>
 							<key>pfm_substitution_variables</key>
@@ -548,7 +554,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>DNS Name</string>
+							<string>The DNS name.</string>
 							<key>pfm_name</key>
 							<string>dNSName</string>
 							<key>pfm_substitution_variables</key>
@@ -669,7 +675,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>Uniform Resource Indentifier</string>
+							<string>The Uniform Resource Identifier.</string>
 							<key>pfm_name</key>
 							<string>uniformResourceIdentifier</string>
 							<key>pfm_substitution_variables</key>
@@ -790,7 +796,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>NT Principal Name</string>
+							<string>The NT principal name.</string>
 							<key>pfm_name</key>
 							<string>ntPrincipalName</string>
 							<key>pfm_substitution_variables</key>
@@ -959,7 +965,7 @@
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>Allow all apps to access the certificate in the keychain</string>
+					<string>If 'true', all apps have access to the private key.</string>
 					<key>pfm_name</key>
 					<string>AllowAllAppsAccess</string>
 					<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.smartcard.plist
+++ b/Manifests/ManifestsApple/com.apple.security.smartcard.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12.4</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures SmartCard settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>SmartCard</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.smartcard</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.security.smartcard</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -120,7 +120,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If false, disables the SmartCard for logins, authorizations, and screen saver unlocking. It is still allowed for other functions, such as signing emails and accessing the web.</string>
+			<string>If 'false', disables the SmartCard for logins, authorizations, and screen saver unlocking. It is still allowed for other functions, such as signing emails and accessing the web. A restart is required for a setting change to take effect.</string>
 			<key>pfm_name</key>
 			<string>allowSmartCard</string>
 			<key>pfm_note</key>
@@ -156,7 +156,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>If false, users don't get the pairing dialog, although existing pairings still work.</string>
+			<string>If 'false', users don't get the pairing dialog, although existing pairings still work.</string>
 			<key>pfm_name</key>
 			<string>UserPairing</string>
 			<key>pfm_title</key>
@@ -168,7 +168,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, a user can pair with only one SmartCard, although existing pairings are allowed if already set up.</string>
+			<string>If 'true', a user can pair with only one SmartCard, although existing pairings are allowed if already set up.</string>
 			<key>pfm_name</key>
 			<string>oneCardPerUser</string>
 			<key>pfm_title</key>
@@ -180,15 +180,11 @@
 			<key>pfm_default</key>
 			<integer>0</integer>
 			<key>pfm_description</key>
-			<string>Require unexpired, system trusted certificates for smart cards to work.</string>
-			<key>pfm_description_reference</key>
-			<string>0: Turns off certificate trust check.
-
-1: Turns on certificate trust check. A standard validity check is performed but doesn't include additional revocation checks.
-
-2: Turns on certificate trust check. A soft revocation check is also performed. Until the certificate is explicitly rejected by CRL/OCSP, it's considered valid. This setting means that unavailable or unreachable CRL/OCSP allow this check to succeed.
-
-3: Turns on certificate trust check. A hard revocation check is also performed. Unless CRL/OCSP explicitly says "This certificate is OK," it's considered invalid. This option is the most secure.</string>
+			<string>Valid values are 0 to 3:
+'0': Turns off certificate trust check.
+'1': Turns on certificate trust check. A standard validity check is performed but doesn't include additional revocation checks.
+'2': Turns on certificate trust check. A soft revocation check is also performed. Until the certificate is explicitly rejected by CRL/OCSP, it's considered valid. This setting means that unavailable or unreachable CRL/OCSP allow this check to succeed.
+'3': Turns on certificate trust check. A hard revocation check is also performed. Unless CRL/OCSP explicitly says 'This certificate is OK,' it's considered invalid. This option is the most secure.</string>
 			<key>pfm_name</key>
 			<string>checkCertificateTrust</string>
 			<key>pfm_range_list</key>
@@ -214,9 +210,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, a user can only log in or authenticate with a SmartCard.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, a user can only log in or authenticate with a SmartCard. Available in macOS 10.13.2 and later.</string>
+			<string>If 'true', a user can only log in or authenticate with a SmartCard. Available in macOS 10.13.2 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.2</string>
 			<key>pfm_name</key>
@@ -230,9 +224,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>If enabled, enables the screen saver when the SmartCard is removed.</string>
-			<key>pfm_description_reference</key>
-			<string>If 1, enables the screen saver when the SmartCard is removed. Available in macOS 10.13.4 and later.</string>
+			<string>If '1', enables the screen saver when the SmartCard is removed. Available in macOS 10.13.4 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.13.4</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.servicemanagement.plist
+++ b/Manifests/ManifestsApple/com.apple.servicemanagement.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-12-14T02:29:57Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>13.0</string>
 	<key>pfm_platforms</key>
@@ -24,9 +24,7 @@
 			<key>pfm_default</key>
 			<string>Control the user experience for ServiceManagement login items (including launchd agents and daemons) in Login Items Settings.</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,9 +36,7 @@
 			<key>pfm_default</key>
 			<string>Service Management - Managed Login Items</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,9 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.servicemanagement</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,9 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.servicemanagement</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,9 +76,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -102,9 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload. A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -116,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -126,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An array of rule dictionaries.</string>
+			<string>An array of service management rules.</string>
 			<key>pfm_name</key>
 			<string>Rules</string>
 			<key>pfm_require</key>
@@ -164,7 +152,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The value to compare with each login item's value, to determine a match to this rule.</string>
+							<string>The value to compare with each login item's value, to determine if this rule is a match.</string>
 							<key>pfm_name</key>
 							<string>RuleValue</string>
 							<key>pfm_require</key>
@@ -186,7 +174,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>An additional constraint to limit the scope of the rule that is tested after matching the RuleType/RuleValue.</string>
+							<string>An additional constraint to limit the scope of the rule that the system tests after matching the 'RuleType' and 'RuleValue'.</string>
 							<key>pfm_name</key>
 							<string>TeamIdentifier</string>
 							<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.shareddeviceconfiguration.plist
+++ b/Manifests/ManifestsApple/com.apple.shareddeviceconfiguration.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Lock Screen Message settings</string>
+	<string>Use this section to define text displayed by shared devices in the login window and lock screen.</string>
 	<key>pfm_domain</key>
 	<string>com.apple.shareddeviceconfiguration</string>
 	<key>pfm_format_version</key>
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>9.3</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Lock Screen Message settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Lock Screen Message</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.shareddeviceconfiguration</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.shareddeviceconfiguration</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Displays a name, address, or phone number on the Login window and Lock screen. Deprecated. Use LockScreenFootnote instead.</string>
+			<string>Deprecated. Use 'LockScreenFootnote' instead.</string>
 			<key>pfm_ios_deprecated</key>
 			<string>9.3.1</string>
 			<key>pfm_name</key>
@@ -128,7 +128,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Displays a name, address, or phone number on the Login window and Lock screen.</string>
+			<string>The footnote displayed in the login window and Lock screen.</string>
 			<key>pfm_ios_min</key>
 			<string>9.3.1</string>
 			<key>pfm_name</key>
@@ -140,7 +140,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Displays the asset tag information in the Login window and on the Lock screen.</string>
+			<string>The asset tag information for the device, displayed in the login window and Lock screen.</string>
 			<key>pfm_name</key>
 			<string>AssetTagInformation</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.sso.plist
+++ b/Manifests/ManifestsApple/com.apple.sso.plist
@@ -13,7 +13,7 @@
 	<key>pfm_ios_min</key>
 	<string>7.0</string>
 	<key>pfm_last_modified</key>
-	<date>2020-11-22T08:25:36Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Single Sign-On Account Payload</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Single Sign-On Account Payload</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.sso</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.sso</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,9 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Human-readable name for the account</string>
-			<key>pfm_description_reference</key>
-			<string>(Required) The human-readable name for the account.</string>
+			<string>The human-readable name for the account.</string>
 			<key>pfm_name</key>
 			<string>Name</string>
 			<key>pfm_require</key>
@@ -130,8 +128,6 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Kerberos-related information.</string>
-			<key>pfm_description_reference</key>
 			<string>The Kerberos dictionary.</string>
 			<key>pfm_name</key>
 			<string>Kerberos</string>
@@ -139,14 +135,16 @@
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>List of app identifiers that are allowed to use this login</string>
+					<string>The list of app identifiers that are allowed to use this login. If this field missing, this login will match all app identifiers.
+This array may not be empty.
+This array must contain strings that match App Bundle IDs. These strings may be exact matches, e.g. 'com.mycompany.myapp' or may specify a prefix match on the Bundle ID by using the '*' wildcard character. The wildcard character must appear after a period character ('.'), and may only appear once, at the end of the string, e.g. 'com.mycompany.*'. When a wildcard is given, any app whose Bundle ID begins with the prefix will be granted access to the account.</string>
 					<key>pfm_name</key>
 					<string>AppIdentifierMatches</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>Exact or partial bundle ID match using the wildcard character eg com.apple.*</string>
+							<string>An app identifier.</string>
 							<key>pfm_name</key>
 							<string>AppIdentifierMatchesItem</string>
 							<key>pfm_repetition_min</key>
@@ -164,7 +162,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The PayloadUUID of an identity certificate payload for Kerberos credential renewal without user interaction.</string>
+					<string>The 'PayloadUUID' of an identity certificate payload that can be used to renew the Kerberos credential without user interaction. The certificate payload must have either the 'com.apple.security.pkcs12' or 'com.apple.security.scep' payload type. Both the Single Sign On payload and the identity certificate payload must be included in the same configuration profile.</string>
 					<key>pfm_format</key>
 					<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 					<key>pfm_name</key>
@@ -176,7 +174,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>The Kerberos principal name. The user will be prompted for one during profile installation if not provided.</string>
+					<string>The principal name. If not provided, the user will be prompted for one during profile installation. This field is required for MDM installation.</string>
 					<key>pfm_name</key>
 					<string>PrincipalName</string>
 					<key>pfm_title</key>
@@ -186,7 +184,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Properly capitalized Kerberos realm name</string>
+					<string>The realm name. This value should be properly capitalized.</string>
 					<key>pfm_name</key>
 					<string>Realm</string>
 					<key>pfm_require</key>
@@ -198,14 +196,15 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>List of URLs prefixes that must be matched to use this account for Kerberos authentication over HTTP. Note that the URL postfixes must match as well.</string>
+					<string>The list of URL prefixes that must be matched in order to use this account for Kerberos authentication over HTTP. If this key is missing, the account will be eligible to match all 'http://' and 'https://' URLs.
+The URL matching patterns must begin with either 'http://' or 'https://'. A simple string match is performed, so the URL prefix 'http://www.apple.com/' will not match 'http://www.apple.com:80/'. However, if a matching pattern does not end in '/', a '/' will be appended to it.</string>
 					<key>pfm_name</key>
 					<string>URLPrefixMatches</string>
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>Each entry in the URLPrefixMatches array must contain a URL prefix. Only URLs that begin with one of the strings in this account are allowed to access the Kerberos ticket.</string>
+							<string>A URL prefix.</string>
 							<key>pfm_name</key>
 							<string>URLPrefixMatchesItem</string>
 							<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.subscribedcalendar.account.plist
+++ b/Manifests/ManifestsApple/com.apple.subscribedcalendar.account.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:52Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures settings for calendar subscriptions</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Subscribed Calendars</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.subscribedcalendar.account</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.subscribedcalendar.account</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 			<key>pfm_default</key>
 			<string>My Subscribed Calendar</string>
 			<key>pfm_description</key>
-			<string>The description of the calendar subscription</string>
+			<string>The description of the account.</string>
 			<key>pfm_name</key>
 			<string>SubCalAccountDescription</string>
 			<key>pfm_title</key>
@@ -126,7 +126,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The URL of the calendar file</string>
+			<string>The server's address.</string>
 			<key>pfm_name</key>
 			<string>SubCalAccountHostName</string>
 			<key>pfm_require</key>
@@ -138,7 +138,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The username for this subscription</string>
+			<string>The user's user name.</string>
 			<key>pfm_name</key>
 			<string>SubCalAccountUsername</string>
 			<key>pfm_title</key>
@@ -148,7 +148,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for this subscription</string>
+			<string>The user's password.</string>
 			<key>pfm_name</key>
 			<string>SubCalAccountPassword</string>
 			<key>pfm_sensitive</key>
@@ -162,7 +162,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Use Secure Socket Layer for this subscription</string>
+			<string>If 'true', enables SSL.</string>
 			<key>pfm_name</key>
 			<string>SubCalAccountUseSSL</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.syspolicy.kernel-extension-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.syspolicy.kernel-extension-policy.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-18T19:55:17Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.2</string>
 	<key>pfm_platforms</key>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures Kernel Extension Policy settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>Kernel Extension Policy</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.syspolicy.kernel-extension-policy</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.syspolicy.kernel-extension-policy</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -118,7 +118,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Users can approve kernel extensions not explicitly allowed by configuration profiles.</string>
+			<string>If 'true', users can approve additional kernel extensions that configuration profiles don't explicitly allow.</string>
 			<key>pfm_name</key>
 			<string>AllowUserOverrides</string>
 			<key>pfm_title</key>
@@ -130,7 +130,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Non-admin users can approve kernel extensions not explicitly allowed by configuration profiles.</string>
+			<string>If 'true', nonadministrative users can approve additional kernel extensions in the Security &amp; Privacy preferences.
+Available in macOS 11 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>11</string>
 			<key>pfm_name</key>
@@ -146,7 +147,7 @@
 				<string>com.apple.package</string>
 			</array>
 			<key>pfm_description</key>
-			<string>List of team identifiers that define which validly signed kernel extensions will be allowed to load.</string>
+			<string>The array of team identifiers that define which validly signed kernel extensions can load.</string>
 			<key>pfm_name</key>
 			<string>AllowedTeamIdentifiers</string>
 			<key>pfm_note</key>
@@ -179,7 +180,7 @@
 				<string>com.apple.package</string>
 			</array>
 			<key>pfm_description</key>
-			<string>Bundle identifier and team identifier of kernel extensions that will be allowed. Use an empty team identifier for unsigned legacy kernel extensions.</string>
+			<string>The dictionary that represents a set of kernel extensions that the system always allows to load on the computer. The dictionary maps team identifiers (keys) to arrays of bundle identifiers.</string>
 			<key>pfm_name</key>
 			<string>AllowedKernelExtensions</string>
 			<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.system-extension-policy.plist
+++ b/Manifests/ManifestsApple/com.apple.system-extension-policy.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-11-11T09:27:57Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures System Extensions Policy</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>System Extension Policy</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.system-extension-policy</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.system-extension-policy</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -120,7 +120,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Set this property to false to prevent users from approving system extensions not explicitly allowed by configuration profiles.</string>
+			<string>If 'false', restricts users from approving additional system extensions that configuration profiles don't explicitly allow.</string>
 			<key>pfm_name</key>
 			<string>AllowUserOverrides</string>
 			<key>pfm_note</key>
@@ -132,7 +132,9 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of team identifiers that define which validly signed system extensions will be allowed to load.</string>
+			<string>An array of team identifiers that defines valid, signed system extensions that are allowable to load. Approved system extensions are those signed with any of the specified team identifiers.
+To avoid requiring an administrator to authorize the operation, you can activate system extensions that this key specifies using activationRequestForExtension:queue:.
+It's an error for the same team identifier to appear in both this array and as a key in the 'AllowedSystemExtensions' dictionary.</string>
 			<key>pfm_format</key>
 			<string>^[A-Z0-9]{10}$</string>
 			<key>pfm_name</key>
@@ -159,7 +161,9 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Dictionary of system extensions that will be allowed. Extensions are represented in the dictionary using a team identifier string as key and an array of allowed extension bundle identifier strings as the associated value.</string>
+			<string>A dictionary of approved system extensions on the computer. The dictionary maps the team identifiers (keys) to arrays of bundle identifiers, where the bundle identifier defines the system extension to install.
+To avoid requiring an administrator to authorize the operation, you can activate system extensions that this key specifies using activationRequestForExtension:queue:.
+It's an error for the same team identifier to appear in both the 'AllowedTeamIdentifiers' array and as a key in this dictionary.</string>
 			<key>pfm_name</key>
 			<string>AllowedSystemExtensions</string>
 			<key>pfm_note</key>
@@ -207,7 +211,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Dictionary of developer teams and their allowed system extension types. Entries use the team identifier as the key and an array of the allowed extension type strings as the associated value.</string>
+			<string>A dictionary that maps a team identifier to an array of strings, where each string is a type of system extension that you can install for that team identifier. The allowed extension types are 'DriverExtension', 'NetworkExtension', and 'EndpointSecurityExtension'.
+If there's no entry for a specified team identifier in the dictionary, the system allows all extension types.</string>
 			<key>pfm_name</key>
 			<string>AllowedSystemExtensionTypes</string>
 			<key>pfm_subkeys</key>
@@ -263,7 +268,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Dictionary of system extensions that can be removed by their own app without requiring an admin password. Extensions are represented in the dictionary using a team identifier string as key and an array of removable extension bundle identifier strings as the associated value.</string>
+			<string>A dictionary of system extensions that are allowed to remove themselves from the machine. The dictionary maps team identifiers (keys) to arrays of bundle identifiers, where the bundle identifier defines the system extension. An application using the 'OSSystemExtensionDeactivationRequest' API can deactivate the specified system extensions without requiring an administrator to authorize the operation.
+Available in macOS 12 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>12.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.system.logging.plist
+++ b/Manifests/ManifestsApple/com.apple.system.logging.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2021-09-17T12:35:55Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures System Logging settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>System Logging</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.system.logging</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.system.logging</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -117,6 +117,8 @@
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>This dictionary has one key, 'Enable-Private-Data'. Setting that value to 'true' enables private data logging for the entire system.</string>
 			<key>pfm_name</key>
 			<string>System</string>
 			<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.systemmigration.plist
+++ b/Manifests/ManifestsApple/com.apple.systemmigration.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:52Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12.4</string>
 	<key>pfm_platforms</key>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures System Migration settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>System Migration</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systemmigration</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systemmigration</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Custom Paths to be migrated from source system</string>
+			<string>The list of custom behavior dictionaries.</string>
 			<key>pfm_name</key>
 			<string>CustomBehavior</string>
 			<key>pfm_range_max</key>
@@ -132,7 +132,7 @@
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>The context to which custom paths apply.</string>
+							<string>The context that custom paths apply to.</string>
 							<key>pfm_name</key>
 							<string>Context</string>
 							<key>pfm_range_list</key>
@@ -148,7 +148,7 @@
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The custom paths to be migrated from a source system to a target system.</string>
+							<string>The list of custom behavior path dictionaries.</string>
 							<key>pfm_name</key>
 							<string>Paths</string>
 							<key>pfm_require</key>
@@ -178,7 +178,7 @@
 										</dict>
 										<dict>
 											<key>pfm_description</key>
-											<string>If the source path is located within a user home directory.</string>
+											<string>If 'true', the source path is located within a user home directory.</string>
 											<key>pfm_name</key>
 											<string>SourcePathInUserHome</string>
 											<key>pfm_require</key>
@@ -204,7 +204,7 @@
 										</dict>
 										<dict>
 											<key>pfm_description</key>
-											<string>If the target path is located within a user home directory.</string>
+											<string>If 'true', the target path is located within a user home directory.</string>
 											<key>pfm_name</key>
 											<string>TargetPathInUserHome</string>
 											<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.systempolicy.control.plist
+++ b/Manifests/ManifestsApple/com.apple.systempolicy.control.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2021-12-22T05:49:22Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.8</string>
 	<key>pfm_platforms</key>
@@ -24,7 +24,7 @@
 			<key>pfm_default</key>
 			<string>Configures System Policy: Control settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -36,7 +36,7 @@
 			<key>pfm_default</key>
 			<string>System Policy: Control</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -50,7 +50,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systempolicy.control</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -64,7 +64,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systempolicy.control</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -78,7 +78,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -94,7 +94,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -106,7 +106,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If the key is present and has a value of YES, Gatekeeper is enabled. If the key is present and has a value of NO, Gatekeeper is disabled.</string>
+			<string>If 'true', enables Gatekeeper.</string>
 			<key>pfm_name</key>
 			<string>EnableAssessment</string>
 			<key>pfm_title</key>
@@ -126,7 +126,9 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If the key is present and has a value of YES, Gatekeeper's "Mac App Store and identified developers” option is chosen. If the key is present and has a value of NO, Gatekeeper's "Mac App Store” option is chosen. If EnableAssessment is not true, this key has no effect.</string>
+			<string>If 'true', enables Gatekeeper's 'Mac App Store and identified developers' option.
+If 'false', enables Gatekeeper's 'Mac App Store' option.
+If the value of 'EnableAssessment' isn't set to 'true', this key has no effect.</string>
 			<key>pfm_name</key>
 			<string>AllowIdentifiedDevelopers</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.systempolicy.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.systempolicy.managed.plist
@@ -14,7 +14,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.8</string>
 	<key>pfm_platforms</key>
@@ -27,9 +27,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 			<key>pfm_default</key>
 			<string>System Policy: Managed settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -41,9 +39,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 			<key>pfm_default</key>
 			<string>System Policy: Managed</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -57,9 +53,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 			<key>pfm_default</key>
 			<string>com.apple.systempolicy.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -73,9 +67,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 			<key>pfm_default</key>
 			<string>com.apple.systempolicy.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -89,9 +81,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -107,10 +97,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-	A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -122,10 +109,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-	The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -137,9 +121,7 @@ This payload allows control to disable the Finderʼs contextual menu that allows
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If YES, the Finder's contextual menu item will be disabled.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If YES, the Finderʼs contextual menu item will be disabled.</string>
+			<string>If 'true', disables the Finder's contextual menu item.</string>
 			<key>pfm_name</key>
 			<string>DisableOverride</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.systempreferences.plist
+++ b/Manifests/ManifestsApple/com.apple.systempreferences.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-29T08:33:42Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>13.0</string>
 	<key>pfm_platforms</key>
@@ -28,9 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures System Preferences settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +40,7 @@
 			<key>pfm_default</key>
 			<string>System Preferences</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systempreferences</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systempreferences</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,10 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -123,10 +110,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -171,9 +155,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Allowed Preference Panes within the System Preferences application.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>The list of enabled System Preferences panes.</string>
 			<key>pfm_documentation_source</key>
 			<string></string>
 			<key>pfm_name</key>
@@ -316,9 +298,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Disabled Preference Panes within the System Preferences application.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>The list of disabled System Preferences panes.</string>
 			<key>pfm_documentation_source</key>
 			<string></string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.systemuiserver.plist
+++ b/Manifests/ManifestsApple/com.apple.systemuiserver.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-04-18T11:26:55Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>11.0</string>
 	<key>pfm_macos_max</key>
@@ -30,7 +30,7 @@
 			<key>pfm_default</key>
 			<string>Configures Allowed Media settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,7 +42,7 @@
 			<key>pfm_default</key>
 			<string>Allowed Media</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,7 +56,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systemuiserver</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,7 +70,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systemuiserver</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,7 +84,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,7 +100,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -112,7 +112,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -156,7 +156,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Media type dictionary to control volume mounting.</string>
+			<string>The media type dictionary that controls volume mounting.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.0</string>
 			<key>pfm_macos_max</key>
@@ -169,7 +169,9 @@
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>This key is the default for media types that donʼt fall into other categories. Like internally installed SD-Cards and USB flash drives.</string>
+					<string>A string or an array of media action strings. Internally installed SD cards and USB flash drives are included in the hard disk-external category.
+
+This key is the default for media types that don't fall into other categories.</string>
 					<key>pfm_name</key>
 					<string>harddisk-external</string>
 					<key>pfm_subkeys</key>
@@ -210,7 +212,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>harddisk-internal</string>
 					<key>pfm_subkeys</key>
@@ -251,7 +253,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>networkdisk</string>
 					<key>pfm_subkeys</key>
@@ -292,7 +294,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>disk-image</string>
 					<key>pfm_subkeys</key>
@@ -333,7 +335,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>bd</string>
 					<key>pfm_subkeys</key>
@@ -374,7 +376,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>cd</string>
 					<key>pfm_subkeys</key>
@@ -415,7 +417,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>dvd</string>
 					<key>pfm_subkeys</key>
@@ -456,7 +458,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>dvdram</string>
 					<key>pfm_subkeys</key>
@@ -497,7 +499,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankbd</string>
 					<key>pfm_subkeys</key>
@@ -538,7 +540,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankcd</string>
 					<key>pfm_subkeys</key>
@@ -579,7 +581,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankdvd</string>
 					<key>pfm_subkeys</key>
@@ -626,7 +628,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Media type dictionary to control volume unmounting.</string>
+			<string>The media type dictionary that controls volume unmounting.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.0</string>
 			<key>pfm_macos_max</key>
@@ -639,7 +641,9 @@
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>This key is the default for media types that donʼt fall into other categories. Like internally installed SD-Cards and USB flash drives.</string>
+					<string>A string or an array of media action strings. Internally installed SD cards and USB flash drives are included in the hard disk-external category.
+
+This key is the default for media types that don't fall into other categories.</string>
 					<key>pfm_name</key>
 					<string>harddisk-external</string>
 					<key>pfm_subkeys</key>
@@ -680,7 +684,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>harddisk-internal</string>
 					<key>pfm_subkeys</key>
@@ -721,7 +725,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>networkdisk</string>
 					<key>pfm_subkeys</key>
@@ -762,7 +766,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>disk-image</string>
 					<key>pfm_subkeys</key>
@@ -803,7 +807,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>bd</string>
 					<key>pfm_subkeys</key>
@@ -844,7 +848,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>cd</string>
 					<key>pfm_subkeys</key>
@@ -885,7 +889,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>dvd</string>
 					<key>pfm_subkeys</key>
@@ -926,7 +930,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>dvdram</string>
 					<key>pfm_subkeys</key>
@@ -967,7 +971,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankbd</string>
 					<key>pfm_subkeys</key>
@@ -1008,7 +1012,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankcd</string>
 					<key>pfm_subkeys</key>
@@ -1049,7 +1053,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankdvd</string>
 					<key>pfm_subkeys</key>
@@ -1096,7 +1100,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Volumes to eject when the user logs out.</string>
+			<string>The media type dictionary that defines volumes to eject when the user logs out.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.0</string>
 			<key>pfm_macos_max</key>
@@ -1109,7 +1113,9 @@
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>This key is the default for media types that donʼt fall into other categories. Like internally installed SD-Cards and USB flash drives.</string>
+					<string>A string or an array of media action strings. Internally installed SD cards and USB flash drives are included in the hard disk-external category.
+
+This key is the default for media types that don't fall into other categories.</string>
 					<key>pfm_name</key>
 					<string>harddisk-external</string>
 					<key>pfm_subkeys</key>
@@ -1150,7 +1156,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>harddisk-internal</string>
 					<key>pfm_subkeys</key>
@@ -1191,7 +1197,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>networkdisk</string>
 					<key>pfm_subkeys</key>
@@ -1232,7 +1238,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>disk-image</string>
 					<key>pfm_subkeys</key>
@@ -1273,7 +1279,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>bd</string>
 					<key>pfm_subkeys</key>
@@ -1314,7 +1320,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>cd</string>
 					<key>pfm_subkeys</key>
@@ -1355,7 +1361,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>dvd</string>
 					<key>pfm_subkeys</key>
@@ -1396,7 +1402,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>dvdram</string>
 					<key>pfm_subkeys</key>
@@ -1437,7 +1443,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankbd</string>
 					<key>pfm_subkeys</key>
@@ -1478,7 +1484,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankcd</string>
 					<key>pfm_subkeys</key>
@@ -1519,7 +1525,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>A media action string or an array of media action strings.</string>
 					<key>pfm_name</key>
 					<string>blankdvd</string>
 					<key>pfm_subkeys</key>

--- a/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Third Active Ethernet settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>802.1X Ethernet: Third Active</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.thirdactiveethernet.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.thirdactiveethernet.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Third Ethernet settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>802.1X Ethernet: Third</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.thirdethernet.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.thirdethernet.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.tvremote.plist
+++ b/Manifests/ManifestsApple/com.apple.tvremote.plist
@@ -17,7 +17,7 @@ To lock specific Apple TVs to specific devices running Apple TV Remote app, both
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -29,9 +29,7 @@ To lock specific Apple TVs to specific devices running Apple TV Remote app, both
 			<key>pfm_default</key>
 			<string>Configures TV Remote app settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -43,9 +41,7 @@ To lock specific Apple TVs to specific devices running Apple TV Remote app, both
 			<key>pfm_default</key>
 			<string>TV Remote settings</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -59,9 +55,7 @@ To lock specific Apple TVs to specific devices running Apple TV Remote app, both
 			<key>pfm_default</key>
 			<string>com.apple.tvremote</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -75,9 +69,7 @@ To lock specific Apple TVs to specific devices running Apple TV Remote app, both
 			<key>pfm_default</key>
 			<string>com.apple.tvremote</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -91,9 +83,7 @@ To lock specific Apple TVs to specific devices running Apple TV Remote app, both
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -109,10 +99,7 @@ To lock specific Apple TVs to specific devices running Apple TV Remote app, both
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -124,10 +111,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -137,9 +121,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of permitted iOS remote devices restricted on this device.</string>
-			<key>pfm_description_reference</key>
-			<string>If present, the Apple TV will only connect with the Apple TV Remote app from the devices specified. If not present, or the list is empty, any device will be allowed to connect. Availability: Available in tvOS 11.3 and later.</string>
+			<string>The array of valid devices that Apple TV can connect to.</string>
 			<key>pfm_name</key>
 			<string>AllowedRemotes</string>
 			<key>pfm_platforms</key>
@@ -159,7 +141,7 @@ The payload organization for a payload need not match the payload organization i
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>The iOS remote's MAC address</string>
+							<string>The MAC address of a permitted iOS device that can control this Apple TV. Use the format xx:xx:xx:xx:xx:xx. The field isn't case sensitive.</string>
 							<key>pfm_format</key>
 							<string>^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$</string>
 							<key>pfm_name</key>
@@ -189,9 +171,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>List of permitted tvOS remote devices restricted on this device.</string>
-			<key>pfm_description_reference</key>
-			<string>If present, the Apple TV Remote app will only connect to the specified Apple TVs. If not present, or the list is empty, the device will be able to connect to any Apple TV. Availability: Available in iOS 11.3 and later.</string>
+			<string>The array of valid Apple TV identifiers that the remote can connect to.</string>
 			<key>pfm_ios_min</key>
 			<string>11.3</string>
 			<key>pfm_name</key>
@@ -213,7 +193,7 @@ The payload organization for a payload need not match the payload organization i
 					<array>
 						<dict>
 							<key>pfm_description</key>
-							<string>The tvOS destination MAC address</string>
+							<string>The MAC address of an Apple TV device that this iOS device is permitted to control. Use the format xx:xx:xx:xx:xx:xx. The field isn't case sensitive.</string>
 							<key>pfm_format</key>
 							<string>^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$</string>
 							<key>pfm_name</key>
@@ -229,7 +209,7 @@ The payload organization for a payload need not match the payload organization i
 						</dict>
 						<dict>
 							<key>pfm_description</key>
-							<string>The tvOS destination device name</string>
+							<string>The name of an Apple TV device that this iOS device is permitted to control.</string>
 							<key>pfm_ios_min</key>
 							<string>15</string>
 							<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.universalaccess.plist
+++ b/Manifests/ManifestsApple/com.apple.universalaccess.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.9</string>
 	<key>pfm_platforms</key>
@@ -26,7 +26,7 @@
 			<key>pfm_default</key>
 			<string>Configures Universal Access settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -38,7 +38,7 @@
 			<key>pfm_default</key>
 			<string>Universal Access</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -52,7 +52,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.universalaccess</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -66,7 +66,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.universalaccess</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -80,7 +80,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -96,7 +96,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -108,7 +108,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -120,7 +120,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Use scroll gesture with modifier keys to zoom" in the zoom options</string>
+			<string>If 'true', enables 'Use scroll gesture' in the Zoom options.</string>
 			<key>pfm_name</key>
 			<string>closeViewScrollWheelToggle</string>
 			<key>pfm_title</key>
@@ -132,7 +132,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Use keyboard shortcuts to zoom" in the zoom options</string>
+			<string>If 'true', enables 'Use keyboard shortcuts' in the Zoom options.</string>
 			<key>pfm_name</key>
 			<string>closeViewHotkeysEnabled</string>
 			<key>pfm_title</key>
@@ -142,7 +142,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The maximal zoom magnification that can be set in the Zoom options in an integer value between 1 and 40</string>
+			<string>The maximum zoom level in the Zoom options.</string>
 			<key>pfm_name</key>
 			<string>closeViewNearPoint</string>
 			<key>pfm_range_max</key>
@@ -156,7 +156,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The minimal zoom magnification that can be set in the Zoom options in an integer value between 1 and 40</string>
+			<string>The minimum zoom level in the Zoom options.</string>
 			<key>pfm_name</key>
 			<string>closeViewFarPoint</string>
 			<key>pfm_range_max</key>
@@ -172,7 +172,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Show preview rectangle" in the Zoom options</string>
+			<string>If 'true', enables 'Show preview rectangle' in the Zoom options. Only available in macOS 10.15 and earlier.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -186,7 +186,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Smooth images" in the Zoom options</string>
+			<string>If 'true', enables 'Smooth images' in the Zoom options.</string>
 			<key>pfm_name</key>
 			<string>closeViewSmoothImages</string>
 			<key>pfm_title</key>
@@ -198,7 +198,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Invert colors" in Display options</string>
+			<string>If 'true', enables Invert Colors in Display Accommodations.</string>
 			<key>pfm_name</key>
 			<string>whiteOnBlack</string>
 			<key>pfm_title</key>
@@ -210,7 +210,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Use grayscale" in the Display options</string>
+			<string>If 'true', enables 'Use grayscale' in the Display options.
+This option is deprecated in macOS 11.</string>
 			<key>pfm_macos_deprecated</key>
 			<string>11.0</string>
 			<key>pfm_name</key>
@@ -240,7 +241,7 @@
 			<key>pfm_default</key>
 			<real>1</real>
 			<key>pfm_description</key>
-			<string>The size of the mouse cursor in a decimal value between 1 and 4, where 1 is normal and 4 is the maximum</string>
+			<string>The size of the cursor.</string>
 			<key>pfm_name</key>
 			<string>mouseDriverCursorSize</string>
 			<key>pfm_range_max</key>
@@ -256,7 +257,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>VoiceOver provides spoken and brailled descriptions of items on the computer screen and provides control of the computer through the user of the keyboard</string>
+			<string>If 'true', enables Voice Over.</string>
 			<key>pfm_name</key>
 			<string>voiceOverOnOffKey</string>
 			<key>pfm_title</key>
@@ -268,7 +269,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Flash the screen when an alert sound occurs" in the Audio options</string>
+			<string>If 'true', enables 'Flash the screen' in the Audio options.</string>
 			<key>pfm_name</key>
 			<string>flashScreen</string>
 			<key>pfm_title</key>
@@ -280,7 +281,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Play stereo audio as mono" in the Audio options</string>
+			<string>If 'true', plays stereo audio as mono.</string>
 			<key>pfm_name</key>
 			<string>stereoAsMono</string>
 			<key>pfm_title</key>
@@ -292,7 +293,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Sticky Keys" in the Keyboard options. Sticky keys allows modifier keys to be set without having to hold the key down</string>
+			<string>If 'true', enables Sticky Keys in the Keyboard options.</string>
 			<key>pfm_name</key>
 			<string>stickyKey</string>
 			<key>pfm_title</key>
@@ -304,7 +305,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Display pressed keys on screen" for Sticky Keys in Keyboard options</string>
+			<string>If 'true', enables 'Display pressed keys on screen' for Sticky Keys.</string>
 			<key>pfm_name</key>
 			<string>stickyKeyShowWindow</string>
 			<key>pfm_title</key>
@@ -316,7 +317,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Beep when a modifier key is set" for Sticky Keys in Keyboard options</string>
+			<string>If 'true', enables the beep when a modifier key is set for Sticky Keys.</string>
 			<key>pfm_name</key>
 			<string>stickyKeyBeepOnModifier</string>
 			<key>pfm_title</key>
@@ -328,7 +329,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Slow Keys" in the Keyboard options. Slow keys adjusts the amount of time between when a key is pressed and when it is activated</string>
+			<string>If 'true', enables 'Slow Keys' in the Keyboard options.</string>
 			<key>pfm_name</key>
 			<string>slowKey</string>
 			<key>pfm_title</key>
@@ -340,7 +341,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Use click key sounds" for Slow Keys in the Keyboard options</string>
+			<string>If 'true', enables 'click key sounds' for Slow Keys.</string>
 			<key>pfm_name</key>
 			<string>slowKeyBeepOn</string>
 			<key>pfm_title</key>
@@ -352,7 +353,7 @@
 			<key>pfm_default</key>
 			<integer>250</integer>
 			<key>pfm_description</key>
-			<string>The acceptance delay for Slow Keys in miliseconds</string>
+			<string>The acceptance delay, in milliseconds, for Slow Keys.</string>
 			<key>pfm_name</key>
 			<string>slowKeyDelay</string>
 			<key>pfm_title</key>
@@ -366,7 +367,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Enable Mouse Keys" in the Pointer Control options. Mouse Keys allows the mouse pointer to be controlled using the keyboard number pad</string>
+			<string>If 'true', enables Mouse Keys in the Mouse &amp; Trackpad options.</string>
 			<key>pfm_name</key>
 			<string>mouseDriver</string>
 			<key>pfm_title</key>
@@ -378,7 +379,7 @@
 			<key>pfm_default</key>
 			<real>1</real>
 			<key>pfm_description</key>
-			<string>The initial delay before moving the mouse cursor with Mouse Keys in a decimal value representing seconds</string>
+			<string>The initial delay before moving the mouse with Mouse Keys.</string>
 			<key>pfm_name</key>
 			<string>mouseDriverInitialDelay</string>
 			<key>pfm_title</key>
@@ -390,7 +391,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The maximum speed for the cursor when using Mouse Keys in an integer value between 1 and 32, where 1 is the slowest and 32 is the fastest</string>
+			<string>The maximum speed for the cursor when using Mouse Keys.</string>
 			<key>pfm_name</key>
 			<string>mouseDriverMaxSpeed</string>
 			<key>pfm_range_max</key>
@@ -406,7 +407,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Turns on "Ignore built-in trackpad when mouse or wireless trackpad is present" in the Mouse &amp; Trackpad options</string>
+			<string>If 'true', ignores the built-in trackpad.</string>
 			<key>pfm_name</key>
 			<string>mouseDriverIgnoreTrackpad</string>
 			<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.webClip.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.webClip.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-03-31T08:41:40Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -25,9 +25,7 @@
 			<key>pfm_default</key>
 			<string>Configures settings for a web clip</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -39,9 +37,7 @@
 			<key>pfm_default</key>
 			<string>Web Clip</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,9 +51,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.webClip.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -71,9 +65,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.webClip.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -87,9 +79,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -105,10 +95,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -120,10 +107,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -133,9 +117,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The name of the Web Clip</string>
-			<key>pfm_description_reference</key>
-			<string>The name of the Web Clip as displayed on the Home screen.</string>
+			<string>The name of the web clip as displayed on the Home screen.</string>
 			<key>pfm_name</key>
 			<string>Label</string>
 			<key>pfm_require</key>
@@ -147,9 +129,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The URL that's displayed when users open the Web Clip. The URL must begin with HTTP or HTTPS</string>
-			<key>pfm_description_reference</key>
-			<string>The URL that the Web Clip should open when clicked. The URL must begin with HTTP or HTTPS or it won't work.</string>
+			<string>The URL that the web clip should open when clicked. If the URL doesn't begin with 'HTTP' or 'HTTPS', it doesn't work.</string>
 			<key>pfm_format</key>
 			<string>^https?://.*$</string>
 			<key>pfm_name</key>
@@ -165,9 +145,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Whether the Web Clip can be removed by users</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. If false, the web clip is not removable. Defaults to true. Not available in macOS.</string>
+			<string>If 'true', enables removing the web clip.</string>
 			<key>pfm_name</key>
 			<string>IsRemovable</string>
 			<key>pfm_platforms</key>
@@ -185,9 +163,9 @@ The payload organization for a payload need not match the payload organization i
 				<string>public.png</string>
 			</array>
 			<key>pfm_description</key>
-			<string>The icon to use for the Web Clip</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A PNG icon to be shown on the Home screen. Should be 59 x 60 pixels in size. If not specified, a white square will be shown.</string>
+			<string>The PNG icon to be shown on the Home screen.
+For best results, provide a square image that's no larger than 400 x 400 pixels and less than 1 MB when uncompressed. The graphics file is automatically scaled and cropped to fit, if necessary, and converted to PNG format. Web clip icons are 144 x 144 pixels for iPad devices with a Retina display, and 114 x 114 pixels for iPhone devices. To prevent the device from adding a shine to the image, set 'Precomposed' to 'true'.
+If this property isn't specified, a white square is shown.</string>
 			<key>pfm_name</key>
 			<string>Icon</string>
 			<key>pfm_range_max</key>
@@ -201,9 +179,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevents the iOS device from adding a shine to the image</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>If 'true', prevents SpringBoard from adding 'shine' to the icon.</string>
 			<key>pfm_name</key>
 			<string>Precomposed</string>
 			<key>pfm_platforms</key>
@@ -219,9 +195,7 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Opens the URL as a web app without a browser</string>
-			<key>pfm_description_reference</key>
-			<string></string>
+			<string>If 'true', launches the web clip as a full-screen web app.</string>
 			<key>pfm_name</key>
 			<string>FullScreen</string>
 			<key>pfm_platforms</key>
@@ -237,7 +211,8 @@ The payload organization for a payload need not match the payload organization i
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, a full screen web clip will not show the Safari UI when navigating to URLs other than the web clip's own.</string>
+			<string>If 'true', a full screen web clip can navigate to an external web site without showing Safari UI. Otherwise, Safari UI appears when navigating away from the web clip's URL.
+This key has no effect when 'FullScreen' is 'false'.</string>
 			<key>pfm_ios_min</key>
 			<string>14.5</string>
 			<key>pfm_macos_min</key>
@@ -251,7 +226,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Bundle identifier of the application that opens this web clip's URL.</string>
+			<string>The application bundle identifier that specifies the application which opens the URL. To use this property, the profile must be installed through an MDM.</string>
 			<key>pfm_ios_min</key>
 			<string>14.5</string>
 			<key>pfm_macos_min</key>

--- a/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
+++ b/Manifests/ManifestsApple/com.apple.webcontent-filter.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Web Content Filter settings</string>
+	<string>Use this section to define managed email and web domains.</string>
 	<key>pfm_description_reference</key>
 	<string>URLs are matched by using string-based root matching. A URL matches an allow list, deny list, or permitted list pattern if the exact characters of the pattern appear as the root of the URL. For example, if test.com/a is denylisted, then test.com, test.com/b, and test.com/c/d/e will all be blocked. Matching also discards subdomain prefixes, so if test.com/a is denylisted, m.test.com is also blocked.</string>
 	<key>pfm_documentation_url</key>
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>7.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -29,7 +29,7 @@
 			<key>pfm_default</key>
 			<string>Adds a Web Content Filter</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -41,7 +41,7 @@
 			<key>pfm_default</key>
 			<string>Web Content Filter</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -55,7 +55,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.webcontent-filter</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited. Usually root PayloadIdentifier+subidentifier.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -69,7 +69,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.webcontent-filter</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -83,7 +83,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload. (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -99,7 +99,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -111,7 +111,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -122,8 +122,8 @@
 		<dict>
 			<key>pfm_default</key>
 			<string>BuiltIn</string>
-			<key>pfm_description_reference</key>
-			<string>The type of filter, built-in or plug-in. Built-in filtering is available on iOS only.</string>
+			<key>pfm_description</key>
+			<string>The type of filter, built-in or plug-in. In macOS, the system supports only the plug-in value.</string>
 			<key>pfm_name</key>
 			<string>FilterType</string>
 			<key>pfm_range_list</key>
@@ -144,8 +144,9 @@
 		<dict>
 			<key>pfm_default</key>
 			<string>firewall</string>
-			<key>pfm_description_reference</key>
-			<string>This value is used to derive the relative order of content filters. Filters with a grade of firewall see network traffic before filters with a grade of inspector. The order of filters within a grade is undefined.</string>
+			<key>pfm_description</key>
+			<string>This value is for deriving the relative order of content filters. Filters with a grade of 'firewall' see network traffic before filters with a grade of 'inspector'. The system doesn't define the order of filters within a grade.
+Available in macOS 10.15 and later.</string>
 			<key>pfm_macos_min</key>
 			<string>10.15</string>
 			<key>pfm_name</key>
@@ -173,11 +174,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Optional. If true, automatic filtering is enabled. This function evaluates each web page as it is loaded and attempts to identify and block content not suitable for children.
-
-The search algorithm is complex and may vary from release to release, but it is basically looking for adult language, i.e. swearing and sexually explicit language. The default value is false.</string>
-			<key>pfm_description_reference</key>
-			<string>If true, automatic filtering is enabled. This function evaluates each web page as it is loaded and attempts to identify and block content not suitable for children. The search algorithm is complex and may vary from release to release, but it is basically looking for adult language.</string>
+			<string>If 'true', automatic filtering is in an enabled state. This function evaluates each web page as it loads and attempts to identify and block content not suitable for children. The search algorithm is complex and may vary from release to release, but it's basically looking for adult language.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -202,8 +199,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>An array or URLs that are accessible whether or not the automatic filter allows access. This array is use only when AutoFilterEnabled is true. Otherwise, this field is ignored.</string>
+			<key>pfm_description</key>
+			<string>An array or URLs that are accessible whether or not the automatic filter allows access. The system uses this array only when 'AutoFilterEnabled' is 'true'. Otherwise, it ignores this field.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -254,8 +251,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 		<dict>
 			<key>pfm_default</key>
 			<false/>
-			<key>pfm_description_reference</key>
-			<string>If 'true', enables the filtering of WebKit traffic. Either 'FilterBrowsers or 'FilterSockets' must be 'true'.</string>
+			<key>pfm_description</key>
+			<string>If 'true', enables the filtering of WebKit traffic. Either 'FilterBrowsers' or 'FilterSockets' must be 'true'.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -281,7 +278,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If present, these URLs are added to the browser's bookmarks, and the user is not allowed to visit any sites other than these. The number of these URLs should be limited to about 500.</string>
+			<string>An array of dictionaries defining the pages that the user can visit.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -366,7 +363,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>If present, these URLs are added to the browser's bookmarks, and the user is not allowed to visit any sites other than these. The number of these URLs should be limited to about 500.</string>
+			<string>Use 'AllowListBookmarks' instead.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -450,8 +447,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<string>array</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>If present, the user is denied visiting any of the sites on this list. The number of these URLs should be limited to about 500.</string>
+			<key>pfm_description</key>
+			<string>An array of URLs that are inaccessible. Limit the number of these URLs to about 500.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -504,8 +501,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<string>array</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>If present, the user is denied visiting any of the sites on this list. The number of these URLs should be limited to about 500.</string>
+			<key>pfm_description</key>
+			<string>Use 'DenyListURLs' instead.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -577,7 +574,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>A string which will be displayed for this filtering configuration.</string>
+			<string>The display name for this filtering configuration.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -620,8 +617,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 					</array>
 				</dict>
 			</array>
-			<key>pfm_description_reference</key>
-			<string>The Bundle ID of the plugin that provides filtering service.</string>
+			<key>pfm_description</key>
+			<string>The bundle ID of the plug-in that provides filtering service.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -646,8 +643,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>The server address, which may be IP address, hostname, or URL.</string>
+			<key>pfm_description</key>
+			<string>The server address, which may be the IP address, hostname, or URL.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -672,8 +669,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>A user name for the service.</string>
+			<key>pfm_description</key>
+			<string>The user name for the service.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -698,8 +695,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>A password for the service.</string>
+			<key>pfm_description</key>
+			<string>The password for the service.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -722,8 +719,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>The UUID of the certificate payload within the same profile used to authenticate the user.</string>
+			<key>pfm_description</key>
+			<string>The UUID of the certificate payload within the same profile that the system uses to authenticate the user.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -751,7 +748,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>An Organization string that will be passed to the 3rd party plugin.</string>
+			<string>The organization string that passes to the third-party plug-in.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -776,7 +773,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 		<dict>
 			<key>pfm_default</key>
 			<false/>
-			<key>pfm_description_reference</key>
+			<key>pfm_description</key>
 			<string>If 'true', enables the filtering of socket traffic. Either 'FilterBrowsers' or 'FilterSockets' must be 'true'.</string>
 			<key>pfm_exclude</key>
 			<array>
@@ -823,9 +820,8 @@ The search algorithm is complex and may vary from release to release, but it is 
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The bundle identifier string of the Filter Data Provider System Extension. This string identifies the Filter Data Provider when the filter starts running.</string>
-			<key>pfm_description_reference</key>
-			<string>The bundle identifier string of the Filter Data Provider System Extension. This string identifies the Filter Data Provider when the filter starts running.</string>
+			<string>The bundle identifier string of the filter data provider system extension. This string identifies the filter data provider when the filter starts running. This field is a requirement if 'FilterSockets' is 'true'.
+Available in macOS 10.15 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -883,10 +879,7 @@ The search algorithm is complex and may vary from release to release, but it is 
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The designated requirement string that is embedded in the code signature of the Filter Data Provider System Extension. This string identifies the Filter Data Provider when the filter starts running.</string>
-			<key>pfm_description_reference</key>
-			<string>The designated requirement string that is embedded in the code signature of the Filter Data Provider System Extension. This string identifies the Filter Data Provider when the filter starts running. This field is required if FilterSockets is set to 1.
-
+			<string>The designated requirement string that the system embeds in the code signature of the filter data provider system extension. This string identifies the filter data provider when the filter starts running. This field is a requirement if 'FilterSockets' is 'true'.
 Available in macOS 10.15 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
@@ -929,9 +922,10 @@ Available in macOS 10.15 and later.</string>
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string></string>
-			<key>pfm_description_reference</key>
-			<string> If this value is 'true', the property enables the filtering of network packets. Either 'FilterPackets' or 'FilterSockets' must be 'true'. You can only use this when 'FilterType' is 'Plugin'.</string>
+			<string>If this value is 'true', the property enables the filtering of network packets.
+Either 'FilterPackets' or 'FilterSockets' must be 'true'.
+You can only use this when 'FilterType' is 'Plugin'.
+Available in macOS 10.15 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -983,10 +977,7 @@ Available in macOS 10.15 and later.</string>
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The bundle identifier string of the Filter Packet Provider System Extension. This string identifies the Filter Packet Provider when the filter starts running.</string>
-			<key>pfm_description_reference</key>
-			<string>The bundle identifier string of the Filter Packet Provider System Extension. This string identifies the Filter Packet Provider when the filter starts running. This field is required if FilterPackets is set to 1.
-
+			<string>The bundle identifier string of the filter packet provider system extension. This string identifies the filter packet provider when the filter starts running. This field is a requirement if 'FilterPackets' is 'true'.
 Available in macOS 10.15 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
@@ -1045,10 +1036,7 @@ Available in macOS 10.15 and later.</string>
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The designated requirement string that is embedded in the code signature of the Filter Packet Provider System Extension. This string identifies the Filter Packet Provider when the filter starts running.</string>
-			<key>pfm_description_reference</key>
-			<string>The designated requirement string that is embedded in the code signature of the Filter Packet Provider System Extension. This string identifies the Filter Packet Provider when the filter starts running. This field is required if FilterPackets is set to 1.
-
+			<string>The designated requirement string that the system embeds in the code signature of the filter packet provider system extension. This string identifies the filter packet provider when the filter starts running. This field is a requirement if 'FilterPackets' is 'true'.
 Available in macOS 10.15 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
@@ -1089,7 +1077,7 @@ Available in macOS 10.15 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Custom key/value pairs for the filtering service plugin</string>
+			<string>The custom dictionary that the filtering service plug-in needs.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1134,7 +1122,7 @@ Available in macOS 10.15 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Global identifier of the content filter configuration in this payload. Used for processing network traffic of managed apps with an identical attribute by the filter.</string>
+			<string>A globally-unique identifier for this content filter configuration. Managed apps with the same 'ContentFilterUUID' in their app attributes have their network traffic processed by the content filter.</string>
 			<key>pfm_ios_min</key>
 			<string>16.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -30,7 +30,7 @@
 			<key>pfm_default</key>
 			<string>Configures Wi-Fi settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,7 +42,7 @@
 			<key>pfm_default</key>
 			<string>Wi-Fi</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -56,7 +56,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.wifi.managed</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -70,7 +70,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.wifi.managed</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -84,7 +84,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -100,7 +100,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -112,7 +112,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -169,7 +169,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If the network should be treated as a Legacy Hotspot or Passpoint network.</string>
+			<string>If 'true', the device treats the network as a hotspot.
+Available in iOS 7.0 and later, and in macOS 10.9 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -232,7 +233,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Displayed name of the wireless network</string>
+			<string>The SSID of the Wi-Fi network to be used. In iOS 7.0 and later, the SSID is optional if a 'DomainName' value is provided.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -260,7 +261,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Specify whether the network that the device connects to is broadcasting its identity.</string>
+			<string>If 'true', defines this network as hidden.</string>
 			<key>pfm_name</key>
 			<string>HIDDEN_NETWORK</string>
 			<key>pfm_title</key>
@@ -272,7 +273,9 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Automatically join the network without notifying users.</string>
+			<string>If 'true', the device joins the network automatically.
+If 'false', the user must tap the network name to join it.
+Available in iOS 5.0 and later, and in macOS 10.7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_macos_min</key>
@@ -293,7 +296,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Users won't have an opportunity to join networks that require agreements or other information prior to network access.</string>
+			<string>If 'true', Captive Network detection will be bypassed when the device connects to the network.
+Available in iOS 10.0 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>10.0</string>
 			<key>pfm_name</key>
@@ -311,7 +315,9 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If true, disables MAC address randomization for that Wi-Fi network while associated with the network. This also shows a privacy warning in Settings indicating that the network has reduced privacy protections.</string>
+			<string>If 'true,' disables MAC address randomization for a Wi-Fi network while associated with that network. This feature also shows a privacy warning in Settings indicating that the network has reduced privacy protections.
+This value is only locked when the profile is installed by MDM. If the profile is manually installed, the value is set but the user can change it.
+Available in iOS 14 and later, and watchOS 7 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>14.0</string>
 			<key>pfm_name</key>
@@ -329,7 +335,8 @@
 			<key>pfm_default</key>
 			<string>None</string>
 			<key>pfm_description</key>
-			<string>The type of proxy configuration to use for this wireless connection.</string>
+			<string>The proxy type, if any, to use. If you choose the manual proxy type, you need the proxy server address, including its port and optionally a user name and password into the proxy server. If you choose the auto proxy type, you can enter a proxy autoconfiguration (PAC) URL.
+Available in iOS 5.0 and later, and on all versions of macOS.</string>
 			<key>pfm_ios_min</key>
 			<string>5.0</string>
 			<key>pfm_name</key>
@@ -376,7 +383,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The hostname of the proxy server.</string>
+			<string>The proxy server's network address.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -426,7 +433,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>The port used to connect to the proxy server.</string>
+			<string>The proxy server's port number.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -456,7 +463,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The user name for the manual proxy connection.</string>
+			<string>The user name used to authenticate to the proxy server.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -482,7 +489,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The password for the manual proxy connection.</string>
+			<string>The password used to authenticate to the proxy server.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -510,7 +517,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>URL used to receive proxy settings. If no URL is specified, the device uses the web proxy autodiscovery protocol (WPAD) to discover proxies</string>
+			<string>The URL of the PAC file that defines the proxy configuration.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -538,7 +545,7 @@
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
-			<string>Enable to allow direct connection if PAC is unreachable</string>
+			<string>If 'true', allows connecting directly to the destination if the PAC file is unreachable.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -566,7 +573,15 @@
 			<key>pfm_default</key>
 			<string>Any</string>
 			<key>pfm_description</key>
-			<string>Wireless network encryption to use when connecting. The None value is available in iOS 5.0 and later and the WPA2 value is available in iOS 8.0 and later</string>
+			<string>The encryption type for the network.
+If set to anything except 'None', the payload may contain the following three keys: 'Password', 'PayloadCertificateUUID', or 'EAPClientConfiguration'.
+As of iOS 16, tvOS 16, watchOS 9, and macOS 13:
+* 'WPA' allows joining WPA or WPA2 networks
+* 'WPA2' allows joining WPA2 or WPA3 networks
+* 'WPA3' allows joining WPA3 networks only
+* 'Any' allows joining WPA, WPA2, WPA3, and WEP networks.
+Prior to iOS 16, tvOS 16, and watchOS 9, specifying 'WPA', 'WPA2', and 'WPA3' were equivalent and would allow joining any WPA network.
+Prior to macOS 13, the encryption type, if specified explicitly, needed to match the encryption type of the network exactly.</string>
 			<key>pfm_ios_min</key>
 			<string>4.0</string>
 			<key>pfm_name</key>
@@ -603,7 +618,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Specifies the password for the access point.</string>
+			<string>The password for the access point.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -647,7 +662,8 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Display name of the Passpoint service provider.</string>
+			<string>The operator name to display when connected to this network. Used only with Wi-Fi Hotspot 2.0 access points.
+Available in iOS 7.0 and later, and in macOS 10.9 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -708,7 +724,8 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>Domain name of the Passpoint service provider.</string>
+			<string>The primary domain of the tunnel.
+Available in iOS 7.0 and later, and in macOS 10.9 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -753,7 +770,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Specify whether to connect to additional Passpoint networks pre-approved by the service provider.</string>
+			<string>If 'true', allows connection to roaming service providers.
+Available in iOS 7.0 and later, and in macOS 10.9 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -802,7 +820,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enter a series of digits corresponding to one of the service provider's Passpoint network.</string>
+			<string>An array of Roaming Consortium Organization Identifiers used for Wi-Fi Hotspot 2.0 negotiation.
+Available in iOS 7.0 and later, and in macOS 10.9 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -862,7 +881,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Enter the known NAI realm names.</string>
+			<string>An array of Network Access Identifier Realm names used for Wi-Fi Hotspot 2.0 negotiation.
+Available in iOS 7.0 and later, and in macOS 10.9 and later.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -920,7 +940,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>HotSpot 2.0 MCC/MNCs.</string>
+			<string>An array of Mobile Country Code/Mobile Network Code (MCC/MNC) pairs used for Wi-Fi Hotspot 2.0 negotiation. Each string must contain exactly six digits.
+Available in iOS 7.0 and later. This feature is not supported in macOS.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -977,7 +998,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Select "Login Window" to authenticate the Mac to the network when the user logs in.</string>
+			<string>An array of strings that contain the type of connection mode to be attached.</string>
 			<key>pfm_name</key>
 			<string>SetupModes</string>
 			<key>pfm_platforms</key>
@@ -1016,14 +1037,23 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Specifies 802.1x EAP authentication parameters.</string>
+			<string>The enterprise network configuration.</string>
 			<key>pfm_name</key>
 			<string>EAPClientConfiguration</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
 					<key>pfm_description</key>
-					<string>The EAP types accepted.</string>
+					<string>The system accepts the following EAP types:
+13 = TLS
+17 = LEAP
+18 = EAP-SIM
+21 = TTLS
+23 = EAP-AKA
+25 = PEAP
+43 = EAP-FAST
+
+For EAP-TLS authentication without a network payload, install the necessary identity certificates and have your users select EAP-TLS mode in the 802.1X credentials dialog that appears when they connect to the network. For other EAP types, a network payload is necessary and must specify the correct settings for the network.</string>
 					<key>pfm_name</key>
 					<string>AcceptEAPTypes</string>
 					<key>pfm_require</key>
@@ -1070,7 +1100,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Username. If not provided, the user may be prompted during login.</string>
+					<string>The user name for the account. If you don't specify a value, the system prompts the user during login.</string>
 					<key>pfm_name</key>
 					<string>UserName</string>
 					<key>pfm_title</key>
@@ -1098,7 +1128,7 @@
 						</dict>
 					</array>
 					<key>pfm_description</key>
-					<string>Password. If not provided, the user may be prompted during login.</string>
+					<string>The user's password. If you don't specify a value, the system prompts the user during login.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1134,7 +1164,7 @@
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If set, the user will be prompted for a password each time they connect to the network.</string>
+					<string>If 'true', the user receives a prompt for a password each time they connect to the network.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1173,7 +1203,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Array of UUIDs corresponding to the trusted certificates for this authentication.</string>
+					<string>An array of the UUID of a certificate payload to trust for authentication. Use this key to prevent the device from asking the user whether to trust the listed certificates. Dynamic trust (the certificate dialogue) is in a disabled state if you specify this property without also enabling  'TLSAllowTrustExceptions'.</string>
 					<key>pfm_name</key>
 					<string>PayloadCertificateAnchorUUID</string>
 					<key>pfm_subkeys</key>
@@ -1198,7 +1228,9 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Certificate Common Names expected from authentication server. The wildcard * can be used to match a range of strings.</string>
+					<string>The list of accepted server certificate common names. If a server presents a certificate that isn't in this list, the system doesn't trust it.
+If you specify this property, the system disables dynamic trust (the certificate dialog) unless you also specify 'TLSAllowTrustExceptions'  with the value 'true'.
+If necessary, use wildcards to specify the name, such as 'wpa.*.example.com'.</string>
 					<key>pfm_name</key>
 					<string>TLSTrustedServerNames</string>
 					<key>pfm_subkeys</key>
@@ -1223,7 +1255,9 @@
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>Allows a dynamic trust decision by the user.</string>
+					<string>If 'true', allows a dynamic trust decision by the user. The dynamic trust is the certificate dialogue that appears when the system doesn't trust a certificate.
+If 'false', the authentication fails if the system doesn't already trust the certificate.
+As of iOS 8, Apple no longer supports this key.</string>
 					<key>pfm_ios_deprecated</key>
 					<string>7.1.2</string>
 					<key>pfm_ios_max</key>
@@ -1257,7 +1291,7 @@
 					<key>pfm_default</key>
 					<string>MSCHAPv2</string>
 					<key>pfm_description</key>
-					<string>Specifies the inner authentication used by the TTLS module.</string>
+					<string>The inner authentication that the TTLS module uses.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1291,7 +1325,9 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Externally visible identification (for TTLS, PEAP, and EAP-FAST). This string is used instead of the user's identity outside the encrypted tunnel. This value can be used to mask the true identity of the person using the network.</string>
+					<string>A name that hides the user's true name. The user's actual name appears only inside the encrypted tunnel. For example, you might set this to anonymous or anon, or anon@mycompany.net. It can increase security because an attacker can't see the authenticating user's name in the clear.
+
+This key is only relevant to TTLS, PEAP, and EAP-FAST.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1319,7 +1355,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>The minimum TLS version for EAP authentication.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1358,7 +1394,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string></string>
+					<string>The maximum TLS version for EAP authentication.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1399,7 +1435,7 @@
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If set, the device will use an existing PAC if it's present. Otherwise the server must present its identity using a certificate.</string>
+					<string>If 'true', the device uses an existing PAC if it's present. Otherwise, the server must present its identity using a certificate.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1427,7 +1463,9 @@
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If set, allows PAC provisioning.</string>
+					<string>If 'true', allows PAC provisioning.
+
+This value is only applicable if 'EAPFASTUsePAC' is 'true'. This value must be 'true' for EAP-FAST PAC usage to succeed because there is no other way to provision a PAC.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1468,7 +1506,7 @@
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If set, provisions the device anonymously. Note that there are known man-in-the-middle attacks for anonymous provisioning.</string>
+					<string>If 'true', provisions the device anonymously. Note that there are known machine-in-the-middle attacks for anonymous provisioning.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1509,7 +1547,8 @@
 					<key>pfm_default</key>
 					<integer>3</integer>
 					<key>pfm_description</key>
-					<string>The minimum number of RAND values accepted from the server. 3 is the default, and 2 is allowed, but offers less security.</string>
+					<string>The minimum number of RAND values to accept from the server.
+For use with EAP-SIM only.</string>
 					<key>pfm_exclude</key>
 					<array>
 						<dict>
@@ -1540,7 +1579,8 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Use an alternate set of credentials when in System mode (AKA not a loginwindow profile). This can be used to tell EAPOLClient to use the computer password in a bound active directory scenario for authentication.</string>
+					<string>Set this string to 'ActiveDirectory' to use the AD computer name and password credentials.
+If using this property, you can't use 'SystemModeUseOpenDirectoryCredentials'.</string>
 					<key>pfm_name</key>
 					<string>SystemModeCredentialsSource</string>
 					<key>pfm_range_list</key>
@@ -1554,7 +1594,8 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>This indicates if the connection should try to use the OpenDirectory machine credentials.</string>
+					<string>If 'true', the system mode connection tries to use the Open Directory credentials.
+If using this property, you can't use  'SystemModeCredentialsSource'.</string>
 					<key>pfm_name</key>
 					<string>SystemModeUseOpenDirectoryCredentials</string>
 					<key>pfm_title</key>
@@ -1570,7 +1611,8 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Restrict fast lane QoS marking.</string>
+			<string>A dictionary that contains the list of apps that are allowed to benefit from L2 and L3 marking. When this dictionary isn't present, all apps are allowed to use L2 and L3 marking when the Wi-Fi network supports Cisco QoS fast lane.
+Available in iOS 10.0 and later, and in macOS 10.13 and later.</string>
 			<key>pfm_ios_min</key>
 			<string>10.0</string>
 			<key>pfm_macos_min</key>
@@ -1588,7 +1630,9 @@
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>Enable any kind of QoS marking.</string>
+					<string>If 'true', disables L3 marking and only uses L2 marking for traffic that goes to the Wi-Fi network.
+
+If 'false', the system behaves as if Wi-Fi doesn't have an association with a Cisco QoS fast lane network.</string>
 					<key>pfm_name</key>
 					<string>QoSMarkingEnabled</string>
 					<key>pfm_title</key>
@@ -1600,7 +1644,7 @@
 					<key>pfm_default</key>
 					<true/>
 					<key>pfm_description</key>
-					<string>Enable QoS for WiFi Calling, FaceTime, SMS, etc.</string>
+					<string>If 'true', adds audio and video traffic of built-in audio/video services, such as FaceTime and Wi-Fi Calling, to the allow list for L2 and L3 marking for traffic that goes to the Wi-Fi network.</string>
 					<key>pfm_name</key>
 					<string>QoSMarkingAppleAudioVideoCalls</string>
 					<key>pfm_title</key>
@@ -1610,7 +1654,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Add specific apps to an allow list for QoS marking.</string>
+					<string>An array of app bundle identifiers that defines the allow list for L2 and L3 marking for traffic that goes to the Wi-Fi network. If the array isn't present, but the 'QoSMarkingPolicy' key is present — even empty — no apps can use L2 and L3 marking.</string>
 					<key>pfm_ios_min</key>
 					<string>14.5</string>
 					<key>pfm_macos_min</key>
@@ -1633,7 +1677,7 @@
 				</dict>
 				<dict>
 					<key>pfm_description</key>
-					<string>Add specific apps to an allow list for QoS marking.</string>
+					<string>Use 'QoSMarkingAllowListAppIdentifiers' instead.</string>
 					<key>pfm_ios_deprecated</key>
 					<string>14.5</string>
 					<key>pfm_macos_deprecated</key>
@@ -1680,7 +1724,7 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string>UUID of the certificate payload containing an identity used as the client credential.</string>
+			<string>The UUID of the certificate payload within the same profile to use for the client credential.</string>
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
@@ -1713,7 +1757,8 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>If set, force a non-default authentication method. (if YES, uses certificate from PayloadCertificateUUID).</string>
+			<string>If 'true', allows for two-factor authentication for EAP-TTLS, PEAP, or EAP-FAST.
+If 'false', allows for zero-factor authentication for EAP-TLS.</string>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.xsan.plist
+++ b/Manifests/ManifestsApple/com.apple.xsan.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:52Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Xsan settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Xsan</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.xsan</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.xsan</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -114,7 +114,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The name of the Xsan network.</string>
+			<string>The name of the SAN. This key is required for all Xsan SANs. The name must exactly match the name of the SAN defined in the metadata server.</string>
 			<key>pfm_name</key>
 			<string>sanName</string>
 			<key>pfm_require</key>
@@ -126,7 +126,9 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The IP address or fully qualified domain name (FQDN) of each Xsan file server.</string>
+			<string>An array of storage area network (SAN) File System Name Server coordinators. The list should contain the same addresses in the same order as the metadata controller (MDC) '/Library/Preferences/Xsan/fsnameservers' file.  Xsan SAN clients automatically receive updates to the 'fsnameservers' list from the SAN configuration servers whenever this list changes. StorNext administrators should update their profile whenever the 'fsnameservers' list changes.
+
+This key is required for StorNext SANs.</string>
 			<key>pfm_name</key>
 			<string>fsnameservers</string>
 			<key>pfm_require</key>
@@ -169,7 +171,9 @@
 				</dict>
 			</array>
 			<key>pfm_description</key>
-			<string></string>
+			<string>The authentication method for the SAN. This key is required for all Xsan SANs. It's optional for StorNext SANs but should be set if the StorNext SAN uses an 'auth_secret' file.
+
+Only one value is accepted: 'auth_secret'</string>
 			<key>pfm_name</key>
 			<string>sanAuthMethod</string>
 			<key>pfm_range_list</key>
@@ -187,7 +191,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The secret credential used to join the Xsan network.</string>
+			<string>The shared secret used for Xsan network authentication. This key is required when the 'sanAuthMethod' key is present. The value should equal the content of the MDC's '/Library/Preferences/Xsan/.auth_secret' file.</string>
 			<key>pfm_name</key>
 			<string>sharedSecret</string>
 			<key>pfm_sensitive</key>

--- a/Manifests/ManifestsApple/com.apple.xsan.preferences.plist
+++ b/Manifests/ManifestsApple/com.apple.xsan.preferences.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2020-04-28T13:19:18Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.11</string>
 	<key>pfm_platforms</key>
@@ -28,7 +28,7 @@
 			<key>pfm_default</key>
 			<string>Configures Xsan Preferences settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -40,7 +40,7 @@
 			<key>pfm_default</key>
 			<string>Xsan Preferences</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -54,7 +54,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.xsan.preferences</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -68,7 +68,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.xsan.preferences</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -82,7 +82,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -98,7 +98,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -110,7 +110,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -121,8 +121,8 @@
 		<dict>
 			<key>pfm_default</key>
 			<false/>
-			<key>pfm_description_reference</key>
-			<string>If true, use the DLC for all volumes.</string>
+			<key>pfm_description</key>
+			<string>If 'true', use the DLC for all volumes.</string>
 			<key>pfm_name</key>
 			<string>useDLC</string>
 			<key>pfm_title</key>
@@ -131,8 +131,8 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>An array of Xsan or StorNext volume names. The Xsan client attempts to automatically mount these volumes at startup. The system administrator can mount additional volumes manually by using the xsanctl(8) mount command.</string>
+			<key>pfm_description</key>
+			<string>An array of Xsan or StorNext volume names. The Xsan client attempts to automatically mount these volumes at startup. The system administrator can mount additional volumes manually by using the 'xsanctl(8)' mount command.</string>
 			<key>pfm_name</key>
 			<string>onlyMount</string>
 			<key>pfm_subkeys</key>
@@ -150,8 +150,8 @@
 			<string>array</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>An array of Xsan or StorNext volume names. If no onlyMount array is present, the Xsan client automatically attempts to mount all SAN volumes except the volumes in this array. The system administrator can mount those volumes manually by using the xsanctl(8) mount command.</string>
+			<key>pfm_description</key>
+			<string>An array of Xsan or StorNext volume names. If no 'onlyMount' array is present, the Xsan client automatically attempts to mount all SAN volumes except the volumes in this array. The system administrator can mount those volumes manually by using the 'xsanctl(8)' mount command.</string>
 			<key>pfm_name</key>
 			<string>denyMount</string>
 			<key>pfm_subkeys</key>
@@ -169,8 +169,8 @@
 			<string>array</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
-			<string>An array of StorNext volume names. If the Xsan client is attempting to mount a volume named in this array, the Xsan client attempts to mount the volume using DLC. If DLC isn't available, the client attempts to mount the volume if its LUNs are available through Fibre Channel. The volume name must not also appear in denyDLC.</string>
+			<key>pfm_description</key>
+			<string>An array of StorNext volume names. If the Xsan client is attempting to mount a volume named in this array, the Xsan client attempts to mount the volume using DLC. If DLC isn't available, the client attempts to mount the volume if its LUNs are available through Fibre Channel. The volume name must not also appear in 'denyDLC'.</string>
 			<key>pfm_name</key>
 			<string>preferDLC</string>
 			<key>pfm_subkeys</key>
@@ -188,7 +188,7 @@
 			<string>array</string>
 		</dict>
 		<dict>
-			<key>pfm_description_reference</key>
+			<key>pfm_description</key>
 			<string>An array of StorNext volume names. If the Xsan client is attempting to mount a volume named in this array, the client only mounts the volume if its logical units (LUNs) are available through Fibre Channel. It doesn't attempt to mount the volume using Distributed LAN Client (DLC).</string>
 			<key>pfm_name</key>
 			<string>denyDLC</string>

--- a/Manifests/ManifestsApple/loginwindow.plist
+++ b/Manifests/ManifestsApple/loginwindow.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2019-11-07T15:29:16Z</date>
+	<date>2023-11-30T15:08:23Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -22,7 +22,7 @@
 			<key>pfm_default</key>
 			<string>Configures Login Window: Login Items settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -34,7 +34,7 @@
 			<key>pfm_default</key>
 			<string>Login Window: Login Items</string>
 			<key>pfm_description</key>
-			<string>Name of the payload</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -48,7 +48,7 @@
 			<key>pfm_default</key>
 			<string>loginwindow</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -62,7 +62,7 @@
 			<key>pfm_default</key>
 			<string>loginwindow</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -76,7 +76,7 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF)</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs. During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -92,7 +92,7 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
 			<key>pfm_require</key>
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -116,7 +116,7 @@
 			<key>pfm_default</key>
 			<false/>
 			<key>pfm_description</key>
-			<string>Prevent users from disabling login items launching using the Shift key.</string>
+			<string>If 'true', prevents the user from disabling login item launches by using the Shift key.</string>
 			<key>pfm_name</key>
 			<string>DisableLoginItemsSuppression</string>
 			<key>pfm_title</key>


### PR DESCRIPTION
This is a rerun of the scripts that created #626, off of the current state of the repository. It is meant to replace both #626 and #645, which have become full of unrelated commits.

To recap, in this PR:
* System manifest preference key descriptions updated with official texts where available, except for root descriptions where the official ones are empty
* Common preference keys in all manifests as well as in the manifest template updated with official descriptions
* Reference description tags removed from updated preference keys