### PR TITLE
Windows App

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-11-05T12:57:51Z</date>
+	<date>2024-11-05T15:51:52Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -2504,6 +2504,6 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>16</integer>
+	<integer>17</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.autoupdate2.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-08-23T07:42:22Z</date>
+	<date>2024-11-05T12:57:51Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -1144,6 +1144,73 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 					<string>dictionary</string>
 				</dict>
 				<dict>
+					<key>pfm_app_min</key>
+					<string>4.75</string>
+					<key>pfm_description</key>
+					<string>Register /Applications/Windows App.app.</string>
+					<key>pfm_name</key>
+					<string>/Applications/Windows App.app</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_default</key>
+							<string>MSRD10</string>
+							<key>pfm_name</key>
+							<string>Application ID</string>
+							<key>pfm_range_list</key>
+							<array>
+								<string>MSRD10</string>
+							</array>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>Application ID</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<integer>1033</integer>
+							<key>pfm_hidden</key>
+							<string>all</string>
+							<key>pfm_name</key>
+							<string>LCID</string>
+							<key>pfm_range_list</key>
+							<array>
+								<integer>1033</integer>
+							</array>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>Language Code ID</string>
+							<key>pfm_type</key>
+							<string>integer</string>
+						</dict>
+						<dict>
+							<key>pfm_app_min</key>
+							<string>4.13</string>
+							<key>pfm_description</key>
+							<string>Force quit this application and update X number of days after MAU first detects the update on each computer. Can be used in conjunction with the higher level option of the same setting for more restrictive per-application updating.</string>
+							<key>pfm_description_reference</key>
+							<string>If you have specified a deadline for all applications, you can still configure a more specific deadline for one of the applications. For example, you can configure a deadline of 7 days for all applications, and then specify that the deadline for Excel is 4 days.</string>
+							<key>pfm_documentation_url</key>
+							<string>https://docs.microsoft.com/en-us/deployoffice/mac/mau-deadline#configure-a-deadline-for-a-certain-number-of-days-after-the-update-is-detected</string>
+							<key>pfm_name</key>
+							<string>UpdateDeadline.DaysBeforeForcedQuit</string>
+							<key>pfm_title</key>
+							<string>Update Deadline: Days Before Forced Quit</string>
+							<key>pfm_type</key>
+							<string>integer</string>
+							<key>pfm_value_unit</key>
+							<string>Days</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Windows App</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+				<dict>
 					<key>pfm_description</key>
 					<string>Register /Applications/Microsoft Remote Desktop.app.</string>
 					<key>pfm_name</key>
@@ -1998,6 +2065,65 @@ Writes logs to: /Library/Logs/Microsoft/autoupdate.log</string>
 					</array>
 					<key>pfm_title</key>
 					<string>Microsoft PowerPoint</string>
+					<key>pfm_type</key>
+					<string>dictionary</string>
+				</dict>
+				<dict>
+					<key>pfm_app_min</key>
+					<string>4.75</string>
+					<key>pfm_description</key>
+					<string>Schedule an update for Windows App.</string>
+					<key>pfm_documentation_url</key>
+					<string>https://docs.microsoft.com/en-us/deployoffice/mac/mau-deadline#configure-a-deadline-for-a-specific-date-and-time</string>
+					<key>pfm_name</key>
+					<string>/Applications/Windows App.app</string>
+					<key>pfm_subkeys</key>
+					<array>
+						<dict>
+							<key>pfm_default</key>
+							<string>MSRD10</string>
+							<key>pfm_name</key>
+							<string>Application ID</string>
+							<key>pfm_range_list</key>
+							<array>
+								<string>MSRD10</string>
+							</array>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>Application ID</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The date and time to force the update.</string>
+							<key>pfm_name</key>
+							<string>ForcedUpdateDate</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>Forced Update Date</string>
+							<key>pfm_type</key>
+							<string>date</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>The version of the update.</string>
+							<key>pfm_name</key>
+							<string>ForcedUpdateVersion</string>
+							<key>pfm_require</key>
+							<string>always</string>
+							<key>pfm_title</key>
+							<string>Forced Update Version</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>10.2.13</string>
+						</dict>
+					</array>
+					<key>pfm_title</key>
+					<string>Windows App</string>
 					<key>pfm_type</key>
 					<string>dictionary</string>
 				</dict>

--- a/Manifests/ManagedPreferencesApplications/com.microsoft.rdc.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/com.microsoft.rdc.macos.plist
@@ -3,15 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>pfm_app_url</key>
-	<string>https://itunes.apple.com/us/app/microsoft-remote-desktop-10/id1295203466</string>
+	<string>https://apps.apple.com/us/app/windows-app/id1295203466</string>
 	<key>pfm_description</key>
-	<string>Microsoft Remote Desktop settings</string>
+	<string>Settings for Windows App, previously Microsoft Remote Desktop</string>
 	<key>pfm_domain</key>
 	<string>com.microsoft.rdc.macos</string>
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2019-09-17T08:52:31Z</date>
+	<date>2024-11-05T12:57:51Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -20,7 +20,7 @@
 	<array>
 		<dict>
 			<key>pfm_default</key>
-			<string>Configures Microsoft Remote Desktop settings</string>
+			<string>Configures Windows App settings</string>
 			<key>pfm_description</key>
 			<string>Description of the payload</string>
 			<key>pfm_name</key>
@@ -32,7 +32,7 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<string>Microsoft Remote Desktop</string>
+			<string>Windows App</string>
 			<key>pfm_description</key>
 			<string>Name of the payload</string>
 			<key>pfm_name</key>
@@ -132,7 +132,7 @@
 			<key>pfm_description</key>
 			<string>Disable upload of telemetry data.</string>
 			<key>pfm_description_reference</key>
-			<string>We also added a new key to the UserDefaults that allows you to control whether you want to send telemetry to us: ClientSettings.DisableTelemetryUpload (true/false). When this key is set, the "Help improve Remote Desktop" control will be disabled for the user.</string>
+			<string>We also added a new key to the UserDefaults that allows you to control whether you want to send telemetry to us: ClientSettings.DisableTelemetryUpload (true/false). When this key is set, the "Help improve Windows App" control will be disabled for the user.</string>
 			<key>pfm_documentation_url</key>
 			<string>https://macadmins.slack.com/archives/C8J5E5VPW/p1549656233101800</string>
 			<key>pfm_name</key>
@@ -148,7 +148,7 @@
 			<key>pfm_description</key>
 			<string>Support for all possible values of the "EnableCredSspSupport" and "Authentication Level" RDP file settings if this key is set to 0.</string>
 			<key>pfm_documentation_url</key>
-			<string>https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/mac-whatsnew#updates-for-version-1022</string>
+			<string>https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/mac-whatsnew#updates-for-version-1022</string>
 			<key>pfm_name</key>
 			<string>ClientSettings.EnforceCredSSPSupport</string>
 			<key>pfm_range_list</key>
@@ -171,7 +171,7 @@
 		<string>user</string>
 	</array>
 	<key>pfm_title</key>
-	<string>Microsoft Remote Desktop</string>
+	<string>Windows App</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>


### PR DESCRIPTION
This PR contains updates relating to the Microsoft Remote Desktop rename to Windows App.

For compatibility with profiles existing in the wild, the old Remote Desktop app key was not removed.