### PR TITLE
Google drive AutomaticErrorReporting

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -464,6 +464,8 @@ You can find roots.pem in /Applications/Google\ Drive\ File\ Stream.app/Contents
 			<string>Automatically send diagnostic logs to Google when Drive for desktop encounters a problem.</string>
 			<key>pfm_name</key>
 			<string>AutomaticErrorReporting</string>
+			<key>pfm_note</key>
+			<string>Undocumented key. </string>
 			<key>pfm_title</key>
 			<string>Help improve Drive for desktop</string>
 			<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -151,6 +151,7 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>MinFreeDiskSpaceKBytes</string>
 					<string>OpenOfficeFilesInDocs</string>
 					<string>PromptToBackupDevices</string>
+					<string>AutomaticErrorReporting</string>
 				</array>
 				<key>Proxy Settings</key>
 				<array>

--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -465,7 +465,7 @@ You can find roots.pem in /Applications/Google\ Drive\ File\ Stream.app/Contents
 			<key>pfm_name</key>
 			<string>AutomaticErrorReporting</string>
 			<key>pfm_note</key>
-			<string>Undocumented key. </string>
+			<string>Undocumented key.</string>
 			<key>pfm_title</key>
 			<string>Help improve Drive for desktop</string>
 			<key>pfm_type</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -458,6 +458,8 @@ You can find roots.pem in /Applications/Google\ Drive\ File\ Stream.app/Contents
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_default</key>
+			<true/>
 			<key>pfm_description</key>
 			<string>Automatically send diagnostic logs to Google when Drive for desktop encounters a problem.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.drivefs.settings.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2024-09-10T15:00:29Z</date>
+	<date>2024-10-15T15:00:29Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -456,6 +456,16 @@ You can find roots.pem in /Applications/Google\ Drive\ File\ Stream.app/Contents
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Automatically send diagnostic logs to Google when Drive for desktop encounters a problem.</string>
+			<key>pfm_name</key>
+			<string>AutomaticErrorReporting</string>
+			<key>pfm_title</key>
+			<string>Help improve Drive for desktop</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -467,6 +477,6 @@ You can find roots.pem in /Applications/Google\ Drive\ File\ Stream.app/Contents
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Adding the `AutomaticErrorReporting` key to the manifest. This is an undocumented key, but manages this setting in Google Drive. I wasn't sure if there was a good way to record that it's an undocumented key.

![Screenshot 2024-10-15 at 8 50 19 AM](https://github.com/user-attachments/assets/04844647-ddec-4271-b487-f7ebffc1ca79)
