### PR TITLE
System Preferences update

### DIFF
--- a/Manifests/ManifestsApple/com.apple.systempreferences.plist
+++ b/Manifests/ManifestsApple/com.apple.systempreferences.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-09-20T08:54:27Z</date>
+	<date>2024-10-15T15:06:21Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>13.0</string>
 	<key>pfm_macos_min</key>
@@ -783,6 +783,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>8</integer>
+	<integer>9</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.systempreferences.plist
+++ b/Manifests/ManifestsApple/com.apple.systempreferences.plist
@@ -15,9 +15,11 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-29T08:33:42Z</date>
+	<date>2024-09-20T08:54:27Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>13.0</string>
+	<key>pfm_macos_min</key>
+	<string>10.7</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -28,9 +30,7 @@
 			<key>pfm_default</key>
 			<string>Configures System Preferences settings</string>
 			<key>pfm_description</key>
-			<string>Description of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable description of this payload. This description is shown on the Detail screen.</string>
+			<string>The human-readable description of this payload. This description appears on the Detail screen.</string>
 			<key>pfm_name</key>
 			<string>PayloadDescription</string>
 			<key>pfm_title</key>
@@ -42,9 +42,7 @@
 			<key>pfm_default</key>
 			<string>System Preferences</string>
 			<key>pfm_description</key>
-			<string>Name of the payload.</string>
-			<key>pfm_description_reference</key>
-			<string>A human-readable name for the profile payload. This name is displayed on the Detail screen. It does not have to be unique.</string>
+			<string>The human-readable name for the profile payload. The name appears on the Detail screen and doesn't need to be unique.</string>
 			<key>pfm_name</key>
 			<string>PayloadDisplayName</string>
 			<key>pfm_require</key>
@@ -58,9 +56,8 @@
 			<key>pfm_default</key>
 			<string>com.apple.systempreferences</string>
 			<key>pfm_description</key>
-			<string>A unique identifier for the payload, dot-delimited.  Usually root PayloadIdentifier+subidentifier.</string>
-			<key>pfm_description_reference</key>
-			<string>A reverse-DNS-style identifier for the specific payload. It is usually the same identifier as the root-level PayloadIdentifier value with an additional component appended.</string>
+			<string>The reverse-DNS-style identifier for the payload. This identifier is usually the same as the TopLevel value, with an additional appended component. This string must be unique within the profile.
+During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_name</key>
 			<string>PayloadIdentifier</string>
 			<key>pfm_require</key>
@@ -74,9 +71,7 @@
 			<key>pfm_default</key>
 			<string>com.apple.systempreferences</string>
 			<key>pfm_description</key>
-			<string>The type of the payload, a reverse dns string.</string>
-			<key>pfm_description_reference</key>
-			<string>The payload type.</string>
+			<string>The payload type, which each payload domain's reference page specifies.</string>
 			<key>pfm_name</key>
 			<string>PayloadType</string>
 			<key>pfm_require</key>
@@ -90,9 +85,8 @@
 			<key>pfm_default</key>
 			<string></string>
 			<key>pfm_description</key>
-			<string>Unique identifier for the payload (format 01234567-89AB-CDEF-0123-456789ABCDEF).</string>
-			<key>pfm_description_reference</key>
-			<string>A globally unique identifier for the payload. The actual content is unimportant, but it must be globally unique. In macOS, you can use uuidgen to generate reasonable UUIDs.</string>
+			<string>The globally unique identifier for the payload. The actual content is unimportant, but must be globally unique. In macOS, use 'uuidgen' to generate UUIDs.
+During a profile replacement, the system updates payloads with the same 'PayloadIdentifier' and 'PayloadUUID' in the old and new profiles.</string>
 			<key>pfm_format</key>
 			<string>^[0-9A-Za-z]{8}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{4}-[0-9A-Za-z]{12}$</string>
 			<key>pfm_name</key>
@@ -108,12 +102,13 @@
 			<key>pfm_default</key>
 			<integer>1</integer>
 			<key>pfm_description</key>
-			<string>The version of the whole configuration profile.</string>
-			<key>pfm_description_reference</key>
-			<string>The version number of the individual payload.
-A profile can consist of payloads with different version numbers. For example, changes to the VPN software in iOS might introduce a new payload version to support additional features, but Mail payload versions would not necessarily change in the same release.</string>
+			<string>The version of this specific payload.</string>
 			<key>pfm_name</key>
 			<string>PayloadVersion</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+			</array>
 			<key>pfm_require</key>
 			<string>always</string>
 			<key>pfm_title</key>
