### PR TITLE
DigiDNA Mar 2024

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -7,7 +7,7 @@
 	<key>pfm_app_url</key>
 	<string>https://1password.com</string>
 	<key>pfm_description</key>
-	<string>1Password 8 settings</string>
+	<string>Use this section to define settings for 1Password password manager version 8</string>
 	<key>pfm_documentation_url</key>
 	<string>https://support.1password.com/mobile-device-management/</string>
 	<key>pfm_domain</key>
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
+++ b/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
@@ -7,7 +7,7 @@
 	<key>pfm_app_url</key>
 	<string>https://1password.com</string>
 	<key>pfm_description</key>
-	<string>1Password 7 settings</string>
+	<string>Use this section to define settings for 1Password password manager version 7</string>
 	<key>pfm_documentation_url</key>
 	<string>https://support.1password.com/mobile-device-management/</string>
 	<key>pfm_domain</key>
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-11-29T16:46:29Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_description</key>
-	<string>Google Drive for desktop settings</string>
+	<string>Use this section to define settings for Google Drive for desktop</string>
 	<key>pfm_documentation_url</key>
 	<string>https://support.google.com/a/answer/7644837</string>
 	<key>pfm_domain</key>
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2022-11-29T14:50:44Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.mcneel.rhinoceros.plist
+++ b/Manifests/ManagedPreferencesApplications/com.mcneel.rhinoceros.plist
@@ -5,13 +5,13 @@
 	<key>pfm_app_url</key>
 	<string>https://www.rhino3d.com/mac</string>
 	<key>pfm_description</key>
-	<string>Rhinoceros settings</string>
+	<string>Use this section to define settings for Rhinoceros 3D</string>
 	<key>pfm_domain</key>
 	<string>com.mcneel.rhinoceros</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-06T08:52:31Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate.fba.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate.fba.plist
@@ -5,13 +5,13 @@
 	<key>pfm_app_url</key>
 	<string>https://www.office.com</string>
 	<key>pfm_description</key>
-	<string>Microsoft AutoUpdate FBA settings</string>
+	<string>Use this section to define settings for Microsoft AutoUpdate FBA for Mac</string>
 	<key>pfm_domain</key>
 	<string>com.microsoft.autoupdate.fba</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/com.unity3d.UnityEditor5.x.plist
+++ b/Manifests/ManagedPreferencesApplications/com.unity3d.UnityEditor5.x.plist
@@ -5,13 +5,13 @@
 	<key>pfm_app_url</key>
 	<string>https://unity.com/</string>
 	<key>pfm_description</key>
-	<string>Unity Editor settings</string>
+	<string>Use this section to define settings for Unity Editor</string>
 	<key>pfm_domain</key>
 	<string>com.unity3d.UnityEditor5.x</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-18T17:28:30Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
+++ b/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
@@ -5,7 +5,7 @@
 	<key>pfm_app_url</key>
 	<string>https://github.com/SAP/macOS-enterprise-privileges</string>
 	<key>pfm_description</key>
-	<string>SAP Privileges app settings</string>
+	<string>Use this section to define settings for the SAP Privileges app</string>
 	<key>pfm_documentation_url</key>
 	<string>https://github.com/SAP/macOS-enterprise-privileges/tree/master/application_management</string>
 	<key>pfm_domain</key>
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManagedPreferencesApplications/fr.handbrake.HandBrake.plist
+++ b/Manifests/ManagedPreferencesApplications/fr.handbrake.HandBrake.plist
@@ -5,13 +5,13 @@
 	<key>pfm_app_url</key>
 	<string>https://handbrake.fr/</string>
 	<key>pfm_description</key>
-	<string>Handbrake settings</string>
+	<string>Use this section to define settings for the Handbrake video transcoder</string>
 	<key>pfm_domain</key>
 	<string>fr.handbrake.HandBrake</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2020-08-05T08:52:31Z</date>
+	<date>2024-02-01T10:06:10Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -20,7 +20,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-01T15:48:15Z</date>
+	<date>2024-02-16T10:50:53Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -212,6 +212,7 @@
 					<string>Extensions</string>
 					<string>ExtensionSettings</string>
 					<string>ExtensionUpdate</string>
