### PR TITLE
Update manifests for Tailscale 1.56

### DIFF
--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -220,6 +220,132 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>https://controlserver.ts.example.com</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>Forces the Tailscale client to always use the given exit node. This can be useful if you wish to route all Internet traffic through a node for inspection or logging purposes. Users won't be able to disable or choose another exit node when this policy is active. A message will be displayed in the client UI informing users about this restriction. The value for this key should be the ID of an exit node device. You can find the ID for any device in your tailnet by looking at the Machines page of the admin console, or by using the Tailscale API. Note that if a forced exit node goes offline, Internet connectivity will be unavailable on client devices until the exit node comes back online.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#force-an-exit-node-to-always-be-used</string>
+			<key>pfm_name</key>
+			<string>ExitNodeID</string>
+			<key>pfm_title</key>
+			<string>Forced Exit Node ID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Allow Local Network Access determines whether users can still access devices on the local network while using an exit node.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#toggle-local-network-access-when-an-exit-node-is-in-use</string>
+			<key>pfm_name</key>
+			<string>ExitNodeAllowLANAccess</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow Local Network Access when an exit node is in use</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Determines whether the client accepts subnets advertised by other nodes in your tailnet.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#set-whether-the-device-accepts-tailscale-subnets</string>
+			<key>pfm_name</key>
+			<string>UseTailscaleSubnets</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Use Tailscale Subnets</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Determines whether to apply the DNS configuration provided by the coordination server when the tunnel is connected.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#set-whether-the-device-uses-tailscale-dns-settings</string>
+			<key>pfm_name</key>
+			<string>UseTailscaleDNSSettings</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Use Tailscale DNS Settings</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Determines whether Tailscale should allow incoming connections to the device.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#set-whether-to-allow-incoming-connections</string>
+			<key>pfm_name</key>
+			<string>AllowIncomingConnections</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow incoming connections</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -364,8 +490,34 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<string>show</string>
 			<key>pfm_description</key>
-			<string>Can be used to hides one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
+			<string>Shows or hides the "Update Available" menu item which appears when a newer version of Tailscale is available.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#hide-the-update-menu</string>
+			<key>pfm_name</key>
+			<string>UpdateMenu</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>show</string>
+				<string>hide</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Show</string>
+				<string>Hide</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Show/hide "Update Available" menu item</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Can be used to hide one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://tailscale.com/kb/1315/mdm-keys/#hide-network-devices</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -220,6 +220,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>https://controlserver.ts.example.com</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_description</key>
 			<string>Forces the Tailscale client to always use the given exit node. This can be useful if you wish to route all Internet traffic through a node for inspection or logging purposes. Users won't be able to disable or choose another exit node when this policy is active. A message will be displayed in the client UI informing users about this restriction. The value for this key should be the ID of an exit node device. You can find the ID for any device in your tailnet by looking at the Machines page of the admin console, or by using the Tailscale API. Note that if a forced exit node goes offline, Internet connectivity will be unavailable on client devices until the exit node comes back online.</string>
 			<key>pfm_documentation_url</key>
@@ -230,10 +232,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Forced Exit Node ID</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -258,10 +260,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Allow Local Network Access when an exit node is in use</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -286,10 +288,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Use Tailscale Subnets</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -314,10 +316,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Use Tailscale DNS Settings</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -342,8 +344,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Allow incoming connections</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -490,6 +490,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -512,8 +514,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Show/hide "Update Available" menu item</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-10-31T08:00:00Z</date>
+	<date>2023-12-13T08:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -346,6 +346,34 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Enables gathering of device posture data.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#enable-gathering-device-posture-data</string>
+			<key>pfm_name</key>
+			<string>PostureChecking</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Gather device posture data</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -581,6 +609,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -268,6 +268,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>https://controlserver.ts.example.com</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_description</key>
 			<string>Forces the Tailscale client to always use the given exit node. This can be useful if you wish to route all Internet traffic through a node for inspection or logging purposes. Users won't be able to disable or choose another exit node when this policy is active. A message will be displayed in the client UI informing users about this restriction. The value for this key should be the ID of an exit node device. You can find the ID for any device in your tailnet by looking at the Machines page of the admin console, or by using the Tailscale API. Note that if a forced exit node goes offline, Internet connectivity will be unavailable on client devices until the exit node comes back online.</string>
 			<key>pfm_documentation_url</key>
