### PR TITLE
Google Drive for Desktop - Remove Duplicate DisableMirroredFolders key

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2024-07-22T15:00:29Z</date>
+	<date>2024-09-10T15:00:29Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -313,16 +313,6 @@ The payload organization for a payload need not match the payload organization i
 			<string>DisableMirroredMyDrive</string>
 			<key>pfm_title</key>
 			<string>Disable Mirrored My Drive</string>
-			<key>pfm_type</key>
-			<string>boolean</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>Disables mirroring of arbitrary folders (such as "Documents") to Google Drive.</string>
-			<key>pfm_name</key>
-			<string>DisableMirroredFolders</string>
-			<key>pfm_title</key>
-			<string>Disable Mirrored Folders</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -467,6 +467,6 @@ You can find roots.pem in /Applications/Google\ Drive\ File\ Stream.app/Contents
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Remove the DisableMirroredFolders key as it's currently listed twice within the manifest.
The other key is on lines 299 to lines 308.