+					<string>3rdparty</string>
 					<string>RequestedLocales</string>
 					<string>Preferences</string>
 					<string>SupportMenu</string>
@@ -282,6 +283,7 @@
 					<string>Extensions</string>
 					<string>ExtensionSettings</string>
 					<string>ExtensionUpdate</string>
+					<string>3rdparty</string>
 				</array>
 				<key>Bookmarks</key>
 				<array>
@@ -1593,6 +1595,58 @@ The configuration for each extension is another dictionary that can contain the 
 			<string>Extension Update</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>68</string>
+			<key>pfm_description</key>
+			<string>Configure third party components.</string>
+			<key>pfm_description_reference</key>
+			<string>Allow WebExtensions to configure policy.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/mozilla/policy-templates/blob/master/docs/index.md#3rdparty</string>
+			<key>pfm_name</key>
+			<string>3rdparty</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>68</string>
+					<key>pfm_description</key>
+					<string>Configure third party extensions. Keys in this dictionary specify IDs of extensions to configure, and values are dictionaries containing each third party extension configuration.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://github.com/mozilla/policy-templates/blob/master/docs/index.md#3rdparty</string>
+					<key>pfm_name</key>
+					<string>Extensions</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_name</key>
+							<string>{{key}}</string>
+							<key>pfm_title</key>
+							<string>Extension ID</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_name</key>
+							<string>{{value}}</string>
+							<key>pfm_title</key>
+							<string>Extension Configuration</string>
+							<key>pfm_type</key>
+							<string>dictionary</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>3rd Party Extension Configuration</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>3rd Party Configuration</string>
+			<key>pfm_type</key>
+			<string>dictionary</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -5988,6 +6042,6 @@ UrlbarInterventions Don't offer Firefox specific suggestions in the URL bar. (Fi
 	<key>pfm_user_approved</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>13</integer>
+	<integer>14</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -20,7 +20,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-02-16T10:50:53Z</date>
+	<date>2024-02-16T13:39:39Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -702,8 +702,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Block access to the Add-ons Manager (about:addons).</string>
 			<key>pfm_description_reference</key>
@@ -720,8 +718,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Block access to about:config.</string>
 			<key>pfm_description_reference</key>
@@ -738,8 +734,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Block access to About Profiles (about:profiles).</string>
 			<key>pfm_description_reference</key>
@@ -756,8 +750,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Block access to Troubleshooting Information (about:support).</string>
 			<key>pfm_description_reference</key>
@@ -890,8 +882,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Turn off application updates.</string>
 			<key>pfm_description_reference</key>
@@ -908,8 +898,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable the built in PDF viewer. PDF files are downloaded and sent externally.</string>
 			<key>pfm_description_reference</key>
@@ -967,8 +955,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Remove access to all developer tools.</string>
 			<key>pfm_description_reference</key>
@@ -985,8 +971,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable the menus for reporting sites (Submit Feedback, Report Deceptive Site).</string>
 			<key>pfm_description_reference</key>
@@ -1003,8 +987,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable Firefox Accounts integration (Sync).</string>
 			<key>pfm_description_reference</key>
@@ -1021,8 +1003,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Remove access to Firefox Screenshots.</string>
 			<key>pfm_description_reference</key>
@@ -1039,8 +1019,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable Firefox studies (Shield).</string>
 			<key>pfm_description_reference</key>
@@ -1057,8 +1035,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable the "Forget" button.</string>
 			<key>pfm_description_reference</key>
@@ -1075,8 +1051,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Remove the master password functionality. If this preference is set to true, the master password functionality is removed.</string>
 			<key>pfm_documentation_url</key>
@@ -1109,8 +1083,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Remove Pocket in the Firefox UI.</string>
 			<key>pfm_description_reference</key>
@@ -1129,8 +1101,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Remove access to private browsing.</string>
 			<key>pfm_description_reference</key>
@@ -1147,8 +1117,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disables the "Import data from another browser" option in the bookmarks window.</string>
 			<key>pfm_description_reference</key>
@@ -1165,8 +1133,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable the Refresh Firefox button on about:support and support.mozilla.org, as well as the prompt that displays offering to refresh Firefox when you haven't used it in a while.</string>
 			<key>pfm_description_reference</key>
@@ -1183,8 +1149,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable safe mode within the browser.</string>
 			<key>pfm_description_reference</key>
