### PR TITLE
Update Tailscale manifests for v1.60

### DIFF
--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -623,6 +623,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-01-23T08:00:00Z</date>
+	<date>2024-02-22T08:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -230,6 +230,20 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>ExitNodeID</string>
 			<key>pfm_title</key>
 			<string>Forced Exit Node ID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.58</string>
+			<key>pfm_description</key>
+			<string>The KeyExpirationNotice policy controls how long before key expiry should a notice be displayed. The default is 24 hours ("24h"). Use a Go-style Duration for this policy value, for instance "24h" or "5h25m30s".</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#set-the-key-expiration-notice-period</string>
+			<key>pfm_name</key>
+			<string>KeyExpirationNotice</string>
+			<key>pfm_title</key>
+			<string>Key Expiration Notice Interval</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -699,6 +699,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>3</integer>
+	<integer>4</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-01-23T08:00:00Z</date>
+	<date>2024-02-22T08:00:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -216,6 +216,34 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.60</string>
+			<key>pfm_default</key>
+			<string>user-decides</string>
+			<key>pfm_description</key>
+			<string>Setting UnstableUpdates to "never" means that your users won’t be able to update to unstable versions of the client from the in-app UI. You can deploy this policy to prevent non-tech-savvy users from enrolling in pre-release builds of the client, which might be more prone to issues.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#manage-unstable-versions-availability</string>
+			<key>pfm_name</key>
+			<string>UnstableUpdates</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>always</string>
+				<string>never</string>
+				<string>user-decides</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Always</string>
+				<string>Never</string>
+				<string>User Decides</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Allow updating to unstable builds</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
 			<key>pfm_description</key>
 			<string>The first time the application is opened on a Mac, Tailscale installs a macOS login helper. This allows Tailscale to start automatically when the user logs into their account. This boolean controls whether the login helper should start Tailscale at login time.</string>
 			<key>pfm_documentation_url</key>
@@ -278,6 +306,20 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>ExitNodeID</string>
 			<key>pfm_title</key>
 			<string>Forced Exit Node ID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.58</string>
+			<key>pfm_description</key>
+			<string>The KeyExpirationNotice policy controls how long before key expiry should a notice be displayed. The default is 24 hours ("24h"). Use a Go-style Duration for this policy value, for instance "24h" or "5h25m30s".</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#set-the-key-expiration-notice-period</string>
+			<key>pfm_name</key>
+			<string>KeyExpirationNotice</string>
+			<key>pfm_title</key>
+			<string>Key Expiration Notice Interval</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>


### PR DESCRIPTION
This PR updates the manifests for Tailscale (App Store and Standalone variants of the client).

- Adds 1 new additional setting for the Mac App Store variant of the client (`KeyExpirationNotice`), and 2 new settings for the Standalone variant (`KeyExpirationNotice` and `UnstableUpdates`). These new settings were released across Tailscale v1.58 and v1.60, and can be managed via MDM.