@@ -123,10 +118,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>This value describes the issuing organization of the profile, as displayed to the user.</string>
-			<key>pfm_description_reference</key>
-			<string>Optional. A human-readable string containing the name of the organization that provided the profile.
-The payload organization for a payload need not match the payload organization in the enclosing profile.</string>
+			<string>The human-readable string containing the name of the organization that provides the profile. This value doesn't need to match the organization payload value in the enclosing dictionary.</string>
 			<key>pfm_name</key>
 			<string>PayloadOrganization</string>
 			<key>pfm_title</key>
@@ -150,8 +142,8 @@ The payload organization for a payload need not match the payload organization i
 			<dict>
 				<key>Disabled</key>
 				<array>
+					<string>DisabledSystemSettings</string>
 					<string>DisabledPreferencePanes</string>
-					<string>DisabledSettingsExtensions</string>
 				</array>
 				<key>Enabled</key>
 				<array>
@@ -171,11 +163,136 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Allowed Preference Panes within the System Preferences application.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
-			<key>pfm_documentation_source</key>
-			<string></string>
+			<string>The list of disabled System Settings extensions. All other items will be enabled. When DisabledSystemSettings is specified, DisabledPreferencePanes and EnabledPreferencePanes are ignored. Note that a given System Settings extension may supply more than one section in System Settings; disabling such an extension will disable all sections it supplies.</string>
+			<key>pfm_macos_min</key>
+			<string>13.0</string>
+			<key>pfm_name</key>
+			<string>DisabledSystemSettings</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>SettingsExtensions</string>
+					<key>pfm_range_list</key>
+					<array>
+						<string>com.apple.Accessibility-Settings.extension</string>
+						<string>com.apple.AirDrop-Handoff-Settings.extension</string>
+						<string>com.apple.Battery-Settings.extension</string>
+						<string>com.apple.BluetoothSettings</string>
+						<string>com.apple.CD-DVD-Settings.extension</string>
+						<string>com.apple.ClassKit-Settings.extension</string>
+						<string>com.apple.Classroom-Settings.extension</string>
+						<string>com.apple.ControlCenter-Settings.extension</string>
+						<string>com.apple.Date-Time-Settings.extension</string>
+						<string>com.apple.Desktop-Settings.extension</string>
+						<string>com.apple.Displays-Settings.extension</string>
+						<string>com.apple.ExtensionsPreferences</string>
+						<string>com.apple.Family-Settings.extension</string>
+						<string>com.apple.Focus-Settings.extension</string>
+						<string>com.apple.Game-Center-Settings.extension</string>
+						<string>com.apple.Game-Controller-Settings.extension</string>
+						<string>com.apple.HeadphoneSettings</string>
+						<string>com.apple.Internet-Accounts-Settings.extension</string>
+						<string>com.apple.Keyboard-Settings.extension</string>
+						<string>com.apple.Localization-Settings.extension</string>
+						<string>com.apple.Lock-Screen-Settings.extension</string>
+						<string>com.apple.LoginItems-Settings.extension</string>
+						<string>com.apple.Mouse-Settings.extension</string>
+						<string>com.apple.Network-Settings.extension</string>
+						<string>com.apple.NetworkExtensionSettingsUI.NESettingsUIExtension</string>
+						<string>com.apple.Notifications-Settings.extension</string>
+						<string>com.apple.Passwords-Settings.extension</string>
+						<string>com.apple.Print-Scan-Settings.extension</string>
+						<string>com.apple.Screen-Time-Settings.extension</string>
+						<string>com.apple.ScreenSaver-Settings.extension</string>
+						<string>com.apple.Sharing-Settings.extension</string>
+						<string>com.apple.Siri-Settings.extension</string>
+						<string>com.apple.Software-Update-Settings.extension</string>
+						<string>com.apple.Sound-Settings.extension</string>
+						<string>com.apple.Startup-Disk-Settings.extension</string>
+						<string>com.apple.Time-Machine-Settings.extension</string>
+						<string>com.apple.Touch-ID-Settings.extension</string>
+						<string>com.apple.Trackpad-Settings.extension</string>
+						<string>com.apple.Transfer-Reset-Settings.extension</string>
+						<string>com.apple.Users-Groups-Settings.extension</string>
+						<string>com.apple.WalletSettingsExtension</string>
+						<string>com.apple.Wallpaper-Settings.extension</string>
+						<string>com.apple.settings.Storage</string>
+						<string>com.apple.systempreferences.AppleIDSettings</string>
+						<string>com.apple.wifi-settings-extension</string>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>Accessibility</string>
+						<string>AirDrop Handoff</string>
+						<string>Battery</string>
+						<string>Bluetooth Settings</string>
+						<string>CD &amp; DVD</string>
+						<string>ClassKit</string>
+						<string>Classroom</string>
+						<string>ControlCenter</string>
+						<string>Date Time</string>
+						<string>Desktop</string>
+						<string>Displays</string>
+						<string>Extensions Preferences</string>
+						<string>Family</string>
+						<string>Focus</string>
+						<string>Game Center</string>
+						<string>Game Controller</string>
+						<string>HeadphoneSettings</string>
+						<string>Internet Accounts</string>
+						<string>Keyboard</string>
+						<string>Localization</string>
+						<string>Lock Screen</string>
+						<string>LoginItems</string>
+						<string>Mouse</string>
+						<string>Network</string>
+						<string>Network Extension Settings UI</string>
+						<string>Notifications</string>
+						<string>Passwords</string>
+						<string>Print &amp; Scan</string>
+						<string>Screen Time</string>
+						<string>ScreenSaver</string>
+						<string>Sharing</string>
+						<string>Siri</string>
+						<string>Software Update</string>
+						<string>Sound</string>
+						<string>Startup Disk</string>
+						<string>Time Machine</string>
+						<string>Touch ID</string>
+						<string>Trackpad</string>
+						<string>Transfer &amp; Reset</string>
+						<string>Users Groups</string>
+						<string>Wallet Settings</string>
+						<string>Wallpaper</string>
+						<string>Storage</string>
+						<string>Apple Account</string>
+						<string>Wi-Fi</string>
+					</array>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>The list of enabled System Preferences panes.</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<true/>
+							<key>pfm_target</key>
+							<string>DisabledSystemSettings</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_name</key>
 			<string>EnabledPreferencePanes</string>
 			<key>pfm_subkeys</key>