@@ -1201,8 +1165,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>This preference removes the "Set As Desktop Background..." menu item when right clicking on an image.</string>
 			<key>pfm_description_reference</key>
@@ -1219,8 +1181,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Set the initial state of the menubar. A user can still hide it and it will stay hidden.</string>
 			<key>pfm_documentation_url</key>
@@ -1235,8 +1195,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Prevent system add-ons from being installed or update.</string>
 			<key>pfm_description_reference</key>
@@ -1253,8 +1211,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Set the initial state of the bookmarks toolbar. A user can still hide it and it will stay hidden.</string>
 			<key>pfm_description_reference</key>
@@ -1271,8 +1227,6 @@ For more information, see https://developer.mozilla.org/en-US/docs/Mozilla/Integ
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Don't check if Firefox is the default browser at startup.</string>
 			<key>pfm_description_reference</key>
@@ -1692,8 +1646,6 @@ The configuration for each extension is another dictionary that can contain the 
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
 			<string>Control hardware acceleration.</string>
 			<key>pfm_description_reference</key>
@@ -1913,6 +1865,8 @@ The configuration for each extension is another dictionary that can contain the 
 		<dict>
 			<key>pfm_app_min</key>
 			<string>88</string>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Show the home button on the toolbar.</string>
 			<key>pfm_documentation_url</key>
@@ -1952,8 +1906,6 @@ The configuration for each extension is another dictionary that can contain the 
 		<dict>
 			<key>pfm_app_min</key>
 			<string>68</string>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
 			<string>Enable or disable the New Tab page.</string>
 			<key>pfm_description_reference</key>
@@ -1970,8 +1922,6 @@ The configuration for each extension is another dictionary that can contain the 
 		<dict>
 			<key>pfm_app_min</key>
 			<string>60</string>
-			<key>pfm_default</key>
-			<true/>
 			<key>pfm_description</key>
 			<string>Disable the creation of default bookmarks.</string>
 			<key>pfm_description_reference</key>
@@ -2055,8 +2005,6 @@ The configuration for each extension is another dictionary that can contain the 
 		<dict>
 			<key>pfm_app_min</key>
 			<string>68</string>
-			<key>pfm_default</key>
-			<false/>
 			<key>pfm_description</key>
 			<string>Ask where to save each file before downloading.</string>
 			<key>pfm_description_reference</key>

--- a/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.DirectoryService.managed.plist
@@ -18,9 +18,9 @@ must be set to true to set the ADPacketEncrypt key to enable.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-03-06T10:55:33Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.9</string>
+	<string>10.8</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-02-28T16:03:53Z</date>
+	<date>2024-02-28T16:07:22Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -3027,6 +3027,6 @@ In iOS 10 and earlier, users can always pick an option that is more restrictive 
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>9</integer>
+	<integer>10</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-02-28T16:07:22Z</date>
+	<date>2024-03-07T11:07:13Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -1006,6 +1006,8 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>When 'false', the device prevents installation of alternative marketplace apps from the web, and prevents any installed alternative marketplace apps from installing apps.</string>
 			<key>pfm_ios_min</key>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-02-28T13:23:12Z</date>
+	<date>2024-02-28T16:03:53Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -191,6 +191,7 @@ The payload organization for a payload need not match the payload organization i
 					<string>allowSafari</string>
 					<string>allowSystemAppRemoval</string>
 					<string>allowUIAppInstallation</string>
+					<string>allowMarketplaceAppInstallation</string>
 					<string>allowYouTube</string>
 					<string>allowiTunes</string>
 					<string>blacklistedAppBundleIDs</string>
@@ -1001,6 +1002,24 @@ Additionally, if set to true and ScreenObservationPermissionModificationAllowed 
 			<true/>
 			<key>pfm_title</key>
 			<string>Allow automatic app downloads</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>When 'false', the device prevents installation of alternative marketplace apps from the web, and prevents any installed alternative marketplace apps from installing apps.</string>
