### PR TITLE
Clear deprecation warning from the index-updating script

### DIFF
--- a/updateIndexes.py
+++ b/updateIndexes.py
@@ -4,7 +4,7 @@
 import hashlib
 import os
 import plistlib
-from datetime import datetime
+from datetime import datetime, timezone
 from glob import glob
 
 
@@ -17,7 +17,7 @@ def main():
     # Iterate through index types
     file_types = {"Icons": "png", "Manifests": "plist"}
     for index_type, ext in file_types.items():
-        index = {"date": datetime.utcnow()}
+        index = {"date": datetime.now(timezone.utc)}
 
         # Get all matching files in the desired subfolder
         file_list = glob("%s/%s/*/*.%s" % (repo_path, index_type, ext))


### PR DESCRIPTION
This PR updates `upadateIndexes.py` so it will no longer emit a deprecation warning on new Python versions.

This was already done before and then reverted in 0707c34c because that update used API that was too new to be compatible with the GitHub Actions Python version. This new update includes API that should be compatible across the board.