@@ -316,11 +433,21 @@ The payload organization for a payload need not match the payload organization i
 		</dict>
 		<dict>
 			<key>pfm_description</key>
-			<string>Disabled Preference Panes within the System Preferences application.</string>
-			<key>pfm_description_reference</key>
-			<string></string>
-			<key>pfm_documentation_source</key>
-			<string></string>
+			<string>The list of disabled System Preferences panes.</string>
+			<key>pfm_exclude</key>
+			<array>
+				<dict>
+					<key>pfm_target_conditions</key>
+					<array>
+						<dict>
+							<key>pfm_present</key>
+							<true/>
+							<key>pfm_target</key>
+							<string>DisabledSystemSettings</string>
+						</dict>
+					</array>
+				</dict>
+			</array>
 			<key>pfm_name</key>
 			<string>DisabledPreferencePanes</string>
 			<key>pfm_subkeys</key>
@@ -644,123 +771,6 @@ The payload organization for a payload need not match the payload organization i
 			<string>Attention Preference Pane Bundle IDs</string>
 			<key>pfm_type</key>
 			<string>dictionary</string>
-		</dict>
-		<dict>
-			<key>pfm_description</key>
-			<string>System settings extensions that will be disabled. All other extensions will be enabled. When the key is specified, Disabled Preference Panes and Enabled Preference Panes are ignored. Disabling a system extension will disable all of the sections it provides.</string>
-			<key>pfm_macos_min</key>
-			<string>13.0</string>
-			<key>pfm_name</key>
-			<string>DisabledSettingsExtensions</string>
-			<key>pfm_subkeys</key>
-			<array>
-				<dict>
-					<key>pfm_name</key>
-					<string>SettingsExtensions</string>
-					<key>pfm_range_list</key>
-					<array>
-						<string>com.apple.Accessibility-Settings.extension</string>
-						<string>com.apple.AirDrop-Handoff-Settings.extension</string>
-						<string>com.apple.Battery-Settings.extension</string>
-						<string>com.apple.BluetoothSettings</string>
-						<string>com.apple.CD-DVD-Settings.extension</string>
-						<string>com.apple.ClassKit-Settings.extension</string>
-						<string>com.apple.Classroom-Settings.extension</string>
-						<string>com.apple.ControlCenter-Settings.extension</string>
-						<string>com.apple.Date-Time-Settings.extension</string>
-						<string>com.apple.Desktop-Settings.extension</string>
-						<string>com.apple.Displays-Settings.extension</string>
-						<string>com.apple.ExtensionsPreferences</string>
-						<string>com.apple.Family-Settings.extension</string>
-						<string>com.apple.Focus-Settings.extension</string>
-						<string>com.apple.Game-Center-Settings.extension</string>
-						<string>com.apple.Game-Controller-Settings.extension</string>
-						<string>com.apple.HeadphoneSettings</string>
-						<string>com.apple.Internet-Accounts-Settings.extension</string>
-						<string>com.apple.Keyboard-Settings.extension</string>
-						<string>com.apple.Localization-Settings.extension</string>
-						<string>com.apple.Lock-Screen-Settings.extension</string>
-						<string>com.apple.LoginItems-Settings.extension</string>
-						<string>com.apple.Mouse-Settings.extension</string>
-						<string>com.apple.Network-Settings.extension</string>
-						<string>com.apple.NetworkExtensionSettingsUI.NESettingsUIExtension</string>
-						<string>com.apple.Notifications-Settings.extension</string>
-						<string>com.apple.Passwords-Settings.extension</string>
-						<string>com.apple.Print-Scan-Settings.extension</string>
-						<string>com.apple.Screen-Time-Settings.extension</string>
-						<string>com.apple.ScreenSaver-Settings.extension</string>
-						<string>com.apple.Sharing-Settings.extension</string>
-						<string>com.apple.Siri-Settings.extension</string>
-						<string>com.apple.Software-Update-Settings.extension</string>
-						<string>com.apple.Sound-Settings.extension</string>
-						<string>com.apple.Startup-Disk-Settings.extension</string>
-						<string>com.apple.Time-Machine-Settings.extension</string>
-						<string>com.apple.Touch-ID-Settings.extension</string>
-						<string>com.apple.Trackpad-Settings.extension</string>
-						<string>com.apple.Transfer-Reset-Settings.extension</string>
-						<string>com.apple.Users-Groups-Settings.extension</string>
-						<string>com.apple.WalletSettingsExtension</string>
-						<string>com.apple.Wallpaper-Settings.extension</string>
-						<string>com.apple.settings.Storage</string>
-						<string>com.apple.systempreferences.AppleIDSettings</string>
-						<string>com.apple.wifi-settings-extension</string>
-					</array>
-					<key>pfm_range_list_titles</key>
-					<array>
-						<string>Accessibility Settings</string>
-						<string>AirDrop Handoff Settings</string>
-						<string>Battery Settings</string>
-						<string>Bluetooth Settings</string>
-						<string>CD DVD Settings</string>
-						<string>ClassKit Settings</string>
-						<string>Classroom Settings</string>
-						<string>Control Center Settings</string>
-						<string>Date Time Settings</string>
-						<string>Desktop Settings</string>
-						<string>Displays Settings</string>
-						<string>Extensions Preferences</string>
-						<string>Family Settings</string>
-						<string>Focus Settings</string>
-						<string>Game Center Settings</string>
-						<string>Game Controller Settings</string>
-						<string>Headphone Settings</string>
-						<string>Internet Accounts Settings</string>
-						<string>Keyboard Settings</string>
-						<string>Localization Settings</string>
-						<string>Lock Screen Settings</string>
-						<string>LoginItems Settings</string>
-						<string>Mouse Settings</string>
-						<string>Network Settings</string>
-						<string>Network Extension Settings UI</string>
-						<string>Notifications Settings</string>
-						<string>Passwords Settings</string>
-						<string>Print Scan Settings</string>
-						<string>Screen Time Settings</string>
-						<string>Screen Saver Settings</string>
-						<string>Sharing Settings</string>
-						<string>Siri Settings</string>
-						<string>Software Update Settings</string>
-						<string>Sound Settings</string>
-						<string>Startup Disk Settings</string>
-						<string>Time Machine Settings</string>
-						<string>Touch ID Settings</string>
-						<string>Trackpad Settings</string>
-						<string>Transfer Reset Settings</string>
-						<string>Users Groups Settings</string>
-						<string>Wallet Settings Extension</string>
-						<string>Wallpaper Settings</string>
-						<string>Storage Settings</string>
-						<string>Apple ID Settings</string>
-						<string>WiFi Settings</string>
-					</array>
-					<key>pfm_type</key>
-					<string>string</string>
-				</dict>
-			</array>
-			<key>pfm_title</key>
-			<string>Disabled Settings Extensions</string>
-			<key>pfm_type</key>
-			<string>array</string>
 		</dict>
 	</array>
 	<key>pfm_targets</key>


### PR DESCRIPTION
This PR fixes the incorrect name for the `DisabledSystemSettings` property in the System Preferences manifest and adds conditions related to it along with other common updates. Closes #705.