+			<key>pfm_ios_min</key>
+			<string>17.4</string>
+			<key>pfm_name</key>
+			<string>allowMarketplaceAppInstallation</string>
+			<key>pfm_platforms</key>
+			<array>
+				<string>iOS</string>
+			</array>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_title</key>
+			<string>Allow App Installation from alternative marketplaces</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -15,9 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
-	<key>pfm_note</key>
-	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
+	<date>2024-02-28T13:23:12Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,9 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-01-29T13:18:00Z</date>
-	<key>pfm_note</key>
-	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
+	<date>2024-02-28T13:23:12Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-tvOS.plist
@@ -15,9 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
-	<key>pfm_note</key>
-	<string>You can specify additional restrictions, including maximum allowed content ratings, by creating a profile using Apple Configurator 2 or Profile Manager.</string>
+	<date>2024-02-28T13:23:12Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>tvOS</string>

--- a/Manifests/ManifestsApple/com.apple.configurationprofile.identification.plist
+++ b/Manifests/ManifestsApple/com.apple.configurationprofile.identification.plist
@@ -15,9 +15,9 @@ The Identification payload is not supported in iOS.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:50Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.9</string>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>14.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2024-03-06T10:45:31Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_platforms</key>
@@ -338,53 +338,64 @@ EvaluateConnection: Apply DNS Settings with per-domain exceptions when the dicti
 							<key>pfm_subkeys</key>
 							<array>
 								<dict>
-									<key>pfm_description</key>
-									<string>The DNS settings behavior for the specified domains. Options:
-NeverConnect: Do not use the DNS Settings for the specified domains.
-ConnectIfNeeded: Allow using the DNS Settings for the specified domains.</string>
 									<key>pfm_name</key>
-									<string>DomainAction</string>
-									<key>pfm_range_list</key>
-									<array>
-										<string>NeverConnect</string>
-										<string>ConnectIfNeeded</string>
-									</array>
-									<key>pfm_range_list_titles</key>
-									<array>
-										<string>Never Connect</string>
-										<string>Connect if Needed</string>
-									</array>
-									<key>pfm_require</key>
-									<string>always-nested</string>
-									<key>pfm_title</key>
-									<string>Domain Action</string>
-									<key>pfm_type</key>
-									<string>string</string>
-								</dict>
-								<dict>
-									<key>pfm_description</key>
-									<string>The domains for which this evaluation applies.</string>
-									<key>pfm_name</key>
-									<string>Domains</string>
-									<key>pfm_require</key>
-									<string>always-nested</string>
+									<string>ActionParameter</string>
 									<key>pfm_subkeys</key>
 									<array>
 										<dict>
+											<key>pfm_description</key>
+											<string>The DNS settings behavior for the specified domains. Options:
+		NeverConnect: Do not use the DNS Settings for the specified domains.
+		ConnectIfNeeded: Allow using the DNS Settings for the specified domains.</string>
+											<key>pfm_name</key>
+											<string>DomainAction</string>
+											<key>pfm_range_list</key>
+											<array>
+												<string>NeverConnect</string>
+												<string>ConnectIfNeeded</string>
+											</array>
+											<key>pfm_range_list_titles</key>
+											<array>
+												<string>Never Connect</string>
+												<string>Connect if Needed</string>
+											</array>
+											<key>pfm_require</key>
+											<string>always-nested</string>
 											<key>pfm_title</key>
-											<string>Domain</string>
+											<string>Domain Action</string>
 											<key>pfm_type</key>
 											<string>string</string>
 										</dict>
+										<dict>
+											<key>pfm_description</key>
+											<string>The domains for which this evaluation applies.</string>
+											<key>pfm_name</key>
+											<string>Domains</string>
+											<key>pfm_require</key>
+											<string>always-nested</string>
+											<key>pfm_subkeys</key>
+											<array>
+												<dict>
+													<key>pfm_title</key>
+													<string>Domain</string>
+													<key>pfm_type</key>
+													<string>string</string>
+												</dict>
+											</array>
+											<key>pfm_type</key>
+											<string>array</string>
+										</dict>
 									</array>
+									<key>pfm_title</key>
+									<string>Action Parameter</string>
 									<key>pfm_type</key>
-									<string>array</string>
+									<string>dictionary</string>
 								</dict>
 							</array>
 							<key>pfm_title</key>
 							<string>Action Parameters</string>
 							<key>pfm_type</key>
-							<string>dictionary</string>
+							<string>array</string>
 						</dict>
 						<dict>
 							<key>pfm_description</key>

