### PR TITLE
Update io.tailscale.ipn.macsys.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-12-13T08:00:00Z</date>
+	<date>2024-01-23T08:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -597,7 +597,7 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_documentation_url</key>
 			<string>https://tailscale.com/kb/1315/mdm-keys/#hide-network-devices</string>
 			<key>pfm_name</key>
-			<string>Hidden network devices</string>
+			<string>HiddenNetworkDevices</string>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
@@ -657,6 +657,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Confirmed incorrect key for `pfm_name` by checking this documentation: https://tailscale.com/kb/1315/mdm-keys#hide-network-devices

Addresses #653 