### PR TITLE
Update SkipKeys Array for macOS and iOS:

### DIFF
--- a/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.SetupAssistant.managed.plist
@@ -15,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>14.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-06-20T10:06:55Z</date>
+	<date>2024-08-06T00:00:00Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -136,6 +136,8 @@
 			<string>Skip Appearance window</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -154,6 +156,8 @@
 			<string>Skip iCloud</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -172,6 +176,8 @@
 			<string>Skip iCloud Storage window</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -190,6 +196,8 @@
 			<string>Skip Privacy consent window</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -208,6 +216,8 @@
 			<string>Skip Siri</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -228,6 +238,8 @@
 			<string>Skip True Tone Display window</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -246,6 +258,8 @@
 			<string>Skip Screen Time window</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -264,6 +278,8 @@
 			<string>Skip TouchID</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -282,6 +298,8 @@
 			<string>Skip Unlock with Apple Watch</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -300,6 +318,8 @@
 			<string>Skip Accessibility</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -318,6 +338,8 @@
 			<string>Skip Wallpaper</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+			<key>pfm_macos_deprecated</key>
+			<string>15.0</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
@@ -326,11 +348,14 @@
 			<string>https://developer.apple.com/documentation/devicemanagement/skipkeys</string>
 			<key>pfm_ios_min</key>
 			<string>14.0</string>
+			<key>pfm_macos_min</key>
+			<string>15.0</string>
 			<key>pfm_name</key>
 			<string>SkipSetupItems</string>
 			<key>pfm_platforms</key>
 			<array>
 				<string>iOS</string>
+				<string>macOS</string>
 			</array>
 			<key>pfm_subkeys</key>
 			<array>
@@ -338,6 +363,7 @@
 					<key>pfm_range_list</key>
 					<array>
 						<string>Accessibility</string>
+						<string>ActionButton</string>
 						<string>Android</string>
 						<string>Appearance</string>
 						<string>AppleID</string>
@@ -351,6 +377,7 @@
 						<string>iCloudDiagnostics</string>
 						<string>iCloudStorage</string>
 						<string>iMessageAndFaceTime</string>
+						<string>Intelligence</string>
 						<string>Location</string>
 						<string>MessagingActivationUsingPhoneNumber</string>
 						<string>OnBoarding</string>
@@ -368,6 +395,7 @@
 						<string>TOS</string>
 						<string>UnlockWithWatch</string>
 						<string>UpdateCompleted</string>
+						<string>Wallpaper</string>
 						<string>WatchMigration</string>
 						<string>Welcome</string>
 						<string>Zoom</string>
@@ -375,6 +403,7 @@
 					<key>pfm_range_list_titles</key>
 					<array>
 						<string>Accessibility</string>
+						<string>Action Button</string>
 						<string>Android</string>
 						<string>Appearance</string>
 						<string>Apple ID</string>
@@ -388,6 +417,7 @@
 						<string>iCloud Diagnostics</string>
 						<string>iCloud Documents and Desktop</string>
 						<string>iMessage and FaceTime</string>
+						<string>Intelligence</string>
 						<string>Location</string>
 						<string>Messaging Activation Using Phone Number</string>
 						<string>OnBoarding</string>
@@ -405,6 +435,7 @@
 						<string>Terms of Service</string>
 						<string>Unlock with Apple Watch</string>
 						<string>Update Completed</string>
+						<string>Wallpaper</string>
 						<string>Watch Migration</string>
 						<string>Welcome</string>
 						<string>Zoom</string>
@@ -418,7 +449,7 @@
 				</dict>
 			</array>
 			<key>pfm_title</key>
-			<string>iOS Skip Items</string>
+			<string>Setup Items to Skip</string>
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
@@ -435,6 +466,6 @@
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>8</integer>
+	<integer>9</integer>
 </dict>
 </plist>


### PR DESCRIPTION
**macOS:**
- ➕  [Intelligence](https://developer.apple.com/documentation/devicemanagement/skipkeys?changes=latest_major) 
- ➕  [Wallpaper](https://developer.apple.com/documentation/devicemanagement/skipkeys?changes=latest_major)

Marked as [deprecated in 15.0](https://github.com/apple/device-management/blob/seed_iOS-18.0_macOS-15.0/mdm/profiles/com.apple.SetupAssistant.managed.yaml):

- SkipCloudSetup
- SkipSiriSetup
- SkipPrivacySetup
- SkipiCloudStorageSetup
- SkipTrueTone
- SkipAppearance
- SkipTouchIDSetup
- SkipScreenTime
- SkipAccessibility
- SkipUnlockWithWatch
- SkipWallpaper

**iOS:**
- ➕ [ActionButton](https://developer.apple.com/documentation/devicemanagement/skipkeys?changes=latest_major)