--- a/Manifests/ManifestsApple/com.apple.education.plist
+++ b/Manifests/ManifestsApple/com.apple.education.plist
@@ -19,7 +19,7 @@ It is supported on macOS 10.14 and later. On macOS, it must be sent over the use
 	<key>pfm_ios_min</key>
 	<string>9.3</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-03-06T10:45:31Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>
@@ -576,7 +576,7 @@ With one-to-one member devices, this key should include only the device user and
 									<key>pfm_title</key>
 									<string>Group Beacon ID</string>
 									<key>pfm_type</key>
-									<string>string</string>
+									<string>integer</string>
 								</dict>
 							</array>
 							<key>pfm_title</key>

--- a/Manifests/ManifestsApple/com.apple.extensiblesso.plist
+++ b/Manifests/ManifestsApple/com.apple.extensiblesso.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>13.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-23T13:57:28Z</date>
+	<date>2024-02-16T13:07:59Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -246,6 +246,10 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_description</key>
+					<string>A host or domain name, with or without a leading dot.</string>
+					<key>pfm_name</key>
+					<string>hostname</string>
 					<key>pfm_title</key>
 					<string>Hostname / Domain name</string>
 					<key>pfm_type</key>
@@ -315,8 +319,12 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_description</key>
+					<string>An http or https URL prefix.</string>
 					<key>pfm_format</key>
 					<string>^https?://.*</string>
+					<key>pfm_name</key>
+					<string>URL</string>
 					<key>pfm_title</key>
 					<string>URL</string>
 					<key>pfm_type</key>
@@ -340,6 +348,10 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
+					<key>pfm_description</key>
+					<string>The bundle identifier of the app.</string>
+					<key>pfm_name</key>
+					<string>bundleIdentifier</string>
 					<key>pfm_title</key>
 					<string>Bundle Identifier</string>
 					<key>pfm_type</key>
@@ -693,6 +705,10 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
+							<key>pfm_description</key>
+							<string>Bundle IDs allowed to access the TGT.  These values are case sensitive.</string>
+							<key>pfm_name</key>
+							<string>credentialBundleIdACLItem</string>
 							<key>pfm_title</key>
 							<string>Bundle ID</string>
 							<key>pfm_type</key>
@@ -1024,6 +1040,10 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<key>pfm_subkeys</key>
 					<array>
 						<dict>
+							<key>pfm_description</key>
+							<string>A host or domain name in the format of [protocol/]hostname[:port][/path]</string>
+							<key>pfm_name</key>
+							<string>preferredKDC</string>
 							<key>pfm_title</key>
 							<string>Key Distribution Center</string>
 							<key>pfm_type</key>
@@ -1458,6 +1478,52 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 					<string>Use Site Auto Discovery</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>A custom domain-realm mapping for Kerberos. This is used when the DNS name of hosts do not match the realm name. Most administrators will not need to customize this.</string>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_n_range_list</key>
+									<array>
+										<string>com.apple.AppSSOKerberos.KerberosExtension</string>
+									</array>
+									<key>pfm_target</key>
+									<string>ExtensionIdentifier</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>pfm_name</key>
+					<string>domainRealmMapping</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>The key should be the name of the realm, and the value is an array of DNS suffixes that map to the realm.</string>
+							<key>pfm_name</key>
+							<string>Realm</string>
+							<key>pfm_subkeys</key>
+							<array>
+								<dict>
+									<key>pfm_description</key>
+									<string>Domains to map to the realm</string>
+									<key>pfm_name</key>
+									<string>RealmItem</string>
+									<key>pfm_type</key>
+									<string>string</string>
+								</dict>
+							</array>
+							<key>pfm_type</key>
+							<string>array</string>
+						</dict>
+					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
 				</dict>
 				<dict>
 					<key>pfm_default</key>
@@ -2082,6 +2148,6 @@ kerberosDefault - The default Kerberos processes for selecting credentials is us
 	<key>pfm_user_approved</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstactiveethernet.managed.plist
@@ -13,9 +13,9 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.13</string>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.firstethernet.managed.plist
@@ -13,9 +13,9 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.13</string>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.networkusagerules.plist
+++ b/Manifests/ManifestsApple/com.apple.networkusagerules.plist
@@ -11,7 +11,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2020-05-19T15:22:16Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -247,8 +247,6 @@
 			<string>array</string>
 		</dict>
 	</array>