@@ -278,10 +280,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Forced Exit Node ID</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -306,10 +308,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Allow Local Network Access when an exit node is in use</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -334,10 +336,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Use Tailscale Subnets</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -362,10 +364,10 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Use Tailscale DNS Settings</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>
@@ -390,8 +392,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Allow incoming connections</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -538,6 +538,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -560,8 +562,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Show/hide "Update Available" menu item</string>
 			<key>pfm_type</key>
 			<string>string</string>
-			<key>pfm_app_min</key>
-			<string>1.56</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -268,6 +268,132 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>https://controlserver.ts.example.com</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>Forces the Tailscale client to always use the given exit node. This can be useful if you wish to route all Internet traffic through a node for inspection or logging purposes. Users won't be able to disable or choose another exit node when this policy is active. A message will be displayed in the client UI informing users about this restriction. The value for this key should be the ID of an exit node device. You can find the ID for any device in your tailnet by looking at the Machines page of the admin console, or by using the Tailscale API. Note that if a forced exit node goes offline, Internet connectivity will be unavailable on client devices until the exit node comes back online.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#force-an-exit-node-to-always-be-used</string>
+			<key>pfm_name</key>
+			<string>ExitNodeID</string>
+			<key>pfm_title</key>
+			<string>Forced Exit Node ID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Allow Local Network Access determines whether users can still access devices on the local network while using an exit node.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#toggle-local-network-access-when-an-exit-node-is-in-use</string>
+			<key>pfm_name</key>
+			<string>ExitNodeAllowLANAccess</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow Local Network Access when an exit node is in use</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Determines whether the client accepts subnets advertised by other nodes in your tailnet.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#set-whether-the-device-accepts-tailscale-subnets</string>
+			<key>pfm_name</key>
+			<string>UseTailscaleSubnets</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Use Tailscale Subnets</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Determines whether to apply the DNS configuration provided by the coordination server when the tunnel is connected.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#set-whether-the-device-uses-tailscale-dns-settings</string>
+			<key>pfm_name</key>
+			<string>UseTailscaleDNSSettings</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Use Tailscale DNS Settings</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Determines whether Tailscale should allow incoming connections to the device.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#set-whether-to-allow-incoming-connections</string>
+			<key>pfm_name</key>
+			<string>AllowIncomingConnections</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow incoming connections</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -412,8 +538,34 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<string>show</string>
 			<key>pfm_description</key>
-			<string>Can be used to hides one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
+			<string>Shows or hides the "Update Available" menu item which appears when a newer version of Tailscale is available.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#hide-the-update-menu</string>
+			<key>pfm_name</key>
+			<string>UpdateMenu</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>show</string>
+				<string>hide</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Show</string>
+				<string>Hide</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Show/hide "Update Available" menu item</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Can be used to hide one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://tailscale.com/kb/1315/mdm-keys/#hide-network-devices</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-10-31T08:00:00Z</date>
+	<date>2023-12-13T08:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -394,6 +394,34 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.56</string>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Enables gathering of device posture data.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys/#enable-gathering-device-posture-data</string>
+			<key>pfm_name</key>
+			<string>PostureChecking</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Gather device posture data</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -629,6 +657,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
This PR updates the manifests for Tailscale (App Store and Standalone variants of the client).

- Adds 5 additional settings that are being released in Tailscale 1.56 and can be managed via MDM.
- Fixes a typo.