### PR TITLE
Revert #668

### DIFF
--- a/updateIndexes.py
+++ b/updateIndexes.py
@@ -4,7 +4,7 @@
 import hashlib
 import os
 import plistlib
-from datetime import datetime, UTC
+from datetime import datetime
 from glob import glob
 
 
@@ -17,7 +17,7 @@ def main():
     # Iterate through index types
     file_types = {"Icons": "png", "Manifests": "plist"}
     for index_type, ext in file_types.items():
-        index = {"date": datetime.now(UTC)}
+        index = {"date": datetime.utcnow()}
 
         # Get all matching files in the desired subfolder
         file_list = glob("%s/%s/*/*.%s" % (repo_path, index_type, ext))


### PR DESCRIPTION
Looks like the GitHub Actions runner is not yet ready for the changes in #668 because its default Python version predates the API used in the PR, therefore breaking the automatic index update.

This PR rolls the script back to its previous state.

When the `ubuntu-24.04` runner image comes out of beta we can reinstate the changes.