-	<key>pfm_supervised</key>
-	<true/>
 	<key>pfm_targets</key>
 	<array>
 		<string>system</string>

--- a/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondactiveethernet.managed.plist
@@ -13,9 +13,9 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.13</string>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.secondethernet.managed.plist
@@ -13,9 +13,9 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.13</string>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdactiveethernet.managed.plist
@@ -13,9 +13,9 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.13</string>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.thirdethernet.managed.plist
@@ -13,9 +13,9 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2024-03-04T09:35:44Z</date>
 	<key>pfm_macos_min</key>
-	<string>10.13</string>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManifestsApple/com.apple.webClip.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.webClip.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2022-03-31T08:41:40Z</date>
+	<date>2024-02-01T15:28:27Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -147,11 +147,7 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>The URL that's displayed when users open the Web Clip. The URL must begin with HTTP or HTTPS</string>
-			<key>pfm_description_reference</key>
-			<string>The URL that the Web Clip should open when clicked. The URL must begin with HTTP or HTTPS or it won't work.</string>
-			<key>pfm_format</key>
-			<string>^https?://.*$</string>
+			<string>The URL of the web clip.</string>
 			<key>pfm_name</key>
 			<string>URL</string>
 			<key>pfm_require</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2023-11-29T16:46:29Z</date>
+	<date>2024-02-07T14:52:53Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -322,6 +322,18 @@
 			</array>
 			<key>pfm_title</key>
 			<string>Disable MAC Address Randomization</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If 'true', enables IPv6 on this interface.</string>
+			<key>pfm_name</key>
+			<string>EnableIPv6</string>
+			<key>pfm_title</key>
+			<string>Enable IPv6</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -1760,6 +1772,6 @@
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>9</integer>
+	<integer>10</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-02-07T14:52:53Z</date>
+	<date>2024-02-16T14:35:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -1099,6 +1099,17 @@
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
+									<key>pfm_contains_any</key>
+									<array>
+										<integer>17</integer>
+										<integer>21</integer>
+										<integer>25</integer>
+										<integer>43</integer>
+									</array>
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.AcceptEAPTypes</string>
+								</dict>
+								<dict>
 									<key>pfm_n_range_list</key>
 									<array>
 										<true/>
@@ -1124,11 +1135,21 @@
 									<key>pfm_target</key>
 									<string>EAPClientConfiguration.OneTimeUserPassword</string>
 								</dict>
+							</array>
+						</dict>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
 								<dict>
-									<key>pfm_present</key>
-									<true/>
+									<key>pfm_n_contains_any</key>
+									<array>
+										<integer>17</integer>
+										<integer>21</integer>
+										<integer>25</integer>
+										<integer>43</integer>
+									</array>
 									<key>pfm_target</key>
-									<string>EAPClientConfiguration.OneTimeUserPassword</string>
+									<string>EAPClientConfiguration.AcceptEAPTypes</string>
 								</dict>
 							</array>
 						</dict>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-02-16T14:35:00Z</date>
+	<date>2024-03-14T09:10:36Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -601,13 +601,11 @@
 			<array>
 				<string>None</string>
 				<string>WEP</string>
-				<string>WPA/WPA2</string>
-				<string>WPA2</string>
+				<string>WPA and WPA2</string>
+				<string>WPA2 and WPA3</string>
 				<string>WPA3</string>
 				<string>Any</string>
 			</array>
-			<key>pfm_require</key>
-			<string>always</string>
 			<key>pfm_title</key>
 			<string>Encryption Type</string>
 			<key>pfm_type</key>
@@ -618,6 +616,19 @@
 			<string>Specifies the password for the access point.</string>
 			<key>pfm_exclude</key>
 			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<string>None</string>
+							</array>
+							<key>pfm_target</key>
+							<string>EncryptionType</string>
+						</dict>
+					</array>
+				</dict>
 				<dict>
 					<key>pfm_target_conditions</key>
 					<array>
@@ -1029,6 +1040,33 @@
 		<dict>
 			<key>pfm_description</key>
 			<string>Specifies 802.1x EAP authentication parameters.</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_range_list</key>
+							<array>
+								<string>None</string>
+							</array>
+							<key>pfm_target</key>
+							<string>EncryptionType</string>
+						</dict>
+					</array>
+				</dict>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<true/>
+							<key>pfm_target</key>
+							<string>Password</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_name</key>
 			<string>EAPClientConfiguration</string>
 			<key>pfm_subkeys</key>
@@ -1741,6 +1779,25 @@
 			<false/>
 			<key>pfm_description</key>
 			<string>If set, force a non-default authentication method. (if YES, uses certificate from PayloadCertificateUUID).</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_n_contains_any</key>
+							<array>
+								<integer>13</integer>
+								<integer>21</integer>
+								<integer>25</integer>
+								<integer>43</integer>
+							</array>
+							<key>pfm_target</key>
+							<string>EAPClientConfiguration.AcceptEAPTypes</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_ios_min</key>
 			<string>7.0</string>
 			<key>pfm_name</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-03-14T09:10:36Z</date>
+	<date>2024-03-14T11:31:49Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -1001,6 +1001,20 @@
 		<dict>
 			<key>pfm_description</key>
 			<string>Select "Login Window" to authenticate the Mac to the network when the user logs in.</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<false/>
+							<key>pfm_target</key>
+							<string>EAPClientConfiguration</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_name</key>
 			<string>SetupModes</string>
 			<key>pfm_platforms</key>
@@ -1489,6 +1503,32 @@
 					<string>boolean</string>
 				</dict>
 				<dict>
+					<key>pfm_conditionals</key>
+					<array>
+						<dict>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_contains_any</key>
+									<array>
+										<integer>43</integer>
+									</array>
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.AcceptEAPTypes</string>
+								</dict>
+								<dict>
+									<key>pfm_range_list</key>
+									<array>
+										<true/>
+									</array>
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.EAPFASTUsePAC</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-03-26T12:24:00Z</date>
+	<date>2024-03-27T14:16:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -1653,7 +1653,7 @@
 							<array>
 								<dict>
 									<key>pfm_present</key>
-									<true />
+									<true/>
 									<key>pfm_target</key>
 									<string>EAPClientConfiguration.SystemModeUseOpenDirectoryCredentials</string>
 								</dict>
@@ -1683,7 +1683,7 @@
 							<array>
 								<dict>
 									<key>pfm_present</key>
-									<true />
+									<true/>
 									<key>pfm_target</key>
 									<string>EAPClientConfiguration.SystemModeCredentialsSource</string>
 								</dict>
@@ -1694,6 +1694,76 @@
 					<string>SystemModeUseOpenDirectoryCredentials</string>
 					<key>pfm_title</key>
 					<string>Use OpenDirectory System Profile Credentials</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>An array of trusted certificates. Each entry in the array must contain certificate data that represents an anchor certificate used for verifying the server certificate.</string>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_n_contains_any</key>
+									<array>
+										<integer>13</integer>
+									</array>
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.AcceptEAPTypes</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>pfm_name</key>
+					<string>TLSTrustedCertificates</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_description</key>
+							<string>A certificate identifier.</string>
+							<key>pfm_name</key>
+							<string>TLSTrustedCertificatesItem</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>TLS Trusted Certificates</string>
+					<key>pfm_type</key>
+					<string>array</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>If 'true', allows for two-factor authentication for EAP-TTLS, PEAP, or EAP-FAST. If 'false', allows for zero-factor authentication for EAP-TLS.
+If you don't specify a value, the default is 'true' for EAP-TLS, and 'false' for other EAP types.</string>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_n_contains_any</key>
+									<array>
+										<integer>13</integer>
+									</array>
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.AcceptEAPTypes</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
+					<key>pfm_ios_min</key>
+					<string>7.0</string>
+					<key>pfm_name</key>
+					<string>TLSCertificateIsRequired</string>
+					<key>pfm_platforms</key>
+					<array>
+						<string>iOS</string>
+					</array>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
@@ -1920,6 +1990,6 @@
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>10</integer>
+	<integer>11</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-03-27T14:16:00Z</date>
+	<date>2024-03-27T14:50:37Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -1247,6 +1247,8 @@
 					<string>OneTimeUserPassword</string>
 					<key>pfm_title</key>
 					<string>Per-Connection Password</string>
+					<key>pfm_tvos_min</key>
+					<string>7.0</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
 				</dict>
@@ -1397,6 +1399,8 @@
 					<string>string</string>
 				</dict>
 				<dict>
+					<key>pfm_default</key>
+					<string>1.0</string>
 					<key>pfm_description</key>
 					<string></string>
 					<key>pfm_exclude</key>
@@ -1432,10 +1436,14 @@
 					</array>
 					<key>pfm_title</key>
 					<string>TLS Minimum Version</string>
+					<key>pfm_tvos_min</key>
+					<string>11.0</string>
 					<key>pfm_type</key>
 					<string>string</string>
 				</dict>
 				<dict>
+					<key>pfm_default</key>
+					<string>1.2</string>
 					<key>pfm_description</key>
 					<string></string>
 					<key>pfm_exclude</key>
@@ -1471,6 +1479,8 @@
 					</array>
 					<key>pfm_title</key>
 					<string>TLS Maximum Version</string>
+					<key>pfm_tvos_min</key>
+					<string>11.0</string>
 					<key>pfm_type</key>
 					<string>string</string>
 				</dict>
@@ -1631,6 +1641,8 @@
 							</array>
 						</dict>
 					</array>
+					<key>pfm_ios_min</key>
+					<string>8.0</string>
 					<key>pfm_name</key>
 					<string>EAPSIMNumberOfRANDs</string>
 					<key>pfm_range_list</key>
@@ -1782,11 +1794,6 @@ If you don't specify a value, the default is 'true' for EAP-TLS, and 'false' for
 			<string>10.13</string>
 			<key>pfm_name</key>
 			<string>QoSMarkingPolicy</string>
-			<key>pfm_platforms</key>
-			<array>
-				<string>iOS</string>
-				<string>macOS</string>
-			</array>
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>

--- a/Manifests/ManifestsApple/com.apple.wifi.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.wifi.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-03-14T11:31:49Z</date>
+	<date>2024-03-26T12:24:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -1646,6 +1646,20 @@
 				<dict>
 					<key>pfm_description</key>
 					<string>Use an alternate set of credentials when in System mode (AKA not a loginwindow profile). This can be used to tell EAPOLClient to use the computer password in a bound active directory scenario for authentication.</string>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_present</key>
+									<true />
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.SystemModeUseOpenDirectoryCredentials</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
 					<key>pfm_name</key>
 					<string>SystemModeCredentialsSource</string>
 					<key>pfm_range_list</key>
@@ -1658,14 +1672,30 @@
 					<string>string</string>
 				</dict>
 				<dict>
+					<key>pfm_default</key>
+					<false/>
 					<key>pfm_description</key>
 					<string>This indicates if the connection should try to use the OpenDirectory machine credentials.</string>
+					<key>pfm_exclude</key>
+					<array>
+						<dict>
+							<key>pfm_target_conditions</key>
+							<array>
+								<dict>
+									<key>pfm_present</key>
+									<true />
+									<key>pfm_target</key>
+									<string>EAPClientConfiguration.SystemModeCredentialsSource</string>
+								</dict>
+							</array>
+						</dict>
+					</array>
 					<key>pfm_name</key>
 					<string>SystemModeUseOpenDirectoryCredentials</string>
 					<key>pfm_title</key>
 					<string>Use OpenDirectory System Profile Credentials</string>
 					<key>pfm_type</key>
-					<string>string</string>
+					<string>boolean</string>
 				</dict>
 			</array>
 			<key>pfm_title</key>


### PR DESCRIPTION
This PR includes a collection a small fixes and updates:

* Incorrect default values removed and new property added in the Firefox manifest
* Payload descriptions updated to convention on a number of application manifests
* New property added to the iOS Restriction manifest
* Outdated note removed from the macOS and tvOS Restrictions manifests
* Minimum macOS version corrected on a number of system manifests
* Property updated to reflect documentation corrections in the DNS Settings manifest
* Property value type corrected in the Education manifest
* Two properties added and several properties augmented in the Extensible SSO manifest
* The Network Usage Rules manifest is no longer marked as requiring supervision
* Property changed to reflect the most recent documentation in the Web Clip manifest
* One property added, incorrect value type corrected, and multiple conditionals added in the Wi-